### PR TITLE
test: add integration tests for vulnerable token contract and fix mac…

### DIFF
--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -3,6 +3,7 @@ use syn::{parse_str, File, Item, Type, Fields, Meta, ExprMethodCall, Macro};
 use syn::visit::{self, Visit};
 use syn::spanned::Spanned;
 use serde::Serialize;
+use std::collections::HashSet;
 use thiserror::Error;
 
 // ── Existing types ────────────────────────────────────────────────────────────
@@ -395,10 +396,9 @@ struct UnsafeVisitor {
 }
 
 impl<'ast> Visit<'ast> for UnsafeVisitor {
-    fn visit_expr_macro(&mut self, node: &'ast syn::ExprMacro) {
-        if node.mac.path.is_ident("panic") {
+    fn visit_macro(&mut self, node: &'ast syn::Macro) {
+        if node.path.is_ident("panic") {
             let line = node
-                .mac
                 .path
                 .get_ident()
                 .map(|i| i.span().start().line)
@@ -409,7 +409,7 @@ impl<'ast> Visit<'ast> for UnsafeVisitor {
                 snippet: "panic!()".to_string(),
             });
         }
-        visit::visit_expr_macro(self, node);
+        visit::visit_macro(self, node);
     }
 
     fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {

--- a/tooling/sanctifier-core/tests/fixtures/vulnerable_token.rs
+++ b/tooling/sanctifier-core/tests/fixtures/vulnerable_token.rs
@@ -1,0 +1,69 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
+
+#[contracttype]
+pub enum DataKey {
+    Allowance(Address, Address),
+    Balance(Address),
+    Nonce(Address),
+    State(Address),
+    Admin,
+}
+
+#[contract]
+pub struct Token;
+
+#[contractimpl]
+impl Token {
+    pub fn initialize(e: Env, admin: Address, decimal: u32, name: String, symbol: String) {
+        // Safe to skip auth requirement here for the test if we only test transfer/mint
+        // but let's intentionally leave mint and transfer vulnerable.
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn mint(e: Env, to: Address, amount: i128) {
+        // BUG: Missing require_auth!
+        // let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        // admin.require_auth();
+
+        let mut balance = Self::read_balance(&e, to.clone());
+        // BUG: Overflow vulnerability! Standard + instead of a method that might be safer (though i128 is big, we want the analyzer to flag standard operators if it does, or at least we test if missing auth is caught)
+        balance = balance + amount;
+        
+        e.storage().persistent().set(&DataKey::Balance(to), &balance);
+    }
+
+    pub fn transfer(e: Env, from: Address, to: Address, amount: i128) {
+        // BUG: Missing require_auth!
+        // from.require_auth();
+
+        let mut from_balance = Self::read_balance(&e, from.clone());
+        let mut to_balance = Self::read_balance(&e, to.clone());
+
+        // We use a panic here just to trigger panic detection as an UnsafePattern
+        if amount < 0 {
+            panic!("Amount cannot be negative");
+        }
+
+        // Potential overflow bugs too
+        from_balance = from_balance - amount;
+        to_balance = to_balance + amount;
+
+        e.storage().persistent().set(&DataKey::Balance(from), &from_balance);
+        e.storage().persistent().set(&DataKey::Balance(to), &to_balance);
+    }
+    
+    // Unsafe math standard unwrap
+    pub fn burn(e: Env, from: Address, amount: i128) {
+        from.require_auth();
+        let current_balance: i128 = e.storage().persistent().get(&DataKey::Balance(from.clone())).unwrap();
+        let new_balance = current_balance - amount;
+        e.storage().persistent().set(&DataKey::Balance(from), &new_balance);
+    }
+
+    fn read_balance(e: &Env, owner: Address) -> i128 {
+        e.storage().persistent().get(&DataKey::Balance(owner)).unwrap_or(0)
+    }
+}

--- a/tooling/sanctifier-core/tests/integration_token_test.rs
+++ b/tooling/sanctifier-core/tests/integration_token_test.rs
@@ -1,0 +1,31 @@
+use sanctifier_core::{Analyzer, PatternType};
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn test_token_integration_auth_and_panic() {
+    let mut analyzer = Analyzer::new(true);
+
+    let mut fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture_path.push("tests/fixtures/vulnerable_token.rs");
+
+    let source = fs::read_to_string(&fixture_path).expect("Failed to read vulnerable_token.rs");
+
+    let missing_auth_funcs = analyzer.scan_auth_gaps(&source);
+
+    // `mint` and `transfer` are missing require_auth. `burn` has it. `initialize` has it.
+    assert!(missing_auth_funcs.contains(&"mint".to_string()), "mint function should flag missing auth");
+    assert!(missing_auth_funcs.contains(&"transfer".to_string()), "transfer function should flag missing auth");
+    assert!(!missing_auth_funcs.contains(&"burn".to_string()), "burn function should NOT flag missing auth, as it is present");
+
+    // Also check for panic or standard unsafety
+    let unsafe_patterns = analyzer.analyze_unsafe_patterns(&source);
+    assert!(
+        unsafe_patterns.iter().any(|p| matches!(p.pattern_type, PatternType::Panic)),
+        "Analyzer should have detected the panic! in transfer"
+    );
+    assert!(
+        unsafe_patterns.iter().any(|p| matches!(p.pattern_type, PatternType::Unwrap)),
+        "Analyzer should have detected the unwrap in burn or read_balance"
+    );
+}


### PR DESCRIPTION
…ro visiting (#12)

Resolves #12

### Expected Behavior
Sanctifier should be able to analyze standard Soroban Token structures and properly identify missing `require_auth` gaps and explicit `panic!` usages. Integration tests using a realistic mock token are needed to verify the analyzer logic against these cases.

### Actual Behavior
- Created a realistic vulnerable token fixture with intentional missing auth and overflow/panic logic.
- Implemented an integration test in `sanctifier-core` to read the fixture and assert the analyzer successfully flags the simulated errors.
- Discovered and fixed a bug in the [Analyzer](cci:2://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/src/lib.rs:57:0-60:1) where it missed `syn::Macro` statements, preventing it from catching bare `panic!()` usages.

### Changes Included
- **[tests/fixtures/vulnerable_token.rs](cci:7://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/tests/fixtures/vulnerable_token.rs:0:0-0:0)**: Created a Soroban token mock containing missing auth calls in [mint](cci:1://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/tests/fixtures/vulnerable_token.rs:25:4-35:5) and [transfer](cci:1://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/tests/fixtures/vulnerable_token.rs:37:4-55:5), along with unsafe math operations and panic cases.
- **[tests/integration_token_test.rs](cci:7://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/tests/integration_token_test.rs:0:0-0:0)**: Wrote `#[test] test_token_integration_auth_and_panic()` to invoke the analyzer and explicitly assert it flags the [mint](cci:1://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/tests/fixtures/vulnerable_token.rs:25:4-35:5) and [transfer](cci:1://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/tests/fixtures/vulnerable_token.rs:37:4-55:5) functions correctly, along with [panic](cci:1://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/src/lib.rs:99:4-121:5) and `unwrap` pattern detection.
- **[src/lib.rs](cci:7://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/src/lib.rs:0:0-0:0)**: Replaced `visit_expr_macro` with [visit_macro](cci:1://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/src/lib.rs:398:4-412:5) in [UnsafeVisitor](cci:2://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/src/lib.rs:393:0-395:1) to ensure all macro invocations—especially standard statements like `panic!()`—are successfully parsed and detected.

### Verification Steps Done
- Verified that `cargo test` successfully runs and passes against the integrated mock token.
- Verified that [scan_auth_gaps](cci:1://file:///Users/ucheekezie/Documents/web3work/Sanctifier/tooling/sanctifier-core/src/lib.rs:70:4-95:5) correctly identifies functions with lacking `require_auth` conditions without triggering on authorized ones.
