### PR TITLE
feat: Kani integration PoC for standard Soroban token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +696,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kani-poc-contract"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +954,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,7 +1024,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
 ]
 
 [[package]]
@@ -988,6 +1032,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "regex",
  "serde",
  "serde_json",
  "soroban-sdk",
@@ -1049,15 +1094,6 @@ checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
  "serde",
 ]
 
@@ -1477,47 +1513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.11.1",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,15 +1844,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "zerocopy"

--- a/contracts/kani-poc/Cargo.toml
+++ b/contracts/kani-poc/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 soroban-sdk = "20.0.0"
 
-[dev-dependencies]
-# kani = "0.54.0" # Kani dependency is required for verification but removed here to allow cargo check to pass
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(kani)"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/kani-poc/src/lib.rs
+++ b/contracts/kani-poc/src/lib.rs
@@ -1,55 +1,141 @@
 #![no_std]
+
+//! Proof-of-concept: Kani formal verification harnesses for a standard Soroban token contract.
+//!
+//! This module demonstrates the "Core Logic Separation" pattern: extract pure balance/transfer
+//! logic into functions that can be verified with Kani, while the contract layer that uses
+//! `Env`, `Address`, `Symbol`, etc. remains unverified due to Host type limitations.
+
 use soroban_sdk::{contract, contractimpl, Env, Symbol, symbol_short};
+
+// ── Pure logic (verified with Kani) ─────────────────────────────────────────────
+//
+// These functions operate only on i128 and have no Host/FFI dependencies.
+// They model the core arithmetic of a standard Soroban token: transfer, mint, burn.
+
+/// Transfer: deduct from sender, add to receiver.
+pub fn transfer_pure(
+    balance_from: i128,
+    balance_to: i128,
+    amount: i128,
+) -> Result<(i128, i128), &'static str> {
+    if amount <= 0 {
+        return Err("Amount must be positive");
+    }
+    let new_from = balance_from
+        .checked_sub(amount)
+        .ok_or("Insufficient balance")?;
+    let new_to = balance_to
+        .checked_add(amount)
+        .ok_or("Receiver balance overflow")?;
+    Ok((new_from, new_to))
+}
+
+/// Mint: add to a balance.
+pub fn mint_pure(balance: i128, amount: i128) -> Result<i128, &'static str> {
+    if amount <= 0 {
+        return Err("Mint amount must be positive");
+    }
+    balance.checked_add(amount).ok_or("Mint overflow")
+}
+
+/// Burn: subtract from a balance.
+pub fn burn_pure(balance: i128, amount: i128) -> Result<i128, &'static str> {
+    if amount <= 0 {
+        return Err("Burn amount must be positive");
+    }
+    balance.checked_sub(amount).ok_or("Insufficient balance to burn")
+}
+
+// ── Contract (not verified: uses Host types) ────────────────────────────────────
 
 #[contract]
 pub struct TokenContract;
 
 #[contractimpl]
 impl TokenContract {
-    /// A simple transfer function that updates balances.
-    /// This is a simplified version for Kani verification PoC.
-    /// In a real contract, we would use storage.
-    pub fn transfer_pure(balance_from: i128, balance_to: i128, amount: i128) -> (i128, i128) {
-        if amount < 0 {
-            panic!("Negative amount");
-        }
-        if balance_from < amount {
-            panic!("Insufficient balance");
-        }
-        let new_from = balance_from - amount;
-        let new_to = balance_to + amount;
-        (new_from, new_to)
+    /// Wrapper exposing transfer_pure for contract use.
+    /// A full implementation would read/write balances via env.storage().
+    pub fn transfer(balance_from: i128, balance_to: i128, amount: i128) -> (i128, i128) {
+        transfer_pure(balance_from, balance_to, amount)
+            .expect("transfer failed")
     }
 
     /// A function that interacts with Env (Host types).
-    /// This is where Kani verification becomes challenging.
+    /// Kani cannot verify this: Env, Symbol, and storage operations require host FFI.
     pub fn set_admin(env: Env, new_admin: Symbol) {
         env.storage().instance().set(&symbol_short!("admin"), &new_admin);
     }
 }
+
+// ── Kani harnesses ─────────────────────────────────────────────────────────────
 
 #[cfg(kani)]
 mod verification {
     use super::*;
 
     #[kani::proof]
-    pub fn verify_transfer_pure() {
+    fn verify_transfer_pure_conservation() {
         let balance_from: i128 = kani::any();
         let balance_to: i128 = kani::any();
         let amount: i128 = kani::any();
 
-        // Preconditions
-        kani::assume(amount >= 0);
+        kani::assume(amount > 0);
         kani::assume(balance_from >= amount);
+        kani::assume(balance_from <= i128::MAX);
         kani::assume(balance_to >= 0);
-        // Avoid overflow for the receiver
         kani::assume(balance_to <= i128::MAX - amount);
 
-        let (new_from, new_to) = TokenContract::transfer_pure(balance_from, balance_to, amount);
+        let Ok((new_from, new_to)) = transfer_pure(balance_from, balance_to, amount) else {
+            kani::unreachable();
+        };
 
-        // Postconditions
         assert!(new_from == balance_from - amount);
         assert!(new_to == balance_to + amount);
-        assert!(new_from + new_to == balance_from + balance_to);
+        assert!(new_from + new_to == balance_from + balance_to, "Conservation of supply");
+    }
+
+    #[kani::proof]
+    fn verify_transfer_pure_insufficient_balance() {
+        let balance_from: i128 = kani::any();
+        let balance_to: i128 = kani::any();
+        let amount: i128 = kani::any();
+
+        kani::assume(amount > 0);
+        kani::assume(balance_from < amount);
+
+        let result = transfer_pure(balance_from, balance_to, amount);
+        assert!(result.is_err());
+    }
+
+    #[kani::proof]
+    fn verify_mint_pure() {
+        let balance: i128 = kani::any();
+        let amount: i128 = kani::any();
+
+        kani::assume(amount > 0);
+        kani::assume(balance >= 0);
+        kani::assume(balance <= i128::MAX - amount);
+
+        let Ok(new_balance) = mint_pure(balance, amount) else {
+            kani::unreachable();
+        };
+
+        assert!(new_balance == balance + amount);
+    }
+
+    #[kani::proof]
+    fn verify_burn_pure() {
+        let balance: i128 = kani::any();
+        let amount: i128 = kani::any();
+
+        kani::assume(amount > 0);
+        kani::assume(balance >= amount);
+
+        let Ok(new_balance) = burn_pure(balance, amount) else {
+            kani::unreachable();
+        };
+
+        assert!(new_balance == balance - amount);
     }
 }


### PR DESCRIPTION
## Explore Kani integration for formal verification

### Summary
Adds a proof-of-concept setup for using Kani with Soroban token contracts and documents limits when verifying Host types.
Closes #26 
### Changes

**PoC harnesses (`contracts/kani-poc/`)**
- Pure logic functions: `transfer_pure`, `mint_pure`, `burn_pure` (no Env or Host types)
- Kani harnesses covering:
  - Transfer conservation: total supply unchanged
  - Insufficient balance: transfer fails when `balance_from < amount`
  - Mint/burn: correct balance updates with checked arithmetic
- Contract layer (e.g. `set_admin`) remains unverified because it uses Host types

**Documentation (`docs/kani-integration.md`)**
- Host types and FFI: `Env`, `Val`, `Symbol`, `Address` require host calls and are opaque to Kani
- Table of Host types and verification limits
- “Core logic separation” approach: verify pure functions, keep the contract layer thin

### How to run (with Kani installed)
cargo kani --package kani-poc-contract
