### PR TITLE
docs: add initial Architecture Decision Records (ADRs)

### DIFF
--- a/docs/adr/001-record-architecture-decisions.md
+++ b/docs/adr/001-record-architecture-decisions.md
@@ -1,0 +1,35 @@
+# ADR 001: Record Architecture Decisions
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project. Without a formalized process, important technical decisions, their context, and the rationale behind them are lost over time. This leads to repeated discussions, inconsistent architecture, and a steep learning curve for new developers joining the Sanctifier project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in his article "Documenting Architecture Decisions". 
+
+We will store these records in the `docs/adr/` directory of the project repository. Each record will be written in Markdown to remain lightweight, version-controlled alongside the code, and easily readable on GitHub or in any text editor.
+
+The standard template will include:
+- **Title**: A short noun phrase containing the ADR number and topic. (e.g., "ADR 001: Record Architecture Decisions")
+- **Status**: What is the status, such as "Proposed", "Accepted", "Rejected", "Deprecated", "Superseded".
+- **Context**: What is the issue that we're seeing that is motivating this decision or change.
+- **Decision**: What is the change that we're proposing and/or doing.
+- **Consequences**: What becomes easier or more difficult to do because of this change.
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's `adr-tools` at https://github.com/npryce/adr-tools.
+
+**Positive:**
+* A clear, searchable history of architectural decisions.
+* Better onboarding for new team members.
+* Reduced need to re-litigate past decisions unless the underlying context changes.
+
+**Negative:**
+* Requires discipline from developers to document decisions.
+* Slight overhead when making significant architectural changes.

--- a/docs/adr/002-use-rust-for-core-implementation.md
+++ b/docs/adr/002-use-rust-for-core-implementation.md
@@ -1,0 +1,27 @@
+# ADR 002: Use Rust for Core Implementation
+
+## Status
+
+Accepted
+
+## Context
+
+Sanctifier is designed to be a high-performance, secure static analysis tool specifically targeting Smart Contracts written for the Stellar (Soroban) network. We need a language that can parse WebAssembly (WASM) efficiently, manipulate complex Abstract Syntax Trees (ASTs), run quickly as a CLI tool, and potentially be compiled to WASM itself for browser-based execution in the future.
+
+The primary language for writing Soroban smart contracts is Rust. Building our tooling in the same language ecosystem offers synergies in parsing and understanding the host contracts.
+
+## Decision
+
+We will use **Rust** as the primary programming language for the core Sanctifier implementation (analyzers, CLI, and core logic).
+
+## Consequences
+
+**Positive:**
+* **Performance:** Rust is a compiled language with no garbage collector, offering excellent performance which is crucial when analyzing large WASM binaries or deeply nested ASTs.
+* **Safety:** Rust's ownership model prevents many classes of memory safety vulnerabilities, leading to a more robust and secure tool.
+* **Ecosystem Compatibility:** Since Soroban contracts are written in Rust, we can leverage the same crates (e.g., for parsing Rust syntax or interacting with Soroban SDK constructs) if we extend our analysis to source code.
+* **WASM Support:** Rust has first-class support for compiling to WebAssembly, keeping the door open for web-based versions of Sanctifier without a full rewrite.
+
+**Negative:**
+* **Learning Curve:** Rust's borrow checker and lifetimes can present a steep learning curve for new contributors compared to a language like TypeScript or Python.
+* **Compilation Time:** Compiling large Rust applications can be slow, slightly impacting the local development loop.

--- a/docs/adr/003-static-vs-runtime-analysis.md
+++ b/docs/adr/003-static-vs-runtime-analysis.md
@@ -1,0 +1,32 @@
+# ADR 003: Focus on Static Analysis Over Runtime Analysis
+
+## Status
+
+Accepted
+
+## Context
+
+When building a security analysis tool for smart contracts, there are generally two approaches:
+1. **Static Analysis:** Examining the source code or compiled binary (WASM) without executing it. Techniques include pattern matching, control flow analysis, and data flow analysis.
+2. **Runtime (Dynamic) Analysis:** Executing the code (often in a sandboxed or instrumented environment) with various inputs (e.g., fuzzing, symbolic execution) to observe behavior and identify vulnerabilities during runtime.
+
+We need to decide the primary focus of Sanctifier to scope the project effectively and deliver value quickly to the Soroban developer community.
+
+## Decision
+
+Sanctifier will focus primarily on **Static Analysis** of compiled WebAssembly (WASM) binaries and (optionally) Rust source code before deployment. 
+
+While dynamic analysis tools (like fuzzers) are valuable, they require entirely different infrastructure, complex execution environments, and potentially longer execution times. Sanctifier will aim to be a fast, deterministic tool that fits easily into CI/CD pipelines and local development workflows.
+
+## Consequences
+
+**Positive:**
+* **Speed:** Static analysis is generally much faster than dynamic analysis, providing rapid feedback to developers.
+* **Coverage:** Static analysis can theoretically examine all execution paths, whereas dynamic analysis is limited by the test cases or fuzzing inputs provided.
+* **Integration:** Easier to integrate into standard CI/CD pipelines as a linter or pre-deployment check.
+* **Simpler Infrastructure:** No need to build or maintain a complex soroban-environment execution harness within Sanctifier itself.
+
+**Negative:**
+* **False Positives:** Static analysis tools often struggle with complex runtime state and can report false positives that a dynamic execution would prove impossible.
+* **False Negatives:** Complex vulnerabilities that rely on specific timing, state changes, or deep cryptographic manipulations might be missed without actual execution.
+* **Limited Scope:** We will not be building a fuzzer or symbolic execution engine as part of the core Sanctifier project in the near term.

--- a/docs/adr/004-plugin-system-design.md
+++ b/docs/adr/004-plugin-system-design.md
@@ -1,0 +1,32 @@
+# ADR 004: Plugin System Design for Analyzers
+
+## Status
+
+Accepted
+
+## Context
+
+Sanctifier needs to detect a wide variety of vulnerabilities and anti-patterns in Soroban smart contracts. The rules for these detections will inevitably grow and evolve over time as new vulnerabilities are discovered. 
+
+If all analysis logic is tightly coupled into a single massive matching engine, the codebase will become difficult to maintain, test, and extend. We need a way to encapsulate individual detection rules (analyzers) so they can be written independently, activated/deactivated via configuration, and eventually, enable community members to contribute their own rules.
+
+## Decision
+
+We will implement a **Plugin System** (Internal Module Registry pattern) for our vulnerability analyzers.
+
+1. **Analyzer Trait**: All analyzers must implement a common `Analyzer` trait (or standard interface) which provides a unified entry point, taking the parsed WASM AST or metadata as input and returning a vector of `Vulnerability` structs.
+2. **Registry**: There will be a central registry where analyzers are registered at compile-time (using Rust macros or explicit initialization functions).
+3. **Execution Engine**: The core engine will iterate over all active analyzers in the registry and pipe the parsed contract data to them.
+
+For the initial versions, these "plugins" will be statically linked internal modules rather than dynamically loaded external `.so` libraries, to maintain execution speed and cross-platform simplicity.
+
+## Consequences
+
+**Positive:**
+* **Modularity:** Each vulnerability rule lives in its own isolated module, making it easy to test and maintain.
+* **Extensibility:** Adding a new rule is as simple as creating a new struct implementing the `Analyzer` trait and registering it.
+* **Configurations:** The engine can easily enable or disable specific plugins based on user configuration files (e.g., standard vs strict mode).
+
+**Negative:**
+* **Boilerplate:** Requires some boilerplate wiring to instantiate and register each new analyzer.
+* **Shared State Overhead:** Analyzers must share read-only access to the parsed AST. If one analyzer needs specialized data extraction, we might end up doing redundant AST traversals unless we build a very sophisticated intermediate representation (IR) first.

--- a/docs/adr/005-wasm-parsing-infrastructure.md
+++ b/docs/adr/005-wasm-parsing-infrastructure.md
@@ -1,0 +1,29 @@
+# ADR 005: Use Walrus for WASM Parsing
+
+## Status
+
+Accepted
+
+## Context
+
+To perform static analysis on compiled Soroban contracts, Sanctifier must parse the WebAssembly binaries. We need a library that provides a high-level, mutable, and navigable representation of WASM modules. We don't just want to interpret bytes; we need structured access to functions, local variables, imports, exports, and individual instructions to track data flow and control flow.
+
+Several options exist in the Rust ecosystem:
+1. `wasmparser`: Very fast, zero-allocation, iterator-based. Good for simple validation but hard to perform complex global analysis on since it doesn't build a full AST.
+2. `parity-wasm`: An older standard, somewhat deprecated, manipulates ASTs.
+3. `walrus`: Built specifically by the Rust/WASM working group for manipulating and analyzing WASM modules. It builds a full graph of the WASM binary.
+
+## Decision
+
+We will use the **`walrus`** crate for parsing and analyzing WebAssembly binaries in Sanctifier.
+
+## Consequences
+
+**Positive:**
+* **Rich Representation:** `walrus` builds a comprehensive, analyzable graph of the WASM module. It abstracts away raw indices in favor of typed IDs.
+* **Manipulation:** It is designed from the ground up for analyzing and transforming WASM, which perfectly fits our needs for tracing execution paths or identifying unsafe instruction sequences.
+* **Ecosystem:** It is a well-maintained, standard tool in the Rust/WASM ecosystem.
+
+**Negative:**
+* **Memory Overhead:** Building a full graph for very large WASM binaries will consume more memory than a streaming parser like `wasmparser`.
+* **Complexity:** Navigating the `walrus` IR graph taking ownership and borrowing rules into account can be complex compared to simpler byte-matching approaches.


### PR DESCRIPTION
This PR introduces a formalized Architecture Decision Records (ADR) process to the Sanctifier project, fulfilling the requirements for Issue #44.

### Components Added:
1. Created the `docs/adr/` directory structure.
2. Added the 5 core ADRs describing our primary architectural choices:
   - **ADR-001**: Record Architecture Decisions (Formalizes the ADR template process).
   - **ADR-002**: Use Rust for Core Implementation (Justifies language choice for WASM/Soroban).
   - **ADR-003**: Focus on Static Analysis Over Runtime Analysis (Defines the project's analytical boundaries).
   - **ADR-004**: Plugin System Design for Analyzers (Explains extensibility & modularity).
   - **ADR-005**: Use Walrus for WASM Parsing (Defines the preferred parsing infrastructure).

All documents use the standard Michael Nygard template format.

Closes #44