### PR TITLE
test: Benchmarking tool for SMT solver latency

### DIFF
--- a/docs/kani-integration.md
+++ b/docs/kani-integration.md
@@ -93,3 +93,16 @@ Then run:
 ```bash
 cargo kani --package kani-poc-contract
 ```
+
+## SMT Solver Latency Benchmarking
+
+To compare proof strategy cost in CI/local testing, Sanctifier now includes an ignored benchmark test in `sanctifier-core`:
+
+```bash
+cargo test -p sanctifier-core --test smt_latency_benchmark -- --ignored
+```
+
+This runs a set of SMT proof strategies repeatedly and writes `target/smt-latency-report.json` with:
+- per-strategy min/avg/max latency (microseconds)
+- p95 latency
+- a sortable summary for identifying the most expensive strategy

--- a/tooling/sanctifier-core/src/smt.rs
+++ b/tooling/sanctifier-core/src/smt.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::time::Instant;
 use z3::ast::Int;
 use z3::{Context, SatResult, Solver};
 
@@ -12,15 +13,11 @@ pub struct SmtInvariantIssue {
 
 pub struct SmtVerifier<'ctx> {
     ctx: &'ctx Context,
-    solver: Solver<'ctx>,
 }
 
 impl<'ctx> SmtVerifier<'ctx> {
     pub fn new(ctx: &'ctx Context) -> Self {
-        Self {
-            ctx,
-            solver: Solver::new(ctx),
-        }
+        Self { ctx }
     }
 
     /// Proof-of-Concept: Uses Z3 to prove if `a + b` can overflow a 64-bit integer
@@ -30,6 +27,7 @@ impl<'ctx> SmtVerifier<'ctx> {
         fn_name: &str,
         location: &str,
     ) -> Option<SmtInvariantIssue> {
+        let solver = Solver::new(self.ctx);
         let a = Int::new_const(self.ctx, "a");
         let b = Int::new_const(self.ctx, "b");
 
@@ -38,17 +36,17 @@ impl<'ctx> SmtVerifier<'ctx> {
         let max_u64 = Int::from_u64(self.ctx, u64::MAX);
 
         // Constrain variables to valid u64 limits: 0 <= a, b <= u64::MAX
-        self.solver.assert(&a.ge(&zero));
-        self.solver.assert(&a.le(&max_u64));
-        self.solver.assert(&b.ge(&zero));
-        self.solver.assert(&b.le(&max_u64));
+        solver.assert(&a.ge(&zero));
+        solver.assert(&a.le(&max_u64));
+        solver.assert(&b.ge(&zero));
+        solver.assert(&b.le(&max_u64));
 
         // To prove overflow is IMPOSSIBLE, we assert the violation (a + b > max_u64)
         // and check if the solver can SATISFY this violation.
         let sum = Int::add(self.ctx, &[&a, &b]);
-        self.solver.assert(&sum.gt(&max_u64));
+        solver.assert(&sum.gt(&max_u64));
 
-        if self.solver.check() == SatResult::Sat {
+        if solver.check() == SatResult::Sat {
             // A model exists where a + b > u64::MAX, meaning an overflow is mathematically possible
             Some(SmtInvariantIssue {
                 function_name: fn_name.to_string(),
@@ -60,4 +58,115 @@ impl<'ctx> SmtVerifier<'ctx> {
             None
         }
     }
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SmtProofStrategy {
+    UnconstrainedOverflow,
+    BoundedDomainOverflow,
+    SmallDomainOverflow,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct SmtStrategyLatency {
+    pub strategy: SmtProofStrategy,
+    pub runs: usize,
+    pub min_micros: u128,
+    pub max_micros: u128,
+    pub avg_micros: u128,
+    pub p95_micros: u128,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct SmtLatencyBenchmarkReport {
+    pub iterations_per_strategy: usize,
+    pub strategies: Vec<SmtStrategyLatency>,
+}
+
+impl SmtLatencyBenchmarkReport {
+    pub fn most_expensive_first(&self) -> Vec<SmtStrategyLatency> {
+        let mut sorted = self.strategies.clone();
+        sorted.sort_by(|a, b| b.avg_micros.cmp(&a.avg_micros));
+        sorted
+    }
+}
+
+pub fn run_smt_latency_benchmark(iterations_per_strategy: usize) -> SmtLatencyBenchmarkReport {
+    use z3::{Config, Context};
+
+    let iterations = iterations_per_strategy.max(1);
+    let strategies = [
+        SmtProofStrategy::UnconstrainedOverflow,
+        SmtProofStrategy::BoundedDomainOverflow,
+        SmtProofStrategy::SmallDomainOverflow,
+    ];
+
+    let mut results = Vec::with_capacity(strategies.len());
+
+    for strategy in strategies {
+        let mut samples = Vec::with_capacity(iterations);
+        for _ in 0..iterations {
+            let cfg = Config::new();
+            let ctx = Context::new(&cfg);
+
+            let start = Instant::now();
+            let _ = run_strategy(&ctx, strategy);
+            samples.push(start.elapsed().as_micros());
+        }
+
+        samples.sort_unstable();
+        let min_micros = samples.first().copied().unwrap_or_default();
+        let max_micros = samples.last().copied().unwrap_or_default();
+        let total: u128 = samples.iter().sum();
+        let avg_micros = total / samples.len() as u128;
+        let p95_index = (((samples.len() - 1) as f64) * 0.95).round() as usize;
+        let p95_micros = samples[p95_index];
+
+        results.push(SmtStrategyLatency {
+            strategy,
+            runs: iterations,
+            min_micros,
+            max_micros,
+            avg_micros,
+            p95_micros,
+        });
+    }
+
+    SmtLatencyBenchmarkReport {
+        iterations_per_strategy: iterations,
+        strategies: results,
+    }
+}
+
+fn run_strategy(ctx: &Context, strategy: SmtProofStrategy) -> SatResult {
+    let solver = Solver::new(ctx);
+    let a = Int::new_const(ctx, "a");
+    let b = Int::new_const(ctx, "b");
+    let zero = Int::from_i64(ctx, 0);
+    let max_u64 = Int::from_u64(ctx, u64::MAX);
+
+    solver.assert(&a.ge(&zero));
+    solver.assert(&b.ge(&zero));
+
+    match strategy {
+        SmtProofStrategy::UnconstrainedOverflow => {
+            solver.assert(&a.le(&max_u64));
+            solver.assert(&b.le(&max_u64));
+        }
+        SmtProofStrategy::BoundedDomainOverflow => {
+            let max = Int::from_i64(ctx, 5_000_000_000);
+            solver.assert(&a.le(&max));
+            solver.assert(&b.le(&max));
+        }
+        SmtProofStrategy::SmallDomainOverflow => {
+            let max = Int::from_i64(ctx, 10_000);
+            solver.assert(&a.le(&max));
+            solver.assert(&b.le(&max));
+        }
+    }
+
+    let sum = Int::add(ctx, &[&a, &b]);
+    solver.assert(&sum.gt(&max_u64));
+    solver.check()
 }

--- a/tooling/sanctifier-core/tests/smt_latency_benchmark.rs
+++ b/tooling/sanctifier-core/tests/smt_latency_benchmark.rs
@@ -1,0 +1,27 @@
+use sanctifier_core::smt::run_smt_latency_benchmark;
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+#[ignore = "benchmark utility test; run manually to profile SMT latency"]
+fn benchmark_smt_solver_latency() {
+    let report = run_smt_latency_benchmark(25);
+
+    assert_eq!(report.strategies.len(), 3);
+    assert!(report.strategies.iter().all(|s| s.runs == 25));
+    assert!(report
+        .strategies
+        .iter()
+        .all(|s| s.max_micros >= s.min_micros));
+
+    let sorted = report.most_expensive_first();
+    assert_eq!(sorted.len(), 3);
+    for pair in sorted.windows(2) {
+        assert!(pair[0].avg_micros >= pair[1].avg_micros);
+    }
+
+    let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    let output_path = PathBuf::from(target_dir).join("smt-latency-report.json");
+    let json = serde_json::to_string_pretty(&report).expect("benchmark report should serialize");
+    fs::write(&output_path, json).expect("failed to write SMT latency benchmark report");
+}


### PR DESCRIPTION
## Description
Add a benchmark utility for SMT solver latency to compare proof strategy cost in the formal verification stage.

Closes #166

## Changes proposed

### What were you told to do?
I was tasked with adding performance tracking for the formal verification stage so we can identify which SMT proof strategies are most computationally expensive.

Requirements included:
- Add a benchmarking tool focused on SMT solver latency
- Compare multiple proof strategies
- Provide results that are easy to inspect in testing workflows

### What did I do?

#### Added SMT latency benchmark primitives
Updated `tooling/sanctifier-core/src/smt.rs` to:
- Keep `verify_addition_overflow` solver state isolated per run (fresh solver per invocation)
- Add `SmtProofStrategy` variants for multiple overflow proof strategies
- Add benchmark report models (`SmtStrategyLatency`, `SmtLatencyBenchmarkReport`)
- Add `run_smt_latency_benchmark(iterations_per_strategy)` to collect min/avg/max/p95 latency in microseconds
- Add `most_expensive_first()` helper to rank strategies by average latency

#### Added testing entry point for benchmark execution
Added `tooling/sanctifier-core/tests/smt_latency_benchmark.rs` to:
- Run the benchmark as an ignored test for manual/CI opt-in profiling
- Validate benchmark output shape and ordering
- Persist benchmark artifact to `target/smt-latency-report.json`

#### Documented benchmark workflow
Updated `docs/kani-integration.md` with:
- Benchmark command for local/CI usage
- Description of output metrics and artifact path

#### Validation and results
- Ran `cargo fmt --all` successfully
- Attempted `cargo test -p sanctifier-core --test smt_latency_benchmark -- --ignored`
- Test execution failed in this environment due crates.io SSL credential issues before dependency resolution

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `cargo fmt --all` passed locally
- `cargo test -p sanctifier-core --test smt_latency_benchmark -- --ignored` failed before running tests because crates.io index download failed with SSL credential errors in this environment
