### PR TITLE
chore: Standardize error codes across CLI and Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,8 @@ sanctifier update
 ## 🤝 Contributing
 We welcome contributions from the Stellar community! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
+## 🔎 Finding Codes
+Unified finding codes (`S001`...`S007`) are documented in [docs/error-codes.md](docs/error-codes.md).
+
 ## 📄 License
 MIT

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,20 @@
+# Sanctifier Error Code Mapping
+
+Sanctifier now uses a unified finding code system across `sanctifier-core` and `sanctifier-cli` outputs.
+
+| Code | Category | Meaning |
+|------|----------|---------|
+| `S001` | authentication | Missing authentication guard in a state-mutating function |
+| `S002` | panic_handling | `panic!` / `unwrap` / `expect` usage that may abort execution |
+| `S003` | arithmetic | Unchecked arithmetic with overflow/underflow risk |
+| `S004` | storage_limits | Ledger entry size exceeds or approaches configured limits |
+| `S005` | storage_keys | Potential storage key collision |
+| `S006` | unsafe_patterns | Potentially unsafe language/runtime pattern |
+| `S007` | custom_rule | User-defined custom rule match |
+
+## Where codes appear
+
+- Text output from `sanctifier analyze`
+- JSON report output under:
+  - `error_codes` (full mapping table)
+  - each item inside `findings.*` as `code`

--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 use colored::*;
+use sanctifier_core::finding_codes;
 use sanctifier_core::{Analyzer, SanctifyConfig, SizeWarningLevel};
 use serde_json;
 use std::fs;
@@ -119,6 +120,7 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
                 "project_path": path.display().to_string(),
                 "format": "sanctifier-ci-v1",
             },
+            "error_codes": finding_codes::all_finding_codes(),
             "summary": {
                 "total_findings": total_findings,
                 "storage_collisions": collisions.len(),
@@ -132,13 +134,50 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
                 "has_high": has_high,
             },
             "findings": {
-                "storage_collisions": collisions,
-                "ledger_size_warnings": size_warnings,
-                "unsafe_patterns": unsafe_patterns,
-                "auth_gaps": auth_gaps,
-                "panic_issues": panic_issues,
-                "arithmetic_issues": arithmetic_issues,
-                "custom_rules": custom_matches,
+                "storage_collisions": collisions.iter().map(|c| serde_json::json!({
+                    "code": finding_codes::STORAGE_COLLISION,
+                    "key_value": c.key_value,
+                    "key_type": c.key_type,
+                    "location": c.location,
+                    "message": c.message,
+                })).collect::<Vec<_>>(),
+                "ledger_size_warnings": size_warnings.iter().map(|w| serde_json::json!({
+                    "code": finding_codes::LEDGER_SIZE_RISK,
+                    "struct_name": w.struct_name,
+                    "estimated_size": w.estimated_size,
+                    "limit": w.limit,
+                    "level": w.level,
+                })).collect::<Vec<_>>(),
+                "unsafe_patterns": unsafe_patterns.iter().map(|p| serde_json::json!({
+                    "code": finding_codes::UNSAFE_PATTERN,
+                    "pattern_type": p.pattern_type,
+                    "line": p.line,
+                    "snippet": p.snippet,
+                })).collect::<Vec<_>>(),
+                "auth_gaps": auth_gaps.iter().map(|g| serde_json::json!({
+                    "code": finding_codes::AUTH_GAP,
+                    "function": g,
+                })).collect::<Vec<_>>(),
+                "panic_issues": panic_issues.iter().map(|p| serde_json::json!({
+                    "code": finding_codes::PANIC_USAGE,
+                    "function_name": p.function_name,
+                    "issue_type": p.issue_type,
+                    "location": p.location,
+                })).collect::<Vec<_>>(),
+                "arithmetic_issues": arithmetic_issues.iter().map(|a| serde_json::json!({
+                    "code": finding_codes::ARITHMETIC_OVERFLOW,
+                    "function_name": a.function_name,
+                    "operation": a.operation,
+                    "suggestion": a.suggestion,
+                    "location": a.location,
+                })).collect::<Vec<_>>(),
+                "custom_rules": custom_matches.iter().map(|m| serde_json::json!({
+                    "code": finding_codes::CUSTOM_RULE_MATCH,
+                    "rule_name": m.rule_name,
+                    "line": m.line,
+                    "snippet": m.snippet,
+                    "severity": m.severity,
+                })).collect::<Vec<_>>(),
             },
         });
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -157,7 +196,12 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
             "⚠️".yellow()
         );
         for collision in collisions {
-            println!("   {} Value: {}", "->".red(), collision.key_value.bold());
+            println!(
+                "   {} [{}] Value: {}",
+                "->".red(),
+                finding_codes::STORAGE_COLLISION.bold(),
+                collision.key_value.bold()
+            );
             println!("      Type: {}", collision.key_type);
             println!("      Location: {}", collision.location);
             println!("      Message: {}", collision.message);
@@ -169,7 +213,12 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
     } else {
         println!("\n{} Found potential Authentication Gaps!", "⚠️".yellow());
         for gap in auth_gaps {
-            println!("   {} Function: {}", "->".red(), gap.bold());
+            println!(
+                "   {} [{}] Function: {}",
+                "->".red(),
+                finding_codes::AUTH_GAP.bold(),
+                gap.bold()
+            );
         }
     }
 
@@ -178,7 +227,12 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
     } else {
         println!("\n{} Found explicit Panics/Unwraps!", "⚠️".yellow());
         for issue in panic_issues {
-            println!("   {} Type: {}", "->".red(), issue.issue_type.bold());
+            println!(
+                "   {} [{}] Type: {}",
+                "->".red(),
+                finding_codes::PANIC_USAGE.bold(),
+                issue.issue_type.bold()
+            );
             println!("      Location: {}", issue.location);
         }
     }
@@ -188,7 +242,12 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
     } else {
         println!("\n{} Found unchecked Arithmetic Operations!", "⚠️".yellow());
         for issue in arithmetic_issues {
-            println!("   {} Op: {}", "->".red(), issue.operation.bold());
+            println!(
+                "   {} [{}] Op: {}",
+                "->".red(),
+                finding_codes::ARITHMETIC_OVERFLOW.bold(),
+                issue.operation.bold()
+            );
             println!("      Location: {}", issue.location);
         }
     }
@@ -198,7 +257,12 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
     } else {
         println!("\n{} Found Ledger Size Warnings!", "⚠️".yellow());
         for warning in size_warnings {
-            println!("   {} Struct: {}", "->".red(), warning.struct_name.bold());
+            println!(
+                "   {} [{}] Struct: {}",
+                "->".red(),
+                finding_codes::LEDGER_SIZE_RISK.bold(),
+                warning.struct_name.bold()
+            );
             println!("      Size: {} bytes", warning.estimated_size);
         }
     }
@@ -211,7 +275,13 @@ pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
                 sanctifier_core::RuleSeverity::Warning => "⚠️".yellow(),
                 sanctifier_core::RuleSeverity::Info => "ℹ️".blue(),
             };
-            println!("   {} [{}]: {}", sev_icon, m.rule_name.bold(), m.snippet);
+            println!(
+                "   {} [{}|{}]: {}",
+                sev_icon,
+                finding_codes::CUSTOM_RULE_MATCH.bold(),
+                m.rule_name.bold(),
+                m.snippet
+            );
         }
     }
 

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -1,0 +1,81 @@
+use serde::Serialize;
+
+pub const AUTH_GAP: &str = "S001";
+pub const PANIC_USAGE: &str = "S002";
+pub const ARITHMETIC_OVERFLOW: &str = "S003";
+pub const LEDGER_SIZE_RISK: &str = "S004";
+pub const STORAGE_COLLISION: &str = "S005";
+pub const UNSAFE_PATTERN: &str = "S006";
+pub const CUSTOM_RULE_MATCH: &str = "S007";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FindingCode {
+    pub code: &'static str,
+    pub category: &'static str,
+    pub description: &'static str,
+}
+
+pub fn all_finding_codes() -> Vec<FindingCode> {
+    vec![
+        FindingCode {
+            code: AUTH_GAP,
+            category: "authentication",
+            description: "Missing authentication guard in a state-mutating function",
+        },
+        FindingCode {
+            code: PANIC_USAGE,
+            category: "panic_handling",
+            description: "panic!/unwrap/expect usage that may cause runtime aborts",
+        },
+        FindingCode {
+            code: ARITHMETIC_OVERFLOW,
+            category: "arithmetic",
+            description: "Unchecked arithmetic operation with overflow/underflow risk",
+        },
+        FindingCode {
+            code: LEDGER_SIZE_RISK,
+            category: "storage_limits",
+            description: "Ledger entry size is exceeding or approaching configured threshold",
+        },
+        FindingCode {
+            code: STORAGE_COLLISION,
+            category: "storage_keys",
+            description: "Potential storage key collision across contract data paths",
+        },
+        FindingCode {
+            code: UNSAFE_PATTERN,
+            category: "unsafe_patterns",
+            description: "Potentially unsafe language/runtime pattern was detected",
+        },
+        FindingCode {
+            code: CUSTOM_RULE_MATCH,
+            category: "custom_rule",
+            description: "User-defined rule matched contract source",
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn finding_codes_are_unique() {
+        let codes = all_finding_codes();
+        let unique: HashSet<&str> = codes.iter().map(|c| c.code).collect();
+        assert_eq!(codes.len(), unique.len());
+    }
+
+    #[test]
+    fn includes_expected_codes() {
+        let codes = all_finding_codes();
+        assert!(codes.iter().any(|c| c.code == AUTH_GAP));
+        assert!(codes.iter().any(|c| c.code == PANIC_USAGE));
+        assert!(codes.iter().any(|c| c.code == ARITHMETIC_OVERFLOW));
+        assert!(codes.iter().any(|c| c.code == LEDGER_SIZE_RISK));
+        assert!(codes.iter().any(|c| c.code == STORAGE_COLLISION));
+        assert!(codes.iter().any(|c| c.code == UNSAFE_PATTERN));
+        assert!(codes.iter().any(|c| c.code == CUSTOM_RULE_MATCH));
+    }
+}

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::panic::catch_unwind;
+pub mod finding_codes;
 pub mod gas_estimator;
 pub mod rules;
 pub mod smt;


### PR DESCRIPTION
## Description
Standardize Sanctifier security finding codes across Core and CLI so findings can be referenced consistently in docs and reports.

Closes #164

## Changes proposed

### What were you told to do?
I was tasked with defining a unified error code mapping (e.g., `S001`, `S002`) for security findings so they are easier to reference in documentation and tooling output.

Requirements included:
- Define a shared code map
- Apply it consistently across Core and CLI outputs
- Make the mapping easy to reference in docs

### What did I do?

#### Added centralized finding code map in core
Added `tooling/sanctifier-core/src/finding_codes.rs` with:
- Stable code constants:
  - `S001` auth gaps
  - `S002` panic/unwrap/expect usage
  - `S003` arithmetic overflow risk
  - `S004` ledger size risk
  - `S005` storage collisions
  - `S006` unsafe patterns
  - `S007` custom rule matches
- `FindingCode` model
- `all_finding_codes()` helper
- Unit tests for uniqueness and expected presence

Updated `tooling/sanctifier-core/src/lib.rs` to export `finding_codes`.

#### Applied codes in CLI analyze output
Updated `tooling/sanctifier-cli/src/commands/analyze.rs` to:
- Include full mapping under JSON report key `error_codes`
- Add `code` on each item inside `findings.*`
- Include finding codes in human-readable text output lines for collisions, auth gaps, panic issues, arithmetic issues, size warnings, and custom rule matches

#### Added documentation for code mapping
Added `docs/error-codes.md` with:
- Full code table and category descriptions
- Where codes appear in CLI outputs

Updated `README.md` to link to finding code documentation.

#### Validation and results
- Attempted `cargo test -p sanctifier-core finding_codes`
- Test execution failed in this environment before running tests due crates.io SSL credential errors

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `cargo test -p sanctifier-core finding_codes` failed before test execution because crates.io index download failed with SSL credential errors in this environment
