### PR TITLE
feat/Implement 'Emergency Shutdown' verification rule

### DIFF
--- a/contracts/my-contract/.github/workflows/fuzz.yml
+++ b/contracts/my-contract/.github/workflows/fuzz.yml
@@ -1,0 +1,25 @@
+name: Fuzzing
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  bolero-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cargo-bolero
+      - run: cargo bolero test fuzz_raw_bytes_no_panic --time 60s
+      - run: cargo bolero test fuzz_structured_message_no_panic --time 60s
+
+  cargo-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install cargo-fuzz
+      - run: cargo fuzz run fuzz_cross_contract -- -max_total_time=120

--- a/contracts/my-contract/Cargo.toml
+++ b/contracts/my-contract/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "my-contract"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+borsh = "1.3"
+
+[dev-dependencies]
+bolero = "0.10"
+bolero-generator = "0.10"

--- a/contracts/my-contract/fuzz/Cargo.toml
+++ b/contracts/my-contract/fuzz/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "my-contract-fuzz"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+my-contract = { path = ".." }
+borsh = "1.3"
+arbitrary = { version = "1", features = ["derive"] }
+
+[[bin]]
+name = "fuzz_cross_contract"
+path = "fuzz_targets/fuzz_cross_contract.rs"
+test = false
+doc = false

--- a/contracts/my-contract/fuzz/fuzz_targets/fuzz_cross_contract.rs
+++ b/contracts/my-contract/fuzz/fuzz_targets/fuzz_cross_contract.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use my_contract::handle_cross_contract_message;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = handle_cross_contract_message(data);
+});

--- a/contracts/my-contract/src/lib.rs
+++ b/contracts/my-contract/src/lib.rs
@@ -1,0 +1,50 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
+pub struct CrossContractMessage {
+    pub sender: [u8; 32],
+    pub method_id: u8,
+    pub payload: Vec<u8>,
+    pub nonce: u64,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ContractError {
+    DeserializationFailed,
+    UnknownMethod,
+    InvalidPayload(String),
+    OverflowDetected,
+}
+
+pub fn handle_cross_contract_message(raw: &[u8]) -> Result<String, ContractError> {
+    let msg = CrossContractMessage::try_from_slice(raw)
+        .map_err(|_| ContractError::DeserializationFailed)?;
+    match msg.method_id {
+        0 => handle_transfer(&msg.payload),
+        1 => handle_query(&msg.payload),
+        2 => handle_callback(&msg.payload),
+        _ => Err(ContractError::UnknownMethod),
+    }
+}
+
+fn handle_transfer(payload: &[u8]) -> Result<String, ContractError> {
+    if payload.len() < 8 {
+        return Err(ContractError::InvalidPayload("too short".into()));
+    }
+    let amount = u64::from_le_bytes(payload[0..8].try_into().unwrap());
+    let fee = amount.checked_mul(3).ok_or(ContractError::OverflowDetected)?;
+    Ok(format!("transfer: amount={amount}, fee={fee}"))
+}
+
+fn handle_query(payload: &[u8]) -> Result<String, ContractError> {
+    let key = std::str::from_utf8(payload)
+        .map_err(|_| ContractError::InvalidPayload("invalid utf8".into()))?;
+    Ok(format!("query: key={key}"))
+}
+
+fn handle_callback(payload: &[u8]) -> Result<String, ContractError> {
+    if payload.is_empty() {
+        return Err(ContractError::InvalidPayload("empty callback".into()));
+    }
+    Ok(format!("callback: {} bytes", payload.len()))
+}

--- a/contracts/my-contract/tests/bolero_fuzz.rs
+++ b/contracts/my-contract/tests/bolero_fuzz.rs
@@ -1,0 +1,48 @@
+use bolero::{check, generator::*};
+use borsh::BorshSerialize;
+use my_contract::{handle_cross_contract_message, CrossContractMessage};
+
+#[test]
+fn fuzz_raw_bytes_no_panic() {
+    check!()
+        .with_type::<Vec<u8>>()
+        .for_each(|data| {
+            let _ = handle_cross_contract_message(data);
+        });
+}
+
+#[test]
+fn fuzz_structured_message_no_panic() {
+    check!()
+        .with_generator(gen::<(u8, Vec<u8>, u64)>())
+        .for_each(|(method_id, payload, nonce)| {
+            let msg = CrossContractMessage {
+                sender: [0u8; 32],
+                method_id: *method_id,
+                payload: payload.clone(),
+                nonce: *nonce,
+            };
+            if let Ok(encoded) = borsh::to_vec(&msg) {
+                let _ = handle_cross_contract_message(&encoded);
+            }
+        });
+}
+
+#[test]
+fn fuzz_truncated_messages() {
+    check!()
+        .with_type::<Vec<u8>>()
+        .with_max_len(16)
+        .for_each(|data| {
+            let _ = handle_cross_contract_message(data);
+        });
+}
+
+#[test]
+fn fuzz_oversized_payload_no_oom() {
+    check!()
+        .with_generator(gen::<Vec<u8>>().with().len(0usize..=1_000_000))
+        .for_each(|data| {
+            let _ = handle_cross_contract_message(data);
+        });
+}

--- a/my-contract/Cargo.toml
+++ b/my-contract/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "my-contract"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+borsh = "1.3"
+
+[dev-dependencies]
+bolero = "0.10"
+bolero-generator = "0.10"

--- a/my-contract/src/circuit_breaker.rs
+++ b/my-contract/src/circuit_breaker.rs
@@ -1,0 +1,29 @@
+use crate::{
+    guards::{require_admin, require_active, GuardError},
+    state::{ContractState, ShutdownState},
+};
+
+pub fn pause(state: &mut ContractState, caller: &[u8; 32]) -> Result<(), GuardError> {
+    require_admin(state, caller)?;
+    require_active(state)?;
+    state.shutdown = ShutdownState::Paused;
+    Ok(())
+}
+
+pub fn emergency_shutdown(
+    state: &mut ContractState,
+    caller: &[u8; 32],
+) -> Result<(), GuardError> {
+    require_admin(state, caller)?;
+    state.shutdown = ShutdownState::Emergency;
+    Ok(())
+}
+
+pub fn unpause(state: &mut ContractState, caller: &[u8; 32]) -> Result<(), GuardError> {
+    require_admin(state, caller)?;
+    match state.shutdown {
+        ShutdownState::Paused    => { state.shutdown = ShutdownState::Active; Ok(()) }
+        ShutdownState::Emergency => Err(GuardError::EmergencyShutdown),
+        ShutdownState::Active    => Ok(()),
+    }
+}

--- a/my-contract/src/guards.rs
+++ b/my-contract/src/guards.rs
@@ -1,0 +1,42 @@
+use crate::state::{ContractState, ShutdownState};
+
+#[derive(Debug, PartialEq)]
+pub enum GuardError {
+    ContractPaused,
+    EmergencyShutdown,
+    Unauthorized,
+}
+
+impl std::fmt::Display for GuardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GuardError::ContractPaused    => write!(f, "Contract is paused"),
+            GuardError::EmergencyShutdown => write!(f, "Emergency shutdown is active"),
+            GuardError::Unauthorized      => write!(f, "Caller is not authorized"),
+        }
+    }
+}
+
+pub fn require_active(state: &ContractState) -> Result<(), GuardError> {
+    match state.shutdown {
+        ShutdownState::Active    => Ok(()),
+        ShutdownState::Paused    => Err(GuardError::ContractPaused),
+        ShutdownState::Emergency => Err(GuardError::EmergencyShutdown),
+    }
+}
+
+pub fn require_admin(state: &ContractState, caller: &[u8; 32]) -> Result<(), GuardError> {
+    if &state.admin == caller {
+        Ok(())
+    } else {
+        Err(GuardError::Unauthorized)
+    }
+}
+
+pub fn require_admin_and_active(
+    state: &ContractState,
+    caller: &[u8; 32],
+) -> Result<(), GuardError> {
+    require_admin(state, caller)?;
+    require_active(state)
+}

--- a/my-contract/src/lib.rs
+++ b/my-contract/src/lib.rs
@@ -1,0 +1,48 @@
+pub mod circuit_breaker;
+pub mod guards;
+pub mod state;
+
+use guards::{require_active, GuardError};
+use state::ContractState;
+
+pub fn deposit(
+    state: &mut ContractState,
+    _caller: &[u8; 32],
+    amount: u64,
+) -> Result<(), GuardError> {
+    require_active(state)?;
+    state.balance = state.balance.checked_add(amount)
+        .ok_or(GuardError::Unauthorized)?;
+    Ok(())
+}
+
+pub fn withdraw(
+    state: &mut ContractState,
+    _caller: &[u8; 32],
+    amount: u64,
+) -> Result<(), GuardError> {
+    require_active(state)?;
+    if state.balance < amount {
+        return Err(GuardError::Unauthorized);
+    }
+    state.balance -= amount;
+    Ok(())
+}
+
+pub fn update_data(
+    state: &mut ContractState,
+    _caller: &[u8; 32],
+    new_data: Vec<u8>,
+) -> Result<(), GuardError> {
+    require_active(state)?;
+    state.data = new_data;
+    Ok(())
+}
+
+pub fn get_balance(state: &ContractState) -> u64 {
+    state.balance
+}
+
+pub fn get_shutdown_status(state: &ContractState) -> &state::ShutdownState {
+    &state.shutdown
+}

--- a/my-contract/src/state.rs
+++ b/my-contract/src/state.rs
@@ -1,0 +1,27 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone, PartialEq)]
+pub enum ShutdownState {
+    Active,
+    Paused,
+    Emergency
+}
+
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
+pub struct ContractState {
+    pub admin: [u8; 32],
+    pub shutdown: ShutdownState,
+    pub balance: u64,
+    pub data: Vec<u8>,
+}
+
+impl ContractState {
+    pub fn new(admin: [u8; 32]) -> Self {
+        Self {
+            admin,
+            shutdown: ShutdownState::Active,
+            balance: 0,
+            data: vec![],
+        }
+    }
+}

--- a/my-contract/tests/emergency_shutdown_tests.rs
+++ b/my-contract/tests/emergency_shutdown_tests.rs
@@ -1,0 +1,87 @@
+use my_contract::{
+    circuit_breaker::{emergency_shutdown, pause, unpause},
+    deposit, update_data, withdraw,
+    guards::GuardError,
+    state::ContractState,
+};
+
+const ADMIN: [u8; 32] = [1u8; 32];
+const USER:  [u8; 32] = [2u8; 32];
+
+fn fresh_state() -> ContractState {
+    ContractState::new(ADMIN)
+}
+
+#[test]
+fn test_pause_blocks_deposit() {
+    let mut state = fresh_state();
+    pause(&mut state, &ADMIN).unwrap();
+    assert_eq!(deposit(&mut state, &USER, 100), Err(GuardError::ContractPaused));
+}
+
+#[test]
+fn test_pause_blocks_withdraw() {
+    let mut state = fresh_state();
+    state.balance = 500;
+    pause(&mut state, &ADMIN).unwrap();
+    assert_eq!(withdraw(&mut state, &USER, 100), Err(GuardError::ContractPaused));
+}
+
+#[test]
+fn test_pause_blocks_update_data() {
+    let mut state = fresh_state();
+    pause(&mut state, &ADMIN).unwrap();
+    assert_eq!(update_data(&mut state, &USER, vec![1, 2, 3]), Err(GuardError::ContractPaused));
+}
+
+#[test]
+fn test_reads_allowed_during_pause() {
+    let mut state = fresh_state();
+    state.balance = 42;
+    pause(&mut state, &ADMIN).unwrap();
+    assert_eq!(my_contract::get_balance(&state), 42);
+}
+
+#[test]
+fn test_emergency_blocks_all_mutations() {
+    let mut state = fresh_state();
+    emergency_shutdown(&mut state, &ADMIN).unwrap();
+    assert_eq!(deposit(&mut state, &USER, 100),         Err(GuardError::EmergencyShutdown));
+    assert_eq!(withdraw(&mut state, &USER, 100),        Err(GuardError::EmergencyShutdown));
+    assert_eq!(update_data(&mut state, &USER, vec![1]), Err(GuardError::EmergencyShutdown));
+}
+
+#[test]
+fn test_emergency_cannot_be_unpaused() {
+    let mut state = fresh_state();
+    emergency_shutdown(&mut state, &ADMIN).unwrap();
+    assert_eq!(unpause(&mut state, &ADMIN), Err(GuardError::EmergencyShutdown));
+}
+
+#[test]
+fn test_escalation_paused_to_emergency() {
+    let mut state = fresh_state();
+    pause(&mut state, &ADMIN).unwrap();
+    emergency_shutdown(&mut state, &ADMIN).unwrap();
+    assert_eq!(deposit(&mut state, &USER, 100), Err(GuardError::EmergencyShutdown));
+}
+
+#[test]
+fn test_unpause_restores_operations() {
+    let mut state = fresh_state();
+    pause(&mut state, &ADMIN).unwrap();
+    unpause(&mut state, &ADMIN).unwrap();
+    assert!(deposit(&mut state, &USER, 100).is_ok());
+}
+
+#[test]
+fn test_non_admin_cannot_pause() {
+    let mut state = fresh_state();
+    assert_eq!(pause(&mut state, &USER), Err(GuardError::Unauthorized));
+}
+
+#[test]
+fn test_non_admin_cannot_trigger_emergency() {
+    let mut state = fresh_state();
+    assert_eq!(emergency_shutdown(&mut state, &USER), Err(GuardError::Unauthorized));
+}


### PR DESCRIPTION
feat: Implement Emergency Shutdown verification rule
Adds a ShutdownState machine (Active → Paused → Emergency) with a require_active() guard enforced at the boundary of every state-mutating function. Includes admin-only circuit breaker controls (pause, unpause, emergency_shutdown), ensuring no state mutations can occur while the contract is paused or in emergency mode. Reads remain unaffected.
Files changed: src/lib.rs, src/state.rs, src/guards.rs, src/circuit_breaker.rs, tests/emergency_shutdown_tests.rs

test: Build fuzzing harness for cross-contract messaging
Integrates cargo-fuzz and bolero to stress-test the cross-contract message boundary against malformed, truncated, structured, and oversized inputs. Ensures the contract never panics on any raw byte input — only returning typed errors. CI workflow included for nightly automated runs.
Files changed: fuzz/fuzz_targets/fuzz_cross_contract.rs, tests/boler o_fuzz.rs, .github/workflows/fuzz.yml

Closes #151
Closes #153 