### PR TITLE
[ci] upgrade codecov/codecov-action to v4 and pin SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,12 @@ jobs:
         run: cargo tarpaulin -p sanctifier-core --out Xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97 # v4.6.0
         with:
-          file: cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: cobertura.xml
           fail_ci_if_error: false
+          slug: HyperSafeD/Sanctifier
 
       - name: Build Release CLI
         run: cd tooling/sanctifier-cli && cargo build --release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to Sanctifier
+
+Thanks for helping improve Sanctifier.
+
+## Required repository secrets
+
+### `CODECOV_TOKEN`
+
+The CI workflow uploads the `cobertura.xml` coverage report to Codecov by using
+`codecov/codecov-action@v4.6.0` pinned to an immutable commit SHA.
+
+To configure the token:
+
+1. Open the Sanctifier repository on GitHub.
+2. Go to `Settings` -> `Secrets and variables` -> `Actions`.
+3. Create a new repository secret named `CODECOV_TOKEN`.
+4. Copy the upload token for `HyperSafeD/Sanctifier` from [Codecov](https://codecov.io/).
+
+Without this secret, the coverage upload step will fail to authenticate.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sanctifier 🛡️
 
+[![Codecov](https://codecov.io/gh/HyperSafeD/Sanctifier/graph/badge.svg)](https://codecov.io/gh/HyperSafeD/Sanctifier)
+
 <p align="center">
   <img src="branding/logo.png" width="300" alt="Sanctifier Logo">
 </p>


### PR DESCRIPTION
## Description
Upgrade the Codecov upload step to the v4 action pinned to an immutable commit SHA, document the repository token setup, and surface the live coverage badge in the README.
Closes #308
## Changes proposed
### What were you told to do?
Upgrade `codecov/codecov-action@v3` to `@v4` pinned by SHA, configure token-based upload inputs, document `CODECOV_TOKEN` in `CONTRIBUTING.md`, and ensure the README coverage badge points at live Codecov data.
### What did I do?
#### CI hardening
- Replaced the mutable `@v3` action reference in `.github/workflows/ci.yml` with the immutable commit SHA for Codecov v4.6.0.
- Added the `CODECOV_TOKEN`, `files`, and `slug` inputs expected by the upgraded action.
#### Contributor documentation
- Added `CONTRIBUTING.md` with repository secret setup steps for `CODECOV_TOKEN`.
#### README updates
- Added a live Codecov badge that points at the `HyperSafeD/Sanctifier` project coverage page.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
- `cargo fmt --all --check`
- `cargo test -p sanctifier-core --all-features`
- Verified the workflow diff updates only the Codecov step, the README badge, and the new contributor secret documentation.
