### PR TITLE
[integration] add soroban examples case study workflow

### DIFF
--- a/.github/workflows/soroban-examples.yml
+++ b/.github/workflows/soroban-examples.yml
@@ -1,0 +1,46 @@
+name: Soroban Examples Case Study
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  soroban-examples:
+    name: Analyze stellar/soroban-examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libz3-dev libdbus-1-dev
+
+      - name: Clone official Soroban examples
+        run: git clone https://github.com/stellar/soroban-examples.git
+
+      - name: Build sanctifier CLI
+        run: cargo build --manifest-path tooling/sanctifier-cli/Cargo.toml --release
+
+      - name: Analyze Soroban examples
+        run: |
+          python scripts/analyze-soroban-examples.py \
+            soroban-examples \
+            tooling/sanctifier-cli/target/release/sanctifier \
+            soroban-examples-summary.json
+
+      - name: Upload summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: soroban-examples-summary
+          path: soroban-examples-summary.json

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ sanctifier analyze . --format json > sanctifier-report.json
 sanctifier badge --report sanctifier-report.json --svg-output badges/sanctifier-security.svg --markdown-output badges/sanctifier-security.md
 ```
 
+## Case Studies
+Sanctifier is now benchmarked against the official Soroban examples repository.
+See [docs/case-studies/soroban-examples.md](docs/case-studies/soroban-examples.md) for the current baseline results and follow-up precision work.
+
 ## 🤝 Contributing
 We welcome contributions from the Stellar community! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 

--- a/docs/case-studies/soroban-examples.md
+++ b/docs/case-studies/soroban-examples.md
@@ -1,0 +1,69 @@
+# Soroban Examples Case Study
+
+## Summary
+
+On March 24, 2026, Sanctifier was run against the official
+[`stellar/soroban-examples`](https://github.com/stellar/soroban-examples)
+repository as a reproducible benchmark.
+
+- Crates scanned: 43
+- Crates with findings: 39
+- Crates without findings: 4
+- Total findings: 662
+- Authorization gaps: 15
+- Panic issues: 66
+- Arithmetic issues: 64
+- Unhandled results: 161
+- SMT issues: 0
+
+This baseline is useful, but it does not support a "0 false positives" claim
+yet. Instead, it gives us a public benchmark for precision work.
+
+## Zero-Finding Crates
+
+The following crates completed with no findings:
+
+- `hello_world`
+- `logging`
+- `multisig_1_of_n_account/contract`
+- `workspace/contract_a_interface`
+
+## Highest-Noise Crates
+
+The largest result sets came from:
+
+- `privacy-pools/libs/lean-imt` with 104 findings
+- `privacy-pools/contract` with 95 findings
+- `liquidity_pool` with 87 findings
+- `privacy-pools/cli/coinutils` with 61 findings
+- `token` with 37 findings
+
+The dominant categories across the benchmark were unhandled-result findings,
+panic findings, and arithmetic findings.
+
+## Precision Follow-Up
+
+The scan highlighted several likely precision problems that were turned into
+follow-up issues in this repository:
+
+- Auth-gap investigation: `#347`
+- Unhandled-result investigation: `#348`
+- Arithmetic and panic investigation: `#349`
+
+## Responsible Disclosure Status
+
+This automated pass did not establish any confirmed vulnerabilities that were
+ready for responsible disclosure to the Stellar team. The findings above need
+manual triage to separate true positives from false positives before any
+external report is made.
+
+## Reproducing the Benchmark
+
+The repository now includes:
+
+- `.github/workflows/soroban-examples.yml` for CI execution
+- `scripts/analyze-soroban-examples.py` for local or CI reproduction
+
+The workflow clones the official examples repository, builds the Sanctifier CLI,
+runs the analysis across each crate containing `src/lib.rs`, and uploads a JSON
+summary artifact.

--- a/scripts/analyze-soroban-examples.py
+++ b/scripts/analyze-soroban-examples.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import subprocess
+import sys
+
+
+def iter_contract_dirs(root: pathlib.Path):
+    for lib_rs in sorted(root.rglob("src/lib.rs")):
+        yield lib_rs.parent.parent
+
+
+def analyze_contract(cli_path: pathlib.Path, contract_dir: pathlib.Path, root: pathlib.Path):
+    proc = subprocess.run(
+        [str(cli_path), "analyze", str(contract_dir), "--format", "json"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    report = json.loads(proc.stdout)
+    summary = report.get("summary", {})
+    return {
+        "path": str(contract_dir.relative_to(root)).replace("\\", "/"),
+        "exit_code": proc.returncode,
+        "total_findings": summary.get("total_findings", 0),
+        "auth_gaps": summary.get("auth_gaps", 0),
+        "panic_issues": summary.get("panic_issues", 0),
+        "arithmetic_issues": summary.get("arithmetic_issues", 0),
+        "size_warnings": summary.get("size_warnings", 0),
+        "unhandled_results": summary.get("unhandled_results", 0),
+        "smt_issues": summary.get("smt_issues", 0),
+    }
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit(
+            "usage: analyze-soroban-examples.py <examples-root> <sanctifier-cli> <output-json>"
+        )
+
+    root = pathlib.Path(sys.argv[1]).resolve()
+    cli_path = pathlib.Path(sys.argv[2]).resolve()
+    output_path = pathlib.Path(sys.argv[3]).resolve()
+
+    results = [analyze_contract(cli_path, contract_dir, root) for contract_dir in iter_contract_dirs(root)]
+    aggregate = {
+        "crates_scanned": len(results),
+        "crates_with_findings": sum(1 for item in results if item["total_findings"] > 0),
+        "crates_without_findings": sum(1 for item in results if item["total_findings"] == 0),
+        "total_findings": sum(item["total_findings"] for item in results),
+        "total_auth_gaps": sum(item["auth_gaps"] for item in results),
+        "total_panic_issues": sum(item["panic_issues"] for item in results),
+        "total_arithmetic_issues": sum(item["arithmetic_issues"] for item in results),
+        "total_unhandled_results": sum(item["unhandled_results"] for item in results),
+        "total_smt_issues": sum(item["smt_issues"] for item in results),
+    }
+
+    payload = {"aggregate": aggregate, "results": results}
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(aggregate, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
Add a reproducible Soroban examples case-study workflow, document the current benchmark results, and link the repo back to that case study from the README.
Closes #327
## Changes proposed
### What were you told to do?
Run Sanctifier against the official `stellar/soroban-examples` repository, document the results in `docs/case-studies/soroban-examples.md`, convert false-positive follow-up into detector-improvement issues, and add a README reference to the case study.
### What did I do?
#### Reproducible case-study workflow
- Added `.github/workflows/soroban-examples.yml` to clone the official examples repo, build the CLI, run the benchmark script, and upload a JSON summary artifact.
- Added `scripts/analyze-soroban-examples.py` to scan every crate containing `src/lib.rs` and produce aggregate/result summaries.
#### Documentation
- Added `docs/case-studies/soroban-examples.md` with the March 24, 2026 baseline results.
- Updated the README with a direct case-study reference.
#### Follow-up precision work
- Opened detector-improvement issues `#347`, `#348`, and `#349` for the auth-gap, unhandled-result, and arithmetic/panic noise surfaced by the benchmark.
- Documented that no responsibly reportable Stellar-side findings were confirmed from this automated pass yet.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
- Ran `sanctifier analyze <crate> --format json` across 43 crate directories in the local clone of `stellar/soroban-examples` and captured aggregate totals: 662 findings, 39 crates with findings, 4 crates with zero findings.
- Ran `scripts/analyze-soroban-examples.py soroban-examples tooling/sanctifier-cli/target/debug/sanctifier soroban-examples-summary-artifact.json` locally after fixing UTF-8 subprocess handling.
- Opened follow-up issues `#347`, `#348`, and `#349` from the benchmark results.
