### PR TITLE
[precision] Reduce unhandled-result false positives on soroban-examples

### DIFF
--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -1520,11 +1520,11 @@ impl UnhandledResultVisitor {
                     if let Some(fn_name) = &self.current_fn {
                         let line = expr.span().start().line;
                         self.issues.push(UnhandledResultIssue {
-                            function_name: fn_name.to_string(),
-                            call_expression: Self::expr_to_string(expr),
-                            message: "Result returned from function call is not handled. Use ?, match, or .unwrap()/.expect() to handle the Result.".to_string(),
-                            location: format!("{}:{}", fn_name, line),
-                        });
+                        function_name: fn_name.to_string(),
+                        call_expression: Self::expr_to_string(expr),
+                        message: "Result returned from function call is not handled. Use ?, match, or .unwrap()/.expect() to handle the Result.".to_string(),
+                        location: format!("{}:{}", fn_name, line),
+                    });
                     }
                 }
                 for arg in &call.args {
@@ -1532,9 +1532,10 @@ impl UnhandledResultVisitor {
                 }
             }
             syn::Expr::MethodCall(m) => {
-                if !Self::is_handled(expr) {
-                    self.check_expr_for_unhandled_result(&m.receiver, fn_returns_result);
+                if Self::is_handled(expr) {
+                    return;
                 }
+                self.check_expr_for_unhandled_result(&m.receiver, fn_returns_result);
                 for arg in &m.args {
                     self.check_expr_for_unhandled_result(arg, fn_returns_result);
                 }
@@ -1587,6 +1588,24 @@ impl UnhandledResultVisitor {
                     self.check_expr_for_unhandled_result(expr, true);
                 }
             }
+            syn::Expr::Path(_) => {}
+            syn::Expr::Lit(_) => {}
+            syn::Expr::Field(f) => {
+                self.check_expr_for_unhandled_result(&f.base, fn_returns_result);
+            }
+            syn::Expr::Index(i) => {
+                self.check_expr_for_unhandled_result(&i.expr, fn_returns_result);
+                self.check_expr_for_unhandled_result(&i.index, fn_returns_result);
+            }
+            syn::Expr::Reference(r) => {
+                self.check_expr_for_unhandled_result(&r.expr, fn_returns_result);
+            }
+            syn::Expr::Unary(u) => {
+                self.check_expr_for_unhandled_result(&u.expr, fn_returns_result);
+            }
+            syn::Expr::Cast(c) => {
+                self.check_expr_for_unhandled_result(&c.expr, fn_returns_result);
+            }
             _ => {}
         }
     }
@@ -1601,7 +1620,28 @@ impl UnhandledResultVisitor {
         if let syn::Expr::Path(p) = &*call.func {
             if let Some(seg) = p.path.segments.last() {
                 let name = seg.ident.to_string();
-                return !matches!(name.as_str(), "Ok" | "Err" | "Some" | "None" | "panic");
+                if matches!(name.as_str(), "Ok" | "Err" | "Some" | "None" | "panic") {
+                    return false;
+                }
+                if matches!(
+                    name.as_str(),
+                    "assert"
+                        | "assert_eq"
+                        | "assert_ne"
+                        | "debug_assert"
+                        | "debug_assert_eq"
+                        | "debug_assert_ne"
+                        | "println"
+                        | "print"
+                        | "eprintln"
+                        | "eprint"
+                        | "format"
+                        | "vec"
+                        | "panic"
+                ) {
+                    return false;
+                }
+                return true;
             }
         }
         false
@@ -1641,6 +1681,11 @@ impl UnhandledResultVisitor {
                         | "or_else"
                         | "unwrap_unchecked"
                         | "expect_unchecked"
+                        | "as_ref"
+                        | "as_mut"
+                        | "clone"
+                        | "inspect"
+                        | "inspect_err"
                 )
             }
             syn::Expr::Assign(a) => Self::is_handled(&a.right),
@@ -1654,6 +1699,7 @@ impl UnhandledResultVisitor {
                 }
                 false
             }
+            syn::Expr::Block(_) => true,
             _ => false,
         }
     }
@@ -2371,6 +2417,154 @@ mod tests {
         let source = "this is not valid rust";
         let issues = analyzer.scan_unhandled_results(source);
         assert_eq!(issues.len(), 0, "{:?}", issues);
+    }
+
+    #[test]
+    fn test_unhandled_result_assert_macro() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+fn returns_result() -> Result<u32, Error> { Ok(42) }
+
+#[contractimpl]
+impl MyContract {
+    pub fn test_fn(env: Env) {
+        assert!(true);
+        assert_eq!(1, 1);
+        assert_ne!(1, 2);
+        debug_assert!(true);
+        println!("test");
+        format!("test");
+    }
+}
+"#;
+        let issues = analyzer.scan_unhandled_results(source);
+        assert_eq!(
+            issues.len(),
+            0,
+            "assert/print macros should not be flagged as unhandled results: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_unhandled_result_fluent_builder() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+struct Builder { val: u32 }
+impl Builder {
+    fn with_value(mut self, v: u32) -> Self { self.val = v; self }
+}
+
+#[contractimpl]
+impl MyContract {
+    pub fn build(env: Env) -> u32 {
+        Builder { val: 0 }
+            .with_value(1)
+            .with_value(2)
+    }
+}
+"#;
+        let issues = analyzer.scan_unhandled_results(source);
+        assert_eq!(
+            issues.len(),
+            0,
+            "fluent builder should not be flagged: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_unhandled_result_assignment() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+fn returns_result() -> Result<u32, Error> { Ok(42) }
+
+#[contractimpl]
+impl MyContract {
+    pub fn test_fn(env: Env) {
+        let result = returns_result();
+        let _ = returns_result();
+    }
+}
+"#;
+        let issues = analyzer.scan_unhandled_results(source);
+        assert_eq!(
+            issues.len(),
+            2,
+            "assignment without handling should be flagged: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_unhandled_result_block_expression() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+fn returns_result() -> Result<u32, Error> { Ok(42) }
+
+#[contractimpl]
+impl MyContract {
+    pub fn test_fn(env: Env) -> u32 {
+        {
+            let x = 1;
+            x + 1
+        }
+    }
+}
+"#;
+        let issues = analyzer.scan_unhandled_results(source);
+        assert_eq!(
+            issues.len(),
+            0,
+            "block expressions should not be flagged: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_unhandled_result_inspect() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+fn returns_result() -> Result<u32, Error> { Ok(42) }
+
+#[contractimpl]
+impl MyContract {
+    pub fn test_fn(env: Env) -> u32 {
+        returns_result()
+            .inspect(|v| println!("Got {}", v))
+            .unwrap()
+    }
+}
+"#;
+        let issues = analyzer.scan_unhandled_results(source);
+        assert_eq!(
+            issues.len(),
+            0,
+            "inspect should be recognized as handled: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_unhandled_result_private_fn_not_flagged() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+fn returns_result() -> Result<u32, Error> { Ok(42) }
+
+#[contractimpl]
+impl MyContract {
+    fn private_fn(env: Env) {
+        returns_result();
+    }
+}
+"#;
+        let issues = analyzer.scan_unhandled_results(source);
+        assert_eq!(
+            issues.len(),
+            0,
+            "private function unhandled results should not be flagged: {:?}",
+            issues
+        );
     }
 
     #[test]

--- a/tooling/sanctifier-core/src/rules/unhandled_result.rs
+++ b/tooling/sanctifier-core/src/rules/unhandled_result.rs
@@ -115,6 +115,11 @@ impl ResultVisitor {
                         | "or_else"
                         | "unwrap_unchecked"
                         | "expect_unchecked"
+                        | "as_ref"
+                        | "as_mut"
+                        | "clone"
+                        | "inspect"
+                        | "inspect_err"
                 )
             }
             syn::Expr::Assign(a) => Self::is_handled(&a.right),
@@ -128,6 +133,7 @@ impl ResultVisitor {
                 }
                 false
             }
+            syn::Expr::Block(_) => true,
             _ => false,
         }
     }
@@ -136,7 +142,28 @@ impl ResultVisitor {
         if let syn::Expr::Path(p) = &*call.func {
             if let Some(seg) = p.path.segments.last() {
                 let name = seg.ident.to_string();
-                return !matches!(name.as_str(), "Ok" | "Err" | "Some" | "None" | "panic");
+                if matches!(name.as_str(), "Ok" | "Err" | "Some" | "None" | "panic") {
+                    return false;
+                }
+                if matches!(
+                    name.as_str(),
+                    "assert"
+                        | "assert_eq"
+                        | "assert_ne"
+                        | "debug_assert"
+                        | "debug_assert_eq"
+                        | "debug_assert_ne"
+                        | "println"
+                        | "print"
+                        | "eprintln"
+                        | "eprint"
+                        | "format"
+                        | "vec"
+                        | "panic"
+                ) {
+                    return false;
+                }
+                return true;
             }
         }
         false


### PR DESCRIPTION
## Summary

This PR reduces false positive noise from the `unhandled_result` rule when analyzing soroban-examples helper and contract crates. The original rule was over-reporting on fluent APIs, helper-return patterns, and commonly used macros.

## Problem

Analysis of stellar/soroban-examples surfaced 161 unhandled-result findings, heavily concentrated in:
- liquidity_pool (41)
- privacy-pools/cli/coinutils (36)
- oken (21)
- privacy-pools/contract (14)
- privacy-pools/libs/lean-imt (12)

These examples are broadly used reference implementations, suggesting the rule was over-reporting.

## Changes Made

**Excluded Macro Calls**
- `assert`, `assert_eq`, `assert_ne` - assertions are not Result-returning
- `debug_assert`, `debug_assert_eq`, `debug_assert_ne` - debug assertions
- `println`, `print`, `eprintln`, `eprint` - printing macros
- `format`, `vec` - constructor macros

**Added Handled Methods**
- `as_ref`, `as_mut` - reference conversions
- `clone` - cloning Results is intentional
- `inspect`, `inspect_err` - inspection methods handle the Result

**Improved Handling**
- Block expressions are now treated as handled (they return values, not unhandled Results)
- Method call chains properly check if the expression is handled before recursing

## Test Cases Added

- `test_unhandled_result_assert_macro` - Verifies assert macros aren't flagged
- `test_unhandled_result_fluent_builder` - Fluent API patterns
- `test_unhandled_result_assignment` - Assignment without handling
- `test_unhandled_result_block_expression` - Block expressions
- `test_unhandled_result_inspect` - inspect method handling
- `test_unhandled_result_private_fn_not_flagged` - Private function behavior

## Expected Impact

Significant reduction in false positives on soroban-examples while maintaining detection of genuine unhandled Result values in public contract functions.

Closes #348