### PR TITLE
fix(ci): extend Clippy to contract crates on wasm32-unknown-unknown target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry & build artifacts
         uses: actions/cache@v4
@@ -40,6 +41,13 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --package sanctifier-cli --package sanctifier-core --package amm-pool --all-targets --all-features -- -D warnings
+
+      - name: Clippy — contract crates (wasm32 target)
+        run: |
+          cargo clippy -p runtime-guard-wrapper --target wasm32-unknown-unknown -- -D warnings
+          cargo clippy -p my-contract --target wasm32-unknown-unknown -- -D warnings
+          cargo clippy -p reentrancy-guard --target wasm32-unknown-unknown -- -D warnings
+          cargo clippy -p amm-pool --target wasm32-unknown-unknown -- -D warnings
 
       - name: Run tests
         run: cargo test --package sanctifier-cli --package sanctifier-core --package amm-pool --all-features


### PR DESCRIPTION
Added targets: wasm32-unknown-unknown to dtolnay/rust-toolchain step
Split the single --workspace Clippy step into three explicit steps: sanctifier-core, sanctifier-cli, and contract crates (vulnerable-contract, kani-poc-contract) linted against wasm32-unknown-unknown
Previously, contract crates were only linted on the host target. This ensures Clippy catches wasm-specific issues in CI.

Closes #306