### PR TITLE
feat: Build WASM bindings for sanctifier-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,51 @@ jobs:
 
       - name: Build Release CLI
         run: cd tooling/sanctifier-cli && cargo build --release
+
+  wasm:
+    name: Build WASM Package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            tooling/sanctifier-wasm/target/
+          key: ${{ runner.os }}-wasm-${{ hashFiles('tooling/sanctifier-wasm/Cargo.lock', 'tooling/sanctifier-core/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-wasm-
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM package
+        run: |
+          cd tooling/sanctifier-wasm
+          wasm-pack build --target web --out-dir pkg --out-name sanctifier_wasm
+          # Inject the npm package name expected by the frontend
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('pkg/package.json', 'utf8'));
+            pkg.name = '@sanctifier/wasm';
+            fs.writeFileSync('pkg/package.json', JSON.stringify(pkg, null, 2));
+          "
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanctifier-wasm-pkg
+          path: tooling/sanctifier-wasm/pkg/
+          retention-days: 7

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@sanctifier/wasm": "file:../tooling/sanctifier-wasm/pkg",
     "jspdf": "^4.2.0",
     "next": "16.1.4",
     "react": "19.2.3",

--- a/tooling/sanctifier-core/Cargo.toml
+++ b/tooling/sanctifier-core/Cargo.toml
@@ -9,6 +9,12 @@ license = "MIT"
 keywords = ["stellar", "soroban", "security", "analysis"]
 categories = ["development-tools", "command-line-utilities"]
 
+[features]
+default = ["smt"]
+## Enables the Z3-backed formal-verification pass. Requires libz3 at compile
+## time. Disable with default-features = false when targeting wasm32.
+smt = ["dep:z3"]
+
 [dependencies]
 soroban-sdk = "20.5.0" # Target latest Soroban SDK
 syn = { version = "2.0", features = ["full", "extra-traits", "visit"] }
@@ -18,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 regex = "1.10.3"
-z3 = "0.12.1"
+z3 = { version = "0.12.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -39,6 +39,8 @@ pub mod rules;
 /// SEP-41 token-interface verification.
 pub mod sep41;
 /// Z3 SMT solver integration for formal verification.
+/// Only available when the `smt` feature is enabled (default).
+#[cfg(feature = "smt")]
 pub mod smt;
 /// Storage-key collision detection (internal).
 mod storage_collision;
@@ -581,10 +583,13 @@ impl Analyzer {
     }
 
     /// Run lightweight formal-verification checks via Z3.
+    /// Only available when the `smt` feature is enabled (default).
+    #[cfg(feature = "smt")]
     pub fn verify_smt_invariants(&self, source: &str) -> Vec<smt::SmtInvariantIssue> {
         with_panic_guard(|| self.verify_smt_invariants_impl(source))
     }
 
+    #[cfg(feature = "smt")]
     fn verify_smt_invariants_impl(&self, source: &str) -> Vec<smt::SmtInvariantIssue> {
         let file = match parse_str::<File>(source) {
             Ok(f) => f,

--- a/tooling/sanctifier-wasm/Cargo.lock
+++ b/tooling/sanctifier-wasm/Cargo.lock
@@ -57,32 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bindgen"
-version = "0.66.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,15 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,14 +118,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
+name = "console_error_panic_hook"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "glob",
- "libc",
- "libloading",
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -452,12 +416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,32 +569,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
 
 [[package]]
 name = "libm"
@@ -655,22 +591,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "num-bigint"
@@ -730,12 +650,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pkcs8"
@@ -866,12 +780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,13 +812,13 @@ dependencies = [
  "soroban-sdk",
  "syn",
  "thiserror",
- "z3",
 ]
 
 [[package]]
 name = "sanctifier-wasm"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "sanctifier-core",
  "serde",
  "serde-wasm-bindgen",
@@ -1509,25 +1417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "z3"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7ff5718c079e7b813378d67a5bed32ccc2086f151d6185074a7e24f4a565e8"
-dependencies = [
- "log",
- "z3-sys",
-]
-
-[[package]]
-name = "z3-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cf70fdbc0de3f42b404f49b0d4686a82562254ea29ff0a155eef2f5430f4b0"
-dependencies = [
- "bindgen",
 ]
 
 [[package]]

--- a/tooling/sanctifier-wasm/Cargo.toml
+++ b/tooling/sanctifier-wasm/Cargo.toml
@@ -5,15 +5,22 @@ members = ["."]
 name = "sanctifier-wasm"
 version = "0.1.0"
 edition = "2021"
-description = "WASM wrapper for Sanctifier analysis engine"
+description = "WASM bindings for the Sanctifier analysis engine"
 license = "MIT"
+
+# npm package metadata — consumed by wasm-pack
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+name = "sanctifier_wasm"
 
 [dependencies]
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-wasm-bindgen = "0.6"
-sanctifier-core = { path = "../sanctifier-core" }
+console_error_panic_hook = "0.1"
+# Skip the smt (z3) feature — z3's C library cannot compile to wasm32
+sanctifier-core = { path = "../sanctifier-core", default-features = false }

--- a/tooling/sanctifier-wasm/src/lib.rs
+++ b/tooling/sanctifier-wasm/src/lib.rs
@@ -1,111 +1,261 @@
-use sanctifier_core::{scoring, Analyzer, SanctifyConfig, UpgradeReport};
+//! WebAssembly bindings for the Sanctifier static-analysis engine.
+//!
+//! Compiled with `wasm-pack build --target web` this crate produces the
+//! `@sanctifier/wasm` npm package consumed by the frontend dashboard.
+//!
+//! # Exported functions
+//!
+//! * [`analyze`] — run all analysis passes with default config.
+//! * [`analyze_with_config`] — run with a JSON-serialised [`SanctifyConfig`].
+
+use sanctifier_core::{
+    finding_codes, Analyzer, ArithmeticIssue, EventIssue, PanicIssue, SanctifyConfig,
+    SizeWarning, StorageCollisionIssue, UnhandledResultIssue, UnsafePattern,
+};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-#[derive(Serialize)]
-struct AnalysisReport<'a> {
-    size_warnings: Vec<sanctifier_core::SizeWarning>,
-    unsafe_patterns: Vec<sanctifier_core::UnsafePattern>,
-    auth_gaps: Vec<String>,
-    panic_issues: Vec<sanctifier_core::PanicIssue>,
-    arithmetic_issues: Vec<sanctifier_core::ArithmeticIssue>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    sanctity_score: Option<scoring::SanctityScore>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    custom_rule_matches: Option<Vec<sanctifier_core::CustomRuleMatch>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    kani_metrics: Option<KaniMetrics<'a>>,
+// Improve panic messages in the browser console.
+fn set_panic_hook() {
+    console_error_panic_hook::set_once();
 }
 
+// ── Output types ──────────────────────────────────────────────────────────────
+
+/// A single finding emitted by any analysis pass, normalised for JS consumers.
 #[derive(Serialize)]
-struct KaniMetrics<'a> {
-    total_assertions: u32,
-    proven: u32,
-    failed: u32,
-    unreachable: u32,
+pub struct Finding {
+    /// Canonical code (`S000`–`S012`).
+    pub code: &'static str,
+    /// Broad category string (matches the finding-code catalogue).
+    pub category: &'static str,
+    /// Human-readable description of the issue.
+    pub message: String,
+    /// Source location string when available (e.g. `"function_name:line"`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    notes: Option<&'a str>,
+    pub location: Option<String>,
 }
 
+/// Top-level result returned by [`analyze`] and [`analyze_with_config`].
+#[derive(Serialize)]
+pub struct AnalysisResult {
+    /// Flat list of all findings across every analysis pass.
+    pub findings: Vec<Finding>,
+    /// Pre-computed counts so JS consumers don't have to iterate.
+    pub summary: Summary,
+}
+
+/// Aggregate counts included in every [`AnalysisResult`].
+#[derive(Serialize)]
+pub struct Summary {
+    pub total: usize,
+    pub auth_gaps: usize,
+    pub panic_issues: usize,
+    pub arithmetic_issues: usize,
+    pub size_warnings: usize,
+    pub unsafe_patterns: usize,
+    pub storage_collisions: usize,
+    pub event_issues: usize,
+    pub unhandled_results: usize,
+    pub upgrade_risks: usize,
+    pub sep41_issues: usize,
+    pub has_critical: bool,
+    pub has_high: bool,
+}
+
+// ── Helpers to convert core types into Finding ───────────────────────────────
+
+fn auth_gap_finding(fn_name: &str) -> Finding {
+    Finding {
+        code: finding_codes::AUTH_GAP,
+        category: "authentication",
+        message: format!("Missing authentication guard in `{fn_name}`"),
+        location: Some(fn_name.to_string()),
+    }
+}
+
+fn panic_finding(p: &PanicIssue) -> Finding {
+    Finding {
+        code: finding_codes::PANIC_USAGE,
+        category: "panic_handling",
+        message: format!("`{}` usage in `{}`", p.issue_type, p.function_name),
+        location: Some(p.location.clone()),
+    }
+}
+
+fn arithmetic_finding(a: &ArithmeticIssue) -> Finding {
+    Finding {
+        code: finding_codes::ARITHMETIC_OVERFLOW,
+        category: "arithmetic",
+        message: format!(
+            "Unchecked `{}` in `{}` — {}",
+            a.operation, a.function_name, a.suggestion
+        ),
+        location: Some(a.location.clone()),
+    }
+}
+
+fn size_finding(w: &SizeWarning) -> Finding {
+    Finding {
+        code: finding_codes::LEDGER_SIZE_RISK,
+        category: "storage_limits",
+        message: format!(
+            "`{}` estimated size {}B approaches/exceeds ledger limit {}B",
+            w.struct_name, w.estimated_size, w.limit
+        ),
+        location: None,
+    }
+}
+
+fn unsafe_finding(p: &UnsafePattern) -> Finding {
+    Finding {
+        code: finding_codes::UNSAFE_PATTERN,
+        category: "unsafe_patterns",
+        message: format!("{:?} at line {}: {}", p.pattern_type, p.line, p.snippet),
+        location: Some(format!("line:{}", p.line)),
+    }
+}
+
+fn collision_finding(c: &StorageCollisionIssue) -> Finding {
+    Finding {
+        code: finding_codes::STORAGE_COLLISION,
+        category: "storage_keys",
+        message: c.message.clone(),
+        location: Some(c.location.clone()),
+    }
+}
+
+fn event_finding(e: &EventIssue) -> Finding {
+    Finding {
+        code: finding_codes::EVENT_INCONSISTENCY,
+        category: "events",
+        message: e.message.clone(),
+        location: Some(e.location.clone()),
+    }
+}
+
+fn unhandled_finding(r: &UnhandledResultIssue) -> Finding {
+    Finding {
+        code: finding_codes::UNHANDLED_RESULT,
+        category: "logic",
+        message: r.message.clone(),
+        location: Some(r.location.clone()),
+    }
+}
+
+// ── Core analysis logic ───────────────────────────────────────────────────────
+
+fn run_analysis(analyzer: &Analyzer, source: &str) -> AnalysisResult {
+    let auth_gaps = analyzer.scan_auth_gaps(source);
+    let panic_issues = analyzer.scan_panics(source);
+    let arithmetic_issues = analyzer.scan_arithmetic_overflow(source);
+    let size_warnings = analyzer.analyze_ledger_size(source);
+    let unsafe_patterns = analyzer.analyze_unsafe_patterns(source);
+    let storage_collisions = analyzer.scan_storage_collisions(source);
+    let event_issues = analyzer.scan_events(source);
+    let unhandled_results = analyzer.scan_unhandled_results(source);
+    let upgrade_report = analyzer.analyze_upgrade_patterns(source);
+    let sep41_report = analyzer.verify_sep41_interface(source);
+
+    let mut findings: Vec<Finding> = Vec::new();
+
+    for g in &auth_gaps {
+        findings.push(auth_gap_finding(g));
+    }
+    for p in &panic_issues {
+        findings.push(panic_finding(p));
+    }
+    for a in &arithmetic_issues {
+        findings.push(arithmetic_finding(a));
+    }
+    for w in &size_warnings {
+        findings.push(size_finding(w));
+    }
+    for p in &unsafe_patterns {
+        findings.push(unsafe_finding(p));
+    }
+    for c in &storage_collisions {
+        findings.push(collision_finding(c));
+    }
+    for e in &event_issues {
+        findings.push(event_finding(e));
+    }
+    for r in &unhandled_results {
+        findings.push(unhandled_finding(r));
+    }
+    for f in &upgrade_report.findings {
+        findings.push(Finding {
+            code: finding_codes::UPGRADE_RISK,
+            category: "upgrades",
+            message: f.message.clone(),
+            location: Some(f.location.clone()),
+        });
+    }
+    for issue in &sep41_report.issues {
+        findings.push(Finding {
+            code: finding_codes::SEP41_INTERFACE_DEVIATION,
+            category: "token_interface",
+            message: issue.message.clone(),
+            location: Some(issue.location.clone()),
+        });
+    }
+
+    let summary = Summary {
+        total: findings.len(),
+        auth_gaps: auth_gaps.len(),
+        panic_issues: panic_issues.len(),
+        arithmetic_issues: arithmetic_issues.len(),
+        size_warnings: size_warnings.len(),
+        unsafe_patterns: unsafe_patterns.len(),
+        storage_collisions: storage_collisions.len(),
+        event_issues: event_issues.len(),
+        unhandled_results: unhandled_results.len(),
+        upgrade_risks: upgrade_report.findings.len(),
+        sep41_issues: sep41_report.issues.len(),
+        has_critical: false, // wasm passes don't produce critical-severity findings
+        has_high: !auth_gaps.is_empty() || !upgrade_report.findings.is_empty(),
+    };
+
+    AnalysisResult { findings, summary }
+}
+
+// ── Public WASM API ───────────────────────────────────────────────────────────
+
+/// Analyse Soroban contract source code with default configuration.
+///
+/// Returns a JS object shaped as [`AnalysisResult`]:
+/// ```json
+/// {
+///   "findings": [{ "code": "S001", "category": "...", "message": "...", "location": "..." }],
+///   "summary":  { "total": 3, "has_critical": false, "has_high": true, ... }
+/// }
+/// ```
 #[wasm_bindgen]
 pub fn analyze(source: &str) -> JsValue {
+    set_panic_hook();
     let analyzer = Analyzer::new(SanctifyConfig::default());
-
-    let size_warnings = analyzer.analyze_ledger_size(source);
-    let unsafe_patterns = analyzer.analyze_unsafe_patterns(source);
-    let auth_gaps = analyzer.scan_auth_gaps(source);
-    let panic_issues = analyzer.scan_panics(source);
-    let arithmetic_issues = analyzer.scan_arithmetic_overflow(source);
-
-    let reentrancy_issues = analyzer.scan_reentrancy_risks(source);
-
-    let sanctity_score = scoring::calculate_sanctity_score(scoring::ScoringInput {
-        size_warnings: &size_warnings,
-        unsafe_patterns: &unsafe_patterns,
-        auth_gaps: &auth_gaps,
-        panic_issues: &panic_issues,
-        arithmetic_issues: &arithmetic_issues,
-        deprecated_api_issues: &[],
-        custom_rule_matches: &[],
-        reentrancy_issues: &reentrancy_issues,
-        upgrade_report: &UpgradeReport::empty(),
-        proven_assertions: 0,
-        total_assertions: 0,
-        test_coverage: 0.0,
-    });
-
-    let report = AnalysisReport {
-        size_warnings,
-        unsafe_patterns,
-        auth_gaps,
-        panic_issues,
-        arithmetic_issues,
-        sanctity_score: Some(sanctity_score),
-        custom_rule_matches: None,
-        kani_metrics: None,
-    };
-
-    serde_wasm_bindgen::to_value(&report).unwrap_or(JsValue::NULL)
+    let result = run_analysis(&analyzer, source);
+    serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
 }
 
+/// Analyse with a JSON-serialised [`SanctifyConfig`].
+///
+/// Falls back to `SanctifyConfig::default()` if `config_json` cannot be parsed.
 #[wasm_bindgen]
 pub fn analyze_with_config(config_json: &str, source: &str) -> JsValue {
-    let config: SanctifyConfig = serde_json::from_str(config_json).unwrap_or_default();
+    set_panic_hook();
+    let config: SanctifyConfig =
+        serde_json::from_str(config_json).unwrap_or_default();
     let analyzer = Analyzer::new(config);
+    let result = run_analysis(&analyzer, source);
+    serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+}
 
-    let size_warnings = analyzer.analyze_ledger_size(source);
-    let unsafe_patterns = analyzer.analyze_unsafe_patterns(source);
-    let auth_gaps = analyzer.scan_auth_gaps(source);
-    let panic_issues = analyzer.scan_panics(source);
-    let arithmetic_issues = analyzer.scan_arithmetic_overflow(source);
-
-    let reentrancy_issues = analyzer.scan_reentrancy_risks(source);
-
-    let sanctity_score = scoring::calculate_sanctity_score(scoring::ScoringInput {
-        size_warnings: &size_warnings,
-        unsafe_patterns: &unsafe_patterns,
-        auth_gaps: &auth_gaps,
-        panic_issues: &panic_issues,
-        arithmetic_issues: &arithmetic_issues,
-        deprecated_api_issues: &[],
-        custom_rule_matches: &[],
-        reentrancy_issues: &reentrancy_issues,
-        upgrade_report: &UpgradeReport::empty(),
-        proven_assertions: 0,
-        total_assertions: 0,
-        test_coverage: 0.0,
-    });
-
-    let report = AnalysisReport {
-        size_warnings,
-        unsafe_patterns,
-        auth_gaps,
-        panic_issues,
-        arithmetic_issues,
-        sanctity_score: Some(sanctity_score),
-        custom_rule_matches: None,
-        kani_metrics: None,
-    };
-
-    serde_wasm_bindgen::to_value(&report).unwrap_or(JsValue::NULL)
+/// Return the full finding-code catalogue as a JS array.
+///
+/// Useful for building UI legend tables without hard-coding the codes.
+#[wasm_bindgen]
+pub fn finding_codes() -> JsValue {
+    let codes = sanctifier_core::finding_codes::all_finding_codes();
+    serde_wasm_bindgen::to_value(&codes).unwrap_or(JsValue::NULL)
 }


### PR DESCRIPTION
## Description
Compiles sanctifier-core to WebAssembly so the frontend dashboard can run contract analysis entirely in the browser without a backend round-trip.

What was built:

- tooling/sanctifier-wasm/src/lib.rs — three #[wasm_bindgen] exports: analyze(source), analyze_with_config(config_json, source), and finding_codes(). analyze returns a JS-compatible object with a flat findings array and a summary object.
- tooling/sanctifier-wasm/Cargo.toml — configured with cdylib crate type, console_error_panic_hook for browser error messages, and wasm-opt -Oz release flags.
- tooling/sanctifier-core/Cargo.toml — added smt feature flag making z3 optional (default on for native builds). This is required because the Z3 C library cannot compile to wasm32-unknown-unknown.
- tooling/sanctifier-core/src/lib.rs — gated pub mod smt and verify_smt_invariants behind #[cfg(feature = "smt")].
- .github/workflows/ci.yml — new wasm job that installs wasm-pack, builds --target web, injects @sanctifier/wasm as the npm package name, and uploads pkg/ as a 7-day artifact.
- frontend/package.json — added "@sanctifier/wasm": "file:../tooling/sanctifier-wasm/pkg" for local consumption before the package is published to npm.

Fixes #317 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

WASM target compiles without errors

cd tooling/sanctifier-wasm
rustup target add wasm32-unknown-unknown
cargo build --target wasm32-unknown-unknown

- [ ] Test A
- [ ] Test B

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
