### PR TITLE
fix(frontend): persist dashboard theme

### DIFF
--- a/frontend/app/components/ThemeToggle.stories.tsx
+++ b/frontend/app/components/ThemeToggle.stories.tsx
@@ -1,6 +1,55 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useLayoutEffect, type ComponentType, type ReactNode } from "react";
 import { ThemeToggle } from "./ThemeToggle";
 import { ThemeProvider } from "../providers/theme-provider";
+
+type ThemeMode = "light" | "dark";
+
+function applyTheme(theme: ThemeMode) {
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.classList.toggle("dark", theme === "dark");
+  root.style.colorScheme = theme;
+  window.localStorage.setItem("theme", theme);
+}
+
+function ThemeStory({ theme, children }: { theme: ThemeMode; children: ReactNode }) {
+  useLayoutEffect(() => {
+    const previousTheme = document.documentElement.dataset.theme;
+    const previousDark = document.documentElement.classList.contains("dark");
+
+    applyTheme(theme);
+
+    return () => {
+      const root = document.documentElement;
+      if (previousTheme === undefined) {
+        delete root.dataset.theme;
+      } else {
+        root.dataset.theme = previousTheme;
+      }
+      root.classList.toggle("dark", previousDark);
+      root.style.colorScheme = previousDark ? "dark" : "light";
+    };
+  }, [theme]);
+
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+function LightThemeStory(Story: ComponentType) {
+  return (
+    <ThemeStory theme="light">
+      <Story />
+    </ThemeStory>
+  );
+}
+
+function DarkThemeStory(Story: ComponentType) {
+  return (
+    <ThemeStory theme="dark">
+      <Story />
+    </ThemeStory>
+  );
+}
 
 const meta: Meta<typeof ThemeToggle> = {
   title: "Components/ThemeToggle",
@@ -15,16 +64,15 @@ const meta: Meta<typeof ThemeToggle> = {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <ThemeProvider>
-        <Story />
-      </ThemeProvider>
-    ),
-  ],
 };
 
 export default meta;
 type Story = StoryObj<typeof ThemeToggle>;
 
-export const Default: Story = {};
+export const Light: Story = {
+  decorators: [LightThemeStory],
+};
+
+export const Dark: Story = {
+  decorators: [DarkThemeStory],
+};

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -12,6 +12,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
+:root[data-theme="dark"],
 :root.dark {
   --background: #0a0a0a;
   --foreground: #ededed;
@@ -22,6 +23,12 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans), sans-serif;
   transition: background-color 0.3s ease, color 0.3s ease;
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] body,
+:root.dark body {
+  color-scheme: dark;
 }
 
 /* High Contrast Accessibility Mode */

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,8 +24,36 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const themeBootstrapScript = `
+    (() => {
+      const storageKey = "theme";
+      const root = document.documentElement;
+      let theme = "light";
+
+      try {
+        const stored = window.localStorage.getItem(storageKey);
+        if (stored === "light" || stored === "dark") {
+          theme = stored;
+        } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          theme = "dark";
+        }
+      } catch (error) {
+        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          theme = "dark";
+        }
+      }
+
+      root.dataset.theme = theme;
+      root.classList.toggle("dark", theme === "dark");
+      root.style.colorScheme = theme;
+    })();
+  `;
+
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/frontend/app/providers/theme-provider.tsx
+++ b/frontend/app/providers/theme-provider.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 type Theme = "light" | "dark";
+const STORAGE_KEY = "theme";
 
 type ThemeContextValue = {
   theme: Theme;
@@ -12,47 +18,53 @@ type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function syncTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.classList.toggle("dark", theme === "dark");
+  root.style.colorScheme = theme;
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>("light");
 
   useEffect(() => {
-    const stored = window.localStorage.getItem("sanctifier-theme");
-    if (stored === "light" || stored === "dark") {
-      applyTheme(stored);
-      return;
-    }
-
-    const preferred = window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
-    applyTheme(preferred);
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    const nextTheme = stored === "light" || stored === "dark"
+      ? stored
+      : getSystemTheme();
+    // Sync the hydrated state to the persisted theme after the bootstrap script has prevented flicker.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setThemeState(nextTheme);
+    syncTheme(nextTheme);
+    window.localStorage.setItem(STORAGE_KEY, nextTheme);
   }, []);
 
   const setTheme = (nextTheme: Theme) => {
-    applyTheme(nextTheme);
+    setThemeState(nextTheme);
+    syncTheme(nextTheme);
+    window.localStorage.setItem(STORAGE_KEY, nextTheme);
   };
 
   const toggleTheme = () => {
     setTheme(theme === "light" ? "dark" : "light");
   };
 
-  const applyTheme = (nextTheme: Theme) => {
-    const root = document.documentElement;
-    root.classList.toggle("dark", nextTheme === "dark");
-    setThemeState(nextTheme);
-    window.localStorage.setItem("sanctifier-theme", nextTheme);
-  };
-
-  const value = useMemo(
-    () => ({
-      theme,
-      toggleTheme,
-      setTheme,
-    }),
-    [theme]
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
   );
-
-  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
 export function useTheme() {


### PR DESCRIPTION
## Description
Persist the dashboard theme across reloads, apply the theme before first paint, and cover both ThemeToggle states in Storybook.

Fixes #292

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] frontend build completed with `npm run build`
- [x] Storybook build completed with `npm run build-storybook`
- [x] ESLint passed on the changed TSX files

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
