### PR TITLE
fix(core): reduce auth-gap false positives

### DIFF
--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -213,6 +213,10 @@ impl FunctionSecuritySummary {
     }
 }
 
+fn is_reserved_soroban_entrypoint(fn_name: &str) -> bool {
+    matches!(fn_name, "__constructor" | "__check_auth")
+}
+
 impl<'ast> Visit<'ast> for UnsafeVisitor {
     fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
         let method_name = node.method.to_string();
@@ -675,6 +679,9 @@ impl Analyzer {
                     if let syn::ImplItem::Fn(f) = impl_item {
                         if let syn::Visibility::Public(_) = f.vis {
                             let fn_name = f.sig.ident.to_string();
+                            if is_reserved_soroban_entrypoint(&fn_name) {
+                                continue;
+                            }
                             let mut summary = FunctionSecuritySummary::default();
                             self.check_fn_body(&f.block, &mut summary);
                             if summary.has_sensitive_action() && !summary.has_auth {
@@ -1451,6 +1458,7 @@ fn is_external_contract_method_call(method_call: &syn::ExprMethodCall) -> bool {
     }
 
     receiver_looks_like_external_client(&method_call.receiver)
+        && !method_looks_read_only(&method_call.method.to_string())
 }
 
 fn receiver_looks_like_external_client(expr: &syn::Expr) -> bool {
@@ -1494,6 +1502,13 @@ fn path_looks_like_client_constructor(path: &syn::Path) -> bool {
 fn ident_looks_like_client(ident: &str) -> bool {
     let lower = ident.to_lowercase();
     lower.ends_with("client") || lower.ends_with("_client")
+}
+
+fn method_looks_read_only(method_name: &str) -> bool {
+    matches!(method_name, "balance" | "paused" | "allowance" | "decimals" | "name" | "symbol")
+        || method_name.starts_with("get_")
+        || method_name.starts_with("is_")
+        || method_name.starts_with("has_")
 }
 
 // ── EventVisitor (stubs/helpers moved) ──────────────────────────────────────
@@ -1965,6 +1980,55 @@ mod tests {
 
         let gaps = analyzer.scan_auth_gaps(source);
         assert_eq!(gaps, vec!["forward".to_string()]);
+    }
+
+    #[test]
+    fn test_scan_auth_gaps_ignores_reserved_soroban_entrypoints() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+            #[contractimpl]
+            impl AccountContract {
+                pub fn __constructor(env: Env, admin: Address) {
+                    env.storage().instance().set(&symbol_short!("admin"), &admin);
+                }
+
+                pub fn reset_admin(env: Env, admin: Address) {
+                    env.storage().instance().set(&symbol_short!("admin"), &admin);
+                }
+            }
+
+            #[contractimpl(contracttrait)]
+            impl CustomAccountInterface for AccountContract {
+                pub fn __check_auth(env: Env, payload: BytesN<32>) {
+                    env.storage().temporary().set(&payload, &true);
+                }
+            }
+        "#;
+
+        let gaps = analyzer.scan_auth_gaps(source);
+        assert_eq!(gaps, vec!["reset_admin".to_string()]);
+    }
+
+    #[test]
+    fn test_scan_auth_gaps_ignores_read_only_external_client_calls() {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let source = r#"
+            #[contractimpl]
+            impl Pool {
+                pub fn get_balance(env: Env, token: Address) -> i128 {
+                    let client = token::Client::new(&env, &token);
+                    client.balance(&env.current_contract_address())
+                }
+
+                pub fn forward_transfer(env: Env, token: Address, to: Address, amount: i128) {
+                    let client = token::Client::new(&env, &token);
+                    client.transfer(&env.current_contract_address(), &to, &amount);
+                }
+            }
+        "#;
+
+        let gaps = analyzer.scan_auth_gaps(source);
+        assert_eq!(gaps, vec!["forward_transfer".to_string()]);
     }
 
     #[test]

--- a/tooling/sanctifier-core/src/rules/auth_gap.rs
+++ b/tooling/sanctifier-core/src/rules/auth_gap.rs
@@ -18,6 +18,10 @@ impl FunctionSecuritySummary {
     }
 }
 
+fn is_reserved_soroban_entrypoint(fn_name: &str) -> bool {
+    matches!(fn_name, "__constructor" | "__check_auth")
+}
+
 impl AuthGapRule {
     /// Create a new instance.
     pub fn new() -> Self {
@@ -53,6 +57,9 @@ impl Rule for AuthGapRule {
                     if let syn::ImplItem::Fn(f) = impl_item {
                         if let syn::Visibility::Public(_) = f.vis {
                             let fn_name = f.sig.ident.to_string();
+                            if is_reserved_soroban_entrypoint(&fn_name) {
+                                continue;
+                            }
                             let mut summary = FunctionSecuritySummary::default();
                             check_fn_body(&f.block, &mut summary);
                             if summary.has_sensitive_action() && !summary.has_auth {
@@ -83,6 +90,9 @@ impl Rule for AuthGapRule {
                 for impl_item in &i.items {
                     if let syn::ImplItem::Fn(f) = impl_item {
                         if let syn::Visibility::Public(_) = f.vis {
+                            if is_reserved_soroban_entrypoint(&f.sig.ident.to_string()) {
+                                continue;
+                            }
                             let mut summary = FunctionSecuritySummary::default();
                             check_fn_body(&f.block, &mut summary);
                             if summary.has_sensitive_action() && !summary.has_auth {
@@ -212,6 +222,7 @@ fn is_external_contract_method_call(method_call: &syn::ExprMethodCall) -> bool {
     }
 
     receiver_looks_like_external_client(&method_call.receiver)
+        && !method_looks_read_only(&method_call.method.to_string())
 }
 
 fn receiver_looks_like_external_client(expr: &syn::Expr) -> bool {
@@ -255,4 +266,11 @@ fn path_looks_like_client_constructor(path: &syn::Path) -> bool {
 fn ident_looks_like_client(ident: &str) -> bool {
     let lower = ident.to_lowercase();
     lower.ends_with("client") || lower.ends_with("_client")
+}
+
+fn method_looks_read_only(method_name: &str) -> bool {
+    matches!(method_name, "balance" | "paused" | "allowance" | "decimals" | "name" | "symbol")
+        || method_name.starts_with("get_")
+        || method_name.starts_with("is_")
+        || method_name.starts_with("has_")
 }


### PR DESCRIPTION
## Description
Reduce auth-gap false positives on soroban-examples by skipping Soroban reserved entrypoints and read-only external client calls, while keeping unauthenticated mutating entrypoints flagged.

Fixes #347

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] `cargo test -p sanctifier-core --no-default-features scan_auth_gaps -- --nocapture`
- [x] Reproduced the listed soroban-examples crates with a temporary local harness against `/tmp/soroban-examples-sanctifier-347`
- [x] Confirmed the remaining findings after the fix are limited to mutating entrypoints: custom_types::increment, increment_with_pause::increment, merkle_distribution::claim, pause::set, ttl::setup

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
