### PR TITLE
fix(frontend): show finding codes

### DIFF
--- a/frontend/app/components/FindingsList.stories.tsx
+++ b/frontend/app/components/FindingsList.stories.tsx
@@ -29,6 +29,7 @@ type Story = StoryObj<typeof FindingsList>;
 const sampleFindings: Finding[] = [
   {
     id: "1",
+    code: "S003",
     severity: "critical",
     category: "Arithmetic",
     title: "Unchecked multiplication may overflow",
@@ -40,6 +41,7 @@ const sampleFindings: Finding[] = [
   },
   {
     id: "2",
+    code: "S001",
     severity: "high",
     category: "Auth Gap",
     title: "Missing authorization check on withdraw()",
@@ -49,6 +51,7 @@ const sampleFindings: Finding[] = [
   },
   {
     id: "3",
+    code: "S002",
     severity: "medium",
     category: "Panic",
     title: "Unwrap on user-supplied input",
@@ -60,6 +63,7 @@ const sampleFindings: Finding[] = [
   },
   {
     id: "4",
+    code: "S005",
     severity: "low",
     category: "Ledger Size",
     title: "Storage struct approaching size limit",

--- a/frontend/app/components/FindingsList.tsx
+++ b/frontend/app/components/FindingsList.tsx
@@ -51,12 +51,17 @@ export function FindingsList({ findings, severityFilter }: FindingsListProps) {
                   <p className="mt-2 text-sm italic">💡 {f.suggestion}</p>
                 )}
               </div>
-<span
-              className={`shrink-0 rounded px-2 py-1 text-xs font-medium border ${severityColors[f.severity]}`}
-              aria-label={severityLabels[f.severity]}
-            >
-              {f.severity}
-            </span>
+              <div className="shrink-0 flex items-center gap-2">
+                <span
+                  className={`rounded px-2 py-1 text-xs font-medium border ${severityColors[f.severity]}`}
+                  aria-label={severityLabels[f.severity]}
+                >
+                  {f.severity}
+                </span>
+                <span className="font-mono text-xs rounded border border-zinc-300/70 dark:border-zinc-600 px-2 py-1 text-zinc-700 dark:text-zinc-300 theme-high-contrast:border-white theme-high-contrast:text-white">
+                  {f.code}
+                </span>
+              </div>
             </div>
             {f.snippet && (
               <div className="mt-3">

--- a/frontend/app/components/SanctityScore.stories.tsx
+++ b/frontend/app/components/SanctityScore.stories.tsx
@@ -26,6 +26,7 @@ function makeFinding(
 ): Finding[] {
   return Array.from({ length: n }, (_, i) => ({
     id: `${severity}-${i}`,
+    code: `TEST_${severity.toUpperCase()}_${i + 1}`,
     severity,
     category: "test",
     title: `${severity} finding ${i + 1}`,

--- a/frontend/app/components/SummaryChart.stories.tsx
+++ b/frontend/app/components/SummaryChart.stories.tsx
@@ -26,6 +26,7 @@ function makeFinding(
 ): Finding[] {
   return Array.from({ length: n }, (_, i) => ({
     id: `${severity}-${i}`,
+    code: `TEST_${severity.toUpperCase()}_${i + 1}`,
     severity,
     category: "test",
     title: `${severity} finding`,

--- a/frontend/app/lib/transform.ts
+++ b/frontend/app/lib/transform.ts
@@ -11,16 +11,35 @@ function arrayValue<T>(value: unknown): T[] {
 export function normalizeReport(input: unknown): AnalysisReport {
   const parsed = isRecord(input) ? input : {};
   const findings = isRecord(parsed.findings) ? parsed.findings : parsed;
-  const authGaps = arrayValue<string | { function?: string }>(findings.auth_gaps).flatMap((gap) => {
+  const authGaps: AnalysisReport["auth_gaps"] = [];
+
+  arrayValue<string | { function?: string; function_name?: string; code?: string }>(
+    findings.auth_gaps
+  ).forEach((gap) => {
     if (typeof gap === "string") {
-      return [gap];
+      authGaps.push(gap);
+      return;
     }
 
-    if (isRecord(gap) && typeof gap.function === "string") {
-      return [gap.function];
+    if (!isRecord(gap)) {
+      return;
     }
 
-    return [];
+    const fnName =
+      typeof gap.function_name === "string"
+        ? gap.function_name
+        : typeof gap.function === "string"
+          ? gap.function
+          : null;
+
+    if (!fnName) {
+      return;
+    }
+
+    authGaps.push({
+      function_name: fnName,
+      code: typeof gap.code === "string" ? gap.code : "AUTH_GAP",
+    });
   });
 
   return {
@@ -37,6 +56,7 @@ export function normalizeReport(input: unknown): AnalysisReport {
 
 function toFinding(
   id: string,
+  code: string,
   severity: Severity,
   category: string,
   title: string,
@@ -46,6 +66,7 @@ function toFinding(
 ): Finding {
   return {
     id,
+    code,
     severity,
     category,
     title,
@@ -60,14 +81,18 @@ export function transformReport(report: AnalysisReport): Finding[] {
   let idx = 0;
 
   (report.auth_gaps ?? []).forEach((g) => {
+    const location = typeof g === "string" ? g : g.function_name;
+    const code = typeof g === "string" ? "AUTH_GAP" : g.code;
     findings.push(
       toFinding(
         `auth-${idx++}`,
+        code,
         "critical",
         "Auth Gap",
         "Modifying state without require_auth()",
+        location,
         g,
-        { snippet: g }
+        { snippet: location }
       )
     );
   });
@@ -77,6 +102,7 @@ export function transformReport(report: AnalysisReport): Finding[] {
     findings.push(
       toFinding(
         `panic-${idx++}`,
+        p.code,
         severity,
         "Panic/Unwrap",
         `Using ${p.issue_type}`,
@@ -91,6 +117,7 @@ export function transformReport(report: AnalysisReport): Finding[] {
     findings.push(
       toFinding(
         `arith-${idx++}`,
+        a.code,
         "high",
         "Arithmetic",
         `Unchecked ${a.operation}`,
@@ -106,6 +133,7 @@ export function transformReport(report: AnalysisReport): Finding[] {
     findings.push(
       toFinding(
         `size-${idx++}`,
+        w.code ?? "LEDGER_SIZE_RISK",
         severity,
         "Ledger Size",
         `Struct ${w.struct_name} ${w.level === "ExceedsLimit" ? "exceeds" : "approaching"} limit`,
@@ -120,6 +148,7 @@ export function transformReport(report: AnalysisReport): Finding[] {
     findings.push(
       toFinding(
         `unsafe-${idx++}`,
+        u.code ?? "UNSAFE_PATTERN",
         "medium",
         "Unsafe Pattern",
         u.pattern_type,
@@ -134,6 +163,7 @@ export function transformReport(report: AnalysisReport): Finding[] {
     findings.push(
       toFinding(
         `custom-${idx++}`,
+        m.code ?? "CUSTOM_RULE",
         "low",
         "Custom Rule",
         m.rule_name,
@@ -157,8 +187,9 @@ export function extractCallGraph(
   (report.auth_gaps ?? []).forEach((gap) => {
     // Auth gaps are strings like "file.rs:function_name" indicating functions
     // that mutate storage without authentication
-    const parts = gap.split(":");
-    const funcName = parts.length > 1 ? parts[parts.length - 1].trim() : gap;
+    const location = typeof gap === "string" ? gap : gap.function_name;
+    const parts = location.split(":");
+    const funcName = parts.length > 1 ? parts[parts.length - 1].trim() : location;
     const file = parts.length > 1 ? parts.slice(0, -1).join(":").trim() : undefined;
     const funcId = `fn-${funcName}`;
 

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -1,6 +1,7 @@
 export type Severity = "critical" | "high" | "medium" | "low";
 
 export interface SizeWarning {
+  code?: string;
   struct_name: string;
   estimated_size: number;
   limit: number;
@@ -8,18 +9,21 @@ export interface SizeWarning {
 }
 
 export interface PanicIssue {
+  code: string;
   function_name: string;
   issue_type: string;
   location: string;
 }
 
 export interface UnsafePattern {
+  code?: string;
   pattern_type: "Panic" | "Unwrap" | "Expect";
   line: number;
   snippet: string;
 }
 
 export interface ArithmeticIssue {
+  code: string;
   function_name: string;
   operation: string;
   suggestion: string;
@@ -27,6 +31,7 @@ export interface ArithmeticIssue {
 }
 
 export interface CustomRuleMatch {
+  code?: string;
   rule_name: string;
   line: number;
   snippet: string;
@@ -35,7 +40,7 @@ export interface CustomRuleMatch {
 export interface AnalysisReport {
   size_warnings?: SizeWarning[];
   unsafe_patterns?: UnsafePattern[];
-  auth_gaps?: string[];
+  auth_gaps?: Array<string | { code: string; function_name: string }>;
   panic_issues?: PanicIssue[];
   arithmetic_issues?: ArithmeticIssue[];
   custom_rule_matches?: CustomRuleMatch[];
@@ -43,6 +48,7 @@ export interface AnalysisReport {
 
 export interface Finding {
   id: string;
+  code: string;
   severity: Severity;
   category: string;
   title: string;


### PR DESCRIPTION
## Description
This adds finding codes to the frontend analysis model and surfaces them in `FindingsList` as a dedicated badge. It also keeps the dashboard compatible with the coded `auth_gaps` payload shape and updates the related stories so the UI examples match the live data.

Fixes #290

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `cd frontend && npx eslint app/components/FindingsList.tsx app/components/FindingsList.stories.tsx app/components/SanctityScore.stories.tsx app/components/SummaryChart.stories.tsx app/lib/transform.ts app/types.ts`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm run build-storybook`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
