### PR TITLE
feat: ship Sanctifier action, CI clippy coverage, and analyze API workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,11 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
-      - name: Run Clippy
-        run: |
-          cargo clippy -p sanctifier-core --all-targets --all-features -- -D warnings
-          cd tooling/sanctifier-cli && cargo clippy --all-targets -- -D warnings
+      - name: Run Clippy (workspace)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Run Clippy (runtime guard wasm target)
+        run: cargo clippy -p runtime-guard-wrapper --target wasm32-unknown-unknown -- -D warnings
 
       - name: Build All (Debug)
         run: |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and optionally proves invariants with Z3.
 - [CLI Reference](#-cli-reference)
 - [Example JSON Output](#-example-json-output)
 - [JSON Schema](#-json-schema)
+- [GitHub Action](#-github-action)
 - [Project Structure](#-project-structure)
 - [Configuration](#-configuration)
 - [Add a Sanctifier Badge to Your Project](#-add-a-sanctifier-badge-to-your-project)
@@ -353,6 +354,44 @@ Downstream tools (dashboards, IDE plugins, CI integrations) can use the schema t
 The `schema_version` field in every report (e.g. `"1.0.0"`) is bumped independently
 of the Sanctifier tool version whenever the output shape changes, so consumers can
 guard on it without coupling to the CLI release cycle.
+
+---
+
+## 🤖 GitHub Action
+
+Sanctifier ships a composite GitHub Action (`action.yml`) so CI consumers can
+integrate with a few lines.
+
+```yaml
+name: Sanctifier Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Sanctifier
+        uses: HyperSafeD/Sanctifier@main
+        with:
+          path: .
+          format: sarif
+          min-severity: high
+          upload-sarif: "true"
+          sarif-output: sanctifier-results.sarif
+```
+
+When `format: sarif` and `upload-sarif: "true"`, the action uploads the SARIF
+file via `github/codeql-action/upload-sarif@v3` so findings appear in GitHub
+code scanning.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,71 @@
+name: Sanctifier Security Analysis
+description: Scan Soroban contracts for vulnerabilities
+author: HyperSafeD
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  path:
+    description: Contract path to analyze
+    required: false
+    default: "."
+  min-severity:
+    description: Minimum severity to report (critical|high|medium|low)
+    required: false
+    default: high
+  format:
+    description: Output format (text|json|sarif)
+    required: false
+    default: sarif
+  upload-sarif:
+    description: Upload SARIF to GitHub code scanning when format is sarif
+    required: false
+    default: "true"
+  sarif-output:
+    description: Path for generated SARIF report
+    required: false
+    default: sanctifier-results.sarif
+
+outputs:
+  findings-count:
+    description: Total number of findings
+    value: ${{ steps.summarize.outputs.findings-count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Sanctifier CLI
+      shell: bash
+      run: cargo install sanctifier-cli --locked
+
+    - name: Analyze project
+      shell: bash
+      run: |
+        if [ "${{ inputs.format }}" = "sarif" ]; then
+          sanctifier analyze "${{ inputs.path }}" \
+            --format sarif \
+            --min-severity "${{ inputs.min-severity }}" \
+            --exit-code > "${{ inputs.sarif-output }}"
+        else
+          sanctifier analyze "${{ inputs.path }}" \
+            --format "${{ inputs.format }}" \
+            --min-severity "${{ inputs.min-severity }}" \
+            --exit-code
+        fi
+
+    - name: Summarize findings
+      id: summarize
+      shell: bash
+      run: |
+        findings_count=0
+        if [ "${{ inputs.format }}" = "json" ]; then
+          findings_count=$(sanctifier analyze "${{ inputs.path }}" --format json | jq -r '.summary.total_findings // 0')
+        fi
+        echo "findings-count=${findings_count}" >> "$GITHUB_OUTPUT"
+
+    - name: Upload SARIF
+      if: ${{ inputs.format == 'sarif' && inputs.upload-sarif == 'true' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.sarif-output }}

--- a/frontend/app/api/analyze/route.ts
+++ b/frontend/app/api/analyze/route.ts
@@ -3,6 +3,8 @@ import { spawn } from "child_process";
 import path from "path";
 import os from "os";
 import { mkdtemp, rm, writeFile } from "fs/promises";
+import { normalizeReport, transformReport } from "../../lib/transform";
+import type { Finding } from "../../types";
 
 export const runtime = "nodejs";
 
@@ -11,6 +13,7 @@ const SUPPORTED_SOURCE_EXTENSIONS = new Set([".rs"]);
 const MAX_FILE_SIZE_BYTES = 250 * 1024;
 const EXECUTION_TIMEOUT_MS = 30000;
 const RATE_LIMIT_REQUESTS_PER_MINUTE = 10;
+const SANCTIFIER_BIN = process.env.SANCTIFIER_BIN?.trim() || "sanctifier";
 
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
 
@@ -59,12 +62,16 @@ type ProcessResult = {
   exitCode: number | null;
 };
 
-function runAnalyzeCommand(args: string[], timeoutMs: number): Promise<ProcessResult> {
+function runAnalyzeCommand(contractPath: string, timeoutMs: number): Promise<ProcessResult> {
   return new Promise((resolve, reject) => {
-    const cliProcess = spawn("cargo", args, {
+    const cliProcess = spawn(
+      SANCTIFIER_BIN,
+      ["analyze", "--format", "json", contractPath],
+      {
       cwd: REPO_ROOT,
       env: { ...process.env, FORCE_COLOR: "0" },
-    });
+      }
+    );
     let stdout = "";
     let stderr = "";
     let timeoutId: NodeJS.Timeout | null = null;
@@ -108,6 +115,39 @@ function runAnalyzeCommand(args: string[], timeoutMs: number): Promise<ProcessRe
         reject(err);
       }
     });
+  });
+}
+
+function looksLikeSorobanContract(source: string): boolean {
+  return source.includes("soroban_sdk") || source.includes("soroban-sdk");
+}
+
+function parseMultipartSource(formData: FormData): Promise<{ fileName: string; source: string } | null> {
+  const contract = formData.get("contract");
+
+  if (!(contract instanceof File)) {
+    return Promise.resolve(null);
+  }
+
+  if (contract.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error(`PAYLOAD_TOO_LARGE:${MAX_FILE_SIZE_BYTES}`);
+  }
+
+  const extension = path.extname(contract.name).toLowerCase();
+  if (!SUPPORTED_SOURCE_EXTENSIONS.has(extension)) {
+    throw new Error("UNSUPPORTED_EXTENSION");
+  }
+
+  return contract.arrayBuffer().then((buffer) => {
+    const fileBuffer = Buffer.from(buffer);
+    if (!isValidUtf8(fileBuffer)) {
+      throw new Error("INVALID_UTF8");
+    }
+
+    return {
+      fileName: sanitizeFileName(contract.name),
+      source: fileBuffer.toString("utf8"),
+    };
   });
 }
 
@@ -221,52 +261,60 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const formData = await request.formData();
-  const contract = formData.get("contract");
-
-  if (!(contract instanceof File)) {
-    return Response.json({ error: "Attach a Rust contract source file." }, { status: 400 });
-  }
-
-  if (contract.size > MAX_FILE_SIZE_BYTES) {
-    return Response.json(
-      { error: `File size exceeds limit of ${MAX_FILE_SIZE_BYTES / 1024} KB.` },
-      { status: 413 }
-    );
-  }
-
-  const extension = path.extname(contract.name).toLowerCase();
-  if (!SUPPORTED_SOURCE_EXTENSIONS.has(extension)) {
-    return Response.json(
-      { error: "Only .rs contract source files are supported right now." },
-      { status: 400 }
-    );
-  }
-
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "sanctifier-contract-"));
-  const fileName = sanitizeFileName(contract.name);
-  const contractPath = path.join(tempDir, fileName);
 
   try {
-    const fileBuffer = Buffer.from(await contract.arrayBuffer());
-    
-    if (!isValidUtf8(fileBuffer)) {
+    const contentType = request.headers.get("content-type") ?? "";
+
+    let sourcePayload: { fileName: string; source: string } | null = null;
+    if (contentType.includes("application/json")) {
+      const body = await request.json().catch(() => null);
+      const source =
+        body && typeof body === "object" && "source" in body && typeof body.source === "string"
+          ? body.source
+          : null;
+
+      if (!source || !source.trim()) {
+        return Response.json({ error: "Provide JSON body as { source: string }." }, { status: 400 });
+      }
+
+      if (Buffer.byteLength(source, "utf8") > MAX_FILE_SIZE_BYTES) {
+        return Response.json(
+          { error: `Source exceeds limit of ${MAX_FILE_SIZE_BYTES / 1024} KB.` },
+          { status: 413 }
+        );
+      }
+
+      sourcePayload = { fileName: "contract.rs", source };
+    } else if (contentType.includes("multipart/form-data")) {
+      const formData = await request.formData();
+      sourcePayload = await parseMultipartSource(formData);
+      if (!sourcePayload) {
+        return Response.json({ error: "Attach a Rust .rs file in `contract` field." }, { status: 400 });
+      }
+    } else {
       return Response.json(
-        { error: "File content is not valid UTF-8." },
+        { error: "Content-Type must be multipart/form-data or application/json." },
         { status: 400 }
       );
     }
-    
-    await writeFile(contractPath, fileBuffer);
 
-    const { stdout, stderr, exitCode } = await runAnalyzeCommand(
-      ["run", "--quiet", "--bin", "sanctifier", "--", "analyze", contractPath, "--format", "json"],
-      EXECUTION_TIMEOUT_MS
-    );
+    if (!looksLikeSorobanContract(sourcePayload.source)) {
+      return Response.json(
+        { error: "Source is not a Soroban contract (missing soroban-sdk import)." },
+        { status: 422 }
+      );
+    }
+
+    const contractPath = path.join(tempDir, sourcePayload.fileName);
+    await writeFile(contractPath, sourcePayload.source, "utf8");
+
+    const { stdout, stderr, exitCode } = await runAnalyzeCommand(contractPath, EXECUTION_TIMEOUT_MS);
     const report = parseJsonResponse(stdout);
 
     if (report) {
-      return Response.json(report);
+      const findings: Finding[] = transformReport(normalizeReport(report));
+      return Response.json(findings);
     }
 
     return Response.json(
@@ -279,6 +327,21 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   } catch (error) {
+    if (error instanceof Error && error.message.startsWith("PAYLOAD_TOO_LARGE:")) {
+      return Response.json(
+        { error: `File size exceeds limit of ${MAX_FILE_SIZE_BYTES / 1024} KB.` },
+        { status: 413 }
+      );
+    }
+    if (error instanceof Error && error.message === "UNSUPPORTED_EXTENSION") {
+      return Response.json(
+        { error: "Only .rs contract source files are supported right now." },
+        { status: 400 }
+      );
+    }
+    if (error instanceof Error && error.message === "INVALID_UTF8") {
+      return Response.json({ error: "File content is not valid UTF-8." }, { status: 400 });
+    }
     if (error instanceof Error && error.message.includes("timed out")) {
       return Response.json(
         { error: "Analysis timed out. Please try with a smaller contract." },


### PR DESCRIPTION
## Summary
- extend CI Clippy coverage to run across the full workspace and add explicit wasm-target Clippy for `runtime-guard-wrapper`
- add a root `action.yml` composite GitHub Action for Sanctifier with SARIF upload support and documented usage in the root README
- update `frontend/app/api/analyze/route.ts` to support multipart or JSON source input, enforce Soroban source validation, support `SANCTIFIER_BIN`, and return `Finding[]`-shaped responses

Closes #283
Closes #312
Closes #277
Closes #288