### PR TITLE
Implement storage collision CLI command

### DIFF
--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -3,5 +3,6 @@ pub mod badge;
 pub mod complexity;
 pub mod init;
 pub mod report;
+pub mod storage;
 pub mod update;
 pub mod webhook;

--- a/tooling/sanctifier-cli/src/commands/storage.rs
+++ b/tooling/sanctifier-cli/src/commands/storage.rs
@@ -1,0 +1,200 @@
+use anyhow::{anyhow, Context};
+use clap::{Args, ValueEnum};
+use sanctifier_core::{Analyzer, SanctifyConfig, StorageCollisionIssue};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Args, Debug)]
+pub struct StorageArgs {
+    /// Path to a Rust source file, Cargo.toml, or contract directory
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+pub fn exec(args: StorageArgs) -> anyhow::Result<()> {
+    let scan_root = normalize_scan_path(&args.path)?;
+    let config = load_config(&scan_root)?;
+    let analyzer = Analyzer::new(config.clone());
+
+    let mut rust_files = collect_rust_files(&scan_root, &config.ignore_paths);
+    rust_files.sort();
+
+    if rust_files.is_empty() {
+        return Err(anyhow!(
+            "no Rust source files found under {}",
+            scan_root.display()
+        ));
+    }
+
+    let mut collisions = Vec::new();
+    for file_path in rust_files {
+        let source = fs::read_to_string(&file_path)
+            .with_context(|| format!("failed to read {}", file_path.display()))?;
+        let file_label = file_path.display().to_string();
+
+        for mut collision in analyzer.scan_storage_collisions(&source) {
+            collision.location = qualify_location(&file_label, &collision.location);
+            collisions.push(collision);
+        }
+    }
+
+    collisions.sort_by(|left, right| {
+        left.location
+            .cmp(&right.location)
+            .then_with(|| left.key_value.cmp(&right.key_value))
+            .then_with(|| left.key_type.cmp(&right.key_type))
+    });
+
+    match args.format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&collisions)?);
+        }
+        OutputFormat::Text => print_text_report(&collisions),
+    }
+
+    Ok(())
+}
+
+fn print_text_report(collisions: &[StorageCollisionIssue]) {
+    if collisions.is_empty() {
+        println!("No storage key collisions found.");
+        return;
+    }
+
+    println!("Found {} storage key collision(s):", collisions.len());
+    for collision in collisions {
+        println!(
+            "- {} [{}] at {}",
+            collision.key_value, collision.key_type, collision.location
+        );
+        println!("  {}", collision.message);
+    }
+}
+
+fn normalize_scan_path(path: &Path) -> anyhow::Result<PathBuf> {
+    if path.is_dir() {
+        return Ok(path.to_path_buf());
+    }
+
+    if path.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml") {
+        return path
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| anyhow!("{} has no parent directory", path.display()));
+    }
+
+    if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+        return Ok(path.to_path_buf());
+    }
+
+    Err(anyhow!(
+        "expected a Rust source file, Cargo.toml, or directory, got {}",
+        path.display()
+    ))
+}
+
+fn qualify_location(file_label: &str, location: &str) -> String {
+    if let Some((_, line)) = location.rsplit_once(':') {
+        if line.parse::<usize>().is_ok() {
+            return format!("{}:{}", file_label, line);
+        }
+    }
+
+    format!("{}:{}", file_label, location)
+}
+
+fn collect_rust_files(path: &Path, ignore_paths: &[String]) -> Vec<PathBuf> {
+    if path.is_file() {
+        return vec![path.to_path_buf()];
+    }
+
+    let mut files = Vec::new();
+    collect_rust_files_rec(path, ignore_paths, &mut files);
+    files
+}
+
+fn collect_rust_files_rec(dir: &Path, ignore_paths: &[String], out: &mut Vec<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("");
+
+        if path.is_dir() {
+            if ignore_paths.iter().any(|ignored| name.contains(ignored)) {
+                continue;
+            }
+            collect_rust_files_rec(&path, ignore_paths, out);
+            continue;
+        }
+
+        if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn load_config(path: &Path) -> anyhow::Result<SanctifyConfig> {
+    let mut current = if path.is_file() {
+        path.parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))
+    } else {
+        path.to_path_buf()
+    };
+
+    loop {
+        let config_path = current.join(".sanctify.toml");
+        if config_path.exists() {
+            let content = fs::read_to_string(&config_path)
+                .with_context(|| format!("failed to read {}", config_path.display()))?;
+            let config = toml::from_str(&content)
+                .map_err(|error| anyhow!("failed to parse {}: {}", config_path.display(), error))?;
+            return Ok(config);
+        }
+
+        if !current.pop() {
+            break;
+        }
+    }
+
+    Ok(SanctifyConfig::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qualify_location_prefers_file_and_line() {
+        assert_eq!(
+            qualify_location("contracts/sample.rs", "storage-op:42"),
+            "contracts/sample.rs:42"
+        );
+    }
+
+    #[test]
+    fn normalize_scan_path_accepts_cargo_toml() {
+        let path = PathBuf::from("/tmp/demo/Cargo.toml");
+        assert_eq!(
+            normalize_scan_path(&path).unwrap(),
+            PathBuf::from("/tmp/demo")
+        );
+    }
+}

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -27,6 +27,8 @@ pub enum Commands {
     Badge(commands::badge::BadgeArgs),
     /// Generate a Markdown or HTML security report
     Report(commands::report::ReportArgs),
+    /// Detect potential storage key collisions in Soroban contracts
+    Storage(commands::storage::StorageArgs),
     /// Initialize Sanctifier in a new project
     Init(commands::init::InitArgs),
     /// Show per-contract complexity metrics (cyclomatic complexity, nesting, LOC)
@@ -56,6 +58,9 @@ fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let log_output = match &cli.command {
         Commands::Analyze(args) if args.format == "json" => logging::LogOutput::Json,
+        Commands::Storage(args) if args.format == commands::storage::OutputFormat::Json => {
+            logging::LogOutput::Json
+        }
         _ => logging::LogOutput::Text,
     };
     logging::init(log_output)?;
@@ -70,6 +75,9 @@ fn run() -> anyhow::Result<()> {
         }
         Commands::Report(args) => {
             commands::report::exec(args)?;
+        }
+        Commands::Storage(args) => {
+            commands::storage::exec(args)?;
         }
         Commands::Init(args) => {
             let path = Some(args.path.clone());

--- a/tooling/sanctifier-cli/tests/cli_tests.rs
+++ b/tooling/sanctifier-cli/tests/cli_tests.rs
@@ -2,6 +2,7 @@
 use assert_cmd::Command;
 use jsonschema::JSONSchema;
 use mockito::Server;
+use serde_json::Value;
 use std::env;
 use std::fs;
 use tempfile::tempdir;
@@ -122,6 +123,167 @@ fn test_analyze_json_logs_do_not_pollute_stdout() {
         .success()
         .stdout(predicates::str::starts_with("{"))
         .stderr(predicates::str::contains("\"level\":\"DEBUG\""));
+}
+
+#[test]
+fn test_storage_text_output_lists_collisions_with_file_and_line() {
+    let temp_dir = tempdir().unwrap();
+    let contract_path = temp_dir.path().join("storage_contract.rs");
+
+    fs::write(
+        &contract_path,
+        r#"
+            use soroban_sdk::{contractimpl, Env};
+
+            #[contractimpl]
+            impl DemoContract {
+                pub fn write_a(env: Env) {
+                    env.storage().persistent().set(&"USER", &1u32);
+                }
+
+                pub fn write_b(env: Env) {
+                    env.storage().persistent().set(&"USER", &2u32);
+                }
+            }
+        "#,
+    )
+    .unwrap();
+
+    let expected_path = contract_path.display().to_string();
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("storage")
+        .arg(&contract_path)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "Found 2 storage key collision(s):",
+        ))
+        .stdout(predicates::str::contains(
+            "USER [storage::set (persistent)]",
+        ))
+        .stdout(predicates::str::contains(expected_path))
+        .stdout(predicates::str::contains(
+            "persistent storage key collision",
+        ));
+}
+
+#[test]
+fn test_storage_json_output_matches_storage_collision_shape() {
+    let temp_dir = tempdir().unwrap();
+    let contract_path = temp_dir.path().join("storage_contract.rs");
+
+    fs::write(
+        &contract_path,
+        r#"
+            use soroban_sdk::{contractimpl, Env};
+
+            #[contractimpl]
+            impl DemoContract {
+                pub fn write_a(env: Env) {
+                    env.storage().persistent().set(&"USER", &1u32);
+                }
+
+                pub fn write_b(env: Env) {
+                    env.storage().persistent().set(&"USER", &2u32);
+                }
+            }
+        "#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("storage")
+        .arg(&contract_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: Value = serde_json::from_slice(&output).unwrap();
+    let collisions = json.as_array().unwrap();
+    assert_eq!(collisions.len(), 2);
+
+    for collision in collisions {
+        let object = collision.as_object().unwrap();
+        assert!(object.contains_key("key_value"));
+        assert!(object.contains_key("key_type"));
+        assert!(object.contains_key("location"));
+        assert!(object.contains_key("message"));
+    }
+
+    assert!(collisions[0]["location"]
+        .as_str()
+        .unwrap()
+        .contains(&contract_path.display().to_string()));
+}
+
+#[test]
+fn test_storage_directory_scan_aggregates_rust_files() {
+    let temp_dir = tempdir().unwrap();
+    let colliding = temp_dir.path().join("colliding.rs");
+    let clean = temp_dir.path().join("clean.rs");
+
+    fs::write(
+        &colliding,
+        r#"
+            use soroban_sdk::{contractimpl, Env};
+
+            #[contractimpl]
+            impl DemoContract {
+                pub fn write_a(env: Env) {
+                    env.storage().persistent().set(&"ORDER", &1u32);
+                }
+
+                pub fn write_b(env: Env) {
+                    env.storage().persistent().set(&"ORDER", &2u32);
+                }
+            }
+        "#,
+    )
+    .unwrap();
+
+    fs::write(
+        &clean,
+        r#"
+            use soroban_sdk::{contractimpl, Env};
+
+            #[contractimpl]
+            impl CleanContract {
+                pub fn write_once(env: Env) {
+                    env.storage().temporary().set(&"SESSION", &1u32);
+                }
+            }
+        "#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("storage")
+        .arg(temp_dir.path())
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: Value = serde_json::from_slice(&output).unwrap();
+    let collisions = json.as_array().unwrap();
+    assert_eq!(collisions.len(), 2);
+    assert!(collisions.iter().all(|collision| {
+        collision["location"]
+            .as_str()
+            .unwrap()
+            .contains(&colliding.display().to_string())
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement the storage CLI command for storage collision analysis
- run the existing scan_storage_collisions engine across a Rust file, Cargo.toml root, or directory tree
- normalize collision locations to include file and line information in both text and JSON output
- add three integration tests for text output, JSON output shape, and directory aggregation

## Testing
- cargo fmt --all --check
- cargo test -p sanctifier-cli storage --test cli_tests
- cargo test -p sanctifier-cli --no-default-features storage --test cli_tests

Closes #273