### PR TITLE
feat(dx): add Makefile with standard developer targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev pkg-config
 
+      - name: Lint (make lint smoke test)
+        run: make lint
+
       - name: Check formatting
         run: cargo fmt --all --check
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: build test lint fmt audit release clean docs
+
+## Build all workspace crates (debug).
+build:
+	cargo build --workspace
+
+## Run all workspace tests.
+test:
+	cargo test --workspace
+
+## Check formatting and run Clippy with -D warnings.
+lint:
+	cargo fmt --all --check
+	cargo clippy --workspace -- -D warnings
+
+## Auto-format all workspace source files.
+fmt:
+	cargo fmt --all
+
+## Run cargo-audit and cargo-deny supply-chain checks.
+audit:
+	cargo audit
+	cargo deny check
+
+## Build all workspace crates in release mode.
+release:
+	cargo build --workspace --release
+
+## Generate and open rustdoc for all workspace crates (no deps).
+docs:
+	cargo doc --workspace --no-deps --open
+
+## Remove all build artefacts.
+clean:
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ cargo install --path .
 
 ## 🚀 Quick Start
 
+### Developer commands
+
+Common workflows are wrapped in a root-level `Makefile`:
+
+```bash
+make build    # cargo build --workspace
+make test     # cargo test --workspace
+make lint     # cargo fmt --all --check && cargo clippy --workspace -- -D warnings
+make fmt      # cargo fmt --all
+make audit    # cargo audit && cargo deny check
+make release  # cargo build --workspace --release
+make docs     # cargo doc --workspace --no-deps --open
+make clean    # cargo clean
+```
+
+### Analyse a contract
+
 Analyse a Soroban contract in a single command:
 
 ```bash


### PR DESCRIPTION
Add a root Makefile with .PHONY targets: build, test, lint, fmt, audit, release, docs, clean — each wrapping the corresponding cargo command. Lint (fmt --check + clippy -D warnings) is added as a smoke- test step in CI. README Quick Start section updated to document all make targets.

Closes #324


