### PR TITLE
ci(action): versioned action tags + SLSA provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +61,11 @@ jobs:
       - name: Prepare binary for upload (Windows)
         if: runner.os == 'Windows'
         run: mv target/${{ matrix.target }}/release/sanctifier.exe ${{ matrix.artifact_name }}
+
+      - name: Generate build provenance (SLSA)
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ matrix.artifact_name }}
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,13 @@ inputs:
     description: Contract path to analyze
     required: false
     default: "."
+  version:
+    description: >-
+      sanctifier-cli version to install (e.g. 0.2.3). If omitted and the action
+      is used via a semver tag (e.g. HyperSafeD/Sanctifier@v0.2.3), the tag
+      version is used automatically.
+    required: false
+    default: ""
   min-severity:
     description: Minimum severity to report (critical|high|medium|low)
     required: false
@@ -37,7 +44,20 @@ runs:
   steps:
     - name: Install Sanctifier CLI
       shell: bash
-      run: cargo install sanctifier-cli --locked
+      run: |
+        python "${{ github.action_path }}/scripts/resolve_action_version.py" \
+          --action-ref "${{ github.action_ref }}" \
+          --requested "${{ inputs.version }}" \
+          --output "$RUNNER_TEMP/sanctifier_cli_version"
+
+        version="$(cat "$RUNNER_TEMP/sanctifier_cli_version" || true)"
+        if [ -n "$version" ]; then
+          echo "Installing sanctifier-cli==$version"
+          cargo install sanctifier-cli --locked --version "$version"
+        else
+          echo "Installing sanctifier-cli (latest)"
+          cargo install sanctifier-cli --locked
+        fi
 
     - name: Analyze project
       shell: bash

--- a/scripts/resolve_action_version.py
+++ b/scripts/resolve_action_version.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+
+_SEMVER_TAG_RE = re.compile(r"^v(?P<ver>\d+\.\d+\.\d+)$")
+
+
+def resolve_version(*, action_ref: str, requested: str) -> str:
+    """
+    Returns a crates.io version string (e.g. "0.2.3") or "" if we should install latest.
+    """
+    req = (requested or "").strip()
+    if req:
+        # Accept both "0.2.3" and "v0.2.3" for convenience.
+        if req.startswith("v"):
+            req = req[1:]
+        return req
+
+    ref = (action_ref or "").strip()
+    m = _SEMVER_TAG_RE.match(ref)
+    if m:
+        return m.group("ver")
+
+    return ""
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--action-ref", default="")
+    p.add_argument("--requested", default="")
+    p.add_argument("--output", required=True)
+    args = p.parse_args()
+
+    version = resolve_version(action_ref=args.action_ref, requested=args.requested)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/action/fixtures/version-cases.json
+++ b/tests/action/fixtures/version-cases.json
@@ -1,0 +1,10 @@
+[
+  { "action_ref": "v0.2.3", "requested": "", "expected": "0.2.3" },
+  { "action_ref": "main", "requested": "", "expected": "" },
+  { "action_ref": "8b7c1d3", "requested": "", "expected": "" },
+  { "action_ref": "v1", "requested": "", "expected": "" },
+  { "action_ref": "v0.2.3", "requested": "0.9.9", "expected": "0.9.9" },
+  { "action_ref": "v0.2.3", "requested": "v0.9.9", "expected": "0.9.9" },
+  { "action_ref": "", "requested": "  0.1.0  ", "expected": "0.1.0" }
+]
+

--- a/tests/action/test_resolve_action_version.py
+++ b/tests/action/test_resolve_action_version.py
@@ -1,0 +1,27 @@
+import json
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class ResolveActionVersionTests(unittest.TestCase):
+    def test_fixture_cases(self) -> None:
+        from scripts.resolve_action_version import resolve_version
+
+        cases_path = ROOT / "tests" / "action" / "fixtures" / "version-cases.json"
+        cases = json.loads(cases_path.read_text(encoding="utf-8"))
+
+        for case in cases:
+            with self.subTest(case=case):
+                got = resolve_version(
+                    action_ref=case["action_ref"],
+                    requested=case["requested"],
+                )
+                self.assertEqual(got, case["expected"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Ensure versioned Action tags (e.g. `HyperSafeD/Sanctifier@vX.Y.Z`) install the matching `sanctifier-cli` version by default.
- Add unit tests + fixtures for version-resolution logic.
- Emit SLSA build provenance for release binaries.

## Test plan
- `python3 -m unittest -q tests/action/test_resolve_action_version.py`

## Closes
- Closes #634
- Closes #635
- Closes #638 
- Closes #653 

