### PR TITLE
CI: add Playwright e2e and document artifact retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,46 @@ jobs:
           path: frontend/coverage/
           retention-days: 7
 
+  frontend-e2e:
+    name: Frontend E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build WASM stub
+        run: |
+          mkdir -p tooling/sanctifier-wasm/pkg
+          echo '{"name":"@sanctifier/wasm","version":"0.0.0","main":"index.js"}' > tooling/sanctifier-wasm/pkg/package.json
+          echo 'module.exports = {};' > tooling/sanctifier-wasm/pkg/index.js
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: cd frontend && npm run test:e2e
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 7
+
   commitlint:
     name: Lint Commit Messages
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: junit-test-results
           path: target/nextest/ci/junit.xml
+          retention-days: 7
 
       - name: Build release binary
         run: cargo build --release -p sanctifier-cli

--- a/.github/workflows/soroban-examples.yml
+++ b/.github/workflows/soroban-examples.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           name: soroban-examples-summary
           path: soroban-examples-summary.json
+          retention-days: 7

--- a/docs/ci-cd-setup.md
+++ b/docs/ci-cd-setup.md
@@ -9,6 +9,7 @@ The automation includes:
 - **GitHub Actions**: Automated deployment on push and schedule
 - **Continuous Validation**: Periodic health checks and metrics collection
 - **Artifact Management**: Deployment manifests and logs
+- **Frontend E2E (Playwright)**: Browser-level regression checks
 
 ## Prerequisites
 
@@ -171,6 +172,28 @@ The workflow file: `.github/workflows/soroban-deploy.yml`
 1. `build-and-deploy`: Build, deploy, validate
 2. `continuous-validation`: Run health checks
 3. `notification`: Generate reports
+
+### 4.4 Artifact retention strategy (why + where to change)
+
+Sanctifier uploads a few different artifact types and sets retention explicitly to keep CI predictable and costs bounded:
+
+- **Deployment artifacts** (`.github/workflows/soroban-deploy.yml`): `retention-days: 30`
+- **CI artifacts** (coverage, WASM pkg, Playwright reports, JUnit XML, etc.): `retention-days: 7`
+
+To change this, update the relevant `actions/upload-artifact@v4` steps and adjust the `retention-days` value(s).
+
+### 4.5 Frontend E2E in CI (Playwright)
+
+The frontend has Playwright E2E tests under `frontend/tests/e2e/` and a CI job in `.github/workflows/ci.yml`.
+
+Locally:
+
+```bash
+cd frontend
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
 
 ### 4.2 Workflow Permissions
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
-  reporter: "list",
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
   use: {
     baseURL: "http://127.0.0.1:3000",
     trace: "on-first-retry",


### PR DESCRIPTION
## Summary
- Add Playwright E2E coverage in CI and upload Playwright artifacts.
- Make artifact retention explicit across workflows (CI artifacts: 7 days; deployment artifacts already: 30 days).
- Document retention strategy and E2E setup for contributors.

## Test plan
- CI runs new **Frontend E2E Tests (Playwright)** job.
- Artifacts upload successfully and respect retention days.

Closes #630.
Closes #643. 
Closes #631.
Closes #636.