### PR TITLE
action.yml: harden workflow permissions + add support/threat model docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -12,6 +14,8 @@ jobs:
   publish:
     name: Publish crates on version tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
 jobs:
   build-and-release:
     name: Build and Release Binary

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -198,6 +198,10 @@ See: [QUICK_START.md - Verification](QUICK_START.md#-check-results-1-min)
 - Local Setup: [SOROBAN_DEPLOYMENT.md](SOROBAN_DEPLOYMENT.md#secret-management)
 - Best Practices: [SOROBAN_DEPLOYMENT.md - Security](SOROBAN_DEPLOYMENT.md#security-best-practices)
 
+**GitHub Action Hardening**
+- Support Matrix: [docs/github-action-support-matrix.md](docs/github-action-support-matrix.md)
+- Threat Model Notes: [docs/github-action-threat-model.md](docs/github-action-threat-model.md)
+
 **Production Setup**
 - Branch Protection: [docs/ci-cd-setup.md](docs/ci-cd-setup.md#branch-protection-recommended)
 - Network Security: [SOROBAN_DEPLOYMENT.md](SOROBAN_DEPLOYMENT.md#network-security)

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ on:
 
 permissions:
   contents: read
-  security-events: write
+  # Add `security-events: write` only if you enable SARIF upload.
 
 jobs:
   scan:
@@ -412,6 +412,16 @@ jobs:
 When `format: sarif` and `upload-sarif: "true"`, the action uploads the SARIF
 file via `github/codeql-action/upload-sarif@v3` so findings appear in GitHub
 code scanning.
+
+Permissions notes:
+
+- **Minimum (scan only)**: `contents: read`
+- **With SARIF upload enabled**: add `security-events: write`
+
+See also:
+
+- `docs/github-action-support-matrix.md`
+- `docs/github-action-threat-model.md`
 
 ---
 

--- a/docs/github-action-support-matrix.md
+++ b/docs/github-action-support-matrix.md
@@ -1,0 +1,37 @@
+# GitHub Action Support Matrix
+
+This document describes the supported environment for the composite GitHub Action in `action.yml`.
+
+## Supported runners
+
+- **ubuntu-latest**: supported
+- **macos-latest**: supported
+- **windows-latest**: supported (best-effort; ensure the CLI can be installed for your target environment)
+
+## Required tools on the runner
+
+The action installs the Sanctifier CLI via `cargo install`, so the runner needs:
+
+- **Rust toolchain** (via `rustup` / `cargo` in PATH)
+- **Network access** to download Rust crates
+
+If you use Sanctifier’s formal-verification features, your project may also require:
+
+- **Z3** headers/libraries (platform-specific)
+
+## GitHub token permissions
+
+The action itself does not require elevated permissions to *run* a scan.
+
+- **Minimum** (scan only): `contents: read`
+- **SARIF upload enabled** (`format: sarif` + `upload-sarif: "true"`): `security-events: write`
+
+Notes:
+
+- The action intentionally skips SARIF upload on `pull_request` events originating from forks.
+- If you disable SARIF upload (`upload-sarif: "false"`), you should omit `security-events: write`.
+
+## Inputs stability
+
+The action inputs/outputs in `action.yml` are intended to remain stable across patch releases.
+If an input/output needs to change incompatibly, the change should be documented and released with an appropriate version bump.

--- a/docs/github-action-threat-model.md
+++ b/docs/github-action-threat-model.md
@@ -1,0 +1,50 @@
+# GitHub Action Threat Model Notes
+
+This document captures a lightweight threat model for the composite GitHub Action (`action.yml`) to help contributors and users reason about security boundaries and permissions.
+
+## Assets
+
+- **Repository contents**: source code and configuration being scanned.
+- **`GITHUB_TOKEN`**: ephemeral token used by workflows; scope depends on workflow `permissions`.
+- **Code scanning results** (SARIF): uploaded to GitHub when enabled.
+
+## Trust boundaries
+
+- **Action code**: runs on GitHub-hosted runners, executes shell commands, and installs the CLI via Cargo.
+- **Network**: the action fetches dependencies when installing the CLI (Cargo registry and git dependencies).
+- **Fork pull requests**: are treated as untrusted by default; SARIF upload is skipped for fork PRs.
+
+## Threats & mitigations
+
+### Excessive token permissions
+
+**Threat**: broad workflow permissions increase blast radius if a dependency or step is compromised.
+
+**Mitigation**: use the principle of least privilege in workflow `permissions`:
+
+- `contents: read` for scanning
+- add `security-events: write` **only** when SARIF upload is enabled
+
+### Supply chain risk (CLI installation)
+
+**Threat**: installing via `cargo install` downloads dependencies at runtime.
+
+**Mitigations**:
+
+- Prefer pinning a released action version tag (e.g. `HyperSafeD/Sanctifier@vX.Y.Z`) and, optionally, `with: version: X.Y.Z`.
+- Keep SARIF upload disabled on untrusted events (fork PRs are already handled).
+
+### Data exfiltration via logs/artifacts
+
+**Threat**: secrets or sensitive data could be printed to logs or written into artifacts/SARIF.
+
+**Mitigations**:
+
+- Do not pass secrets to the action inputs.
+- Keep CI logs reviewed and avoid printing environment variables.
+- Only upload SARIF when you intend to publish findings to the repository’s code scanning UI.
+
+## Non-goals
+
+- This document does not attempt to fully model GitHub-hosted runner isolation or GitHub’s internal security posture.
+- This document does not guarantee vulnerability absence; it documents expected boundaries and safe defaults.


### PR DESCRIPTION
## Summary
- Minimize GitHub Actions permissions for release/publish workflows by setting workflow-level `permissions: {}` and scoping required permissions to the specific jobs.
- Document least-privilege permissions for the Sanctifier composite action (only require `security-events: write` when SARIF upload is enabled).
- Add GitHub Action support matrix + lightweight threat model notes, linked from the documentation index.

## Changes
- `.github/workflows/release.yml`: workflow permissions hardened; job permissions remain minimal and explicit.
- `.github/workflows/publish.yml`: workflow permissions hardened; publish job now uses `contents: read`.
- `README.md`: clarify minimal permissions and when to enable `security-events: write`.
- `docs/github-action-support-matrix.md`: new.
- `docs/github-action-threat-model.md`: new.
- `DOCUMENTATION_INDEX.md`: link new docs.

## Test plan
- [ ] CI runs on PR
- [ ] Verify release workflow still has required permissions for provenance + release creation
- [ ] Verify publish workflow can still `checkout` and `cargo publish`

Closes #642
Closes #632
closes #645
Closes #656