### PR TITLE
fix: harden action tests and vulnerability validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
           cargo test -p sanctifier-core --all-features
           cargo test -p sanctifier-cli
 
+      - name: Run action unit tests
+        run: |
+          python -m unittest discover -s tests/action -p "test_*.py"
+          python -m unittest discover -s tests/vulnerability_db -p "test_*.py"
+
       - name: Code coverage (Linux only)
         if: runner.os == 'Linux'
         run: |

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -201,6 +201,8 @@ See: [QUICK_START.md - Verification](QUICK_START.md#-check-results-1-min)
 **GitHub Action Hardening**
 - Support Matrix: [docs/github-action-support-matrix.md](docs/github-action-support-matrix.md)
 - Threat Model Notes: [docs/github-action-threat-model.md](docs/github-action-threat-model.md)
+- Action unit test fixtures: [tests/action/fixtures](tests/action/fixtures)
+- Vulnerability DB format and validation: [docs/vulnerability-database-format.md](docs/vulnerability-database-format.md)
 
 **Production Setup**
 - Branch Protection: [docs/ci-cd-setup.md](docs/ci-cd-setup.md#branch-protection-recommended)

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   min-severity:
-    description: Minimum severity to report (critical|high|medium|low)
+    description: Minimum severity to report (critical|high|medium|low|info)
     required: false
     default: high
   format:
@@ -42,6 +42,18 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate action inputs
+      shell: bash
+      run: |
+        python "${{ github.action_path }}/scripts/action_inputs.py" \
+          --path "${{ inputs.path }}" \
+          --min-severity "${{ inputs.min-severity }}" \
+          --format "${{ inputs.format }}" \
+          --upload-sarif "${{ inputs.upload-sarif }}" \
+          --sarif-output "${{ inputs.sarif-output }}" \
+          --output "$RUNNER_TEMP/sanctifier_action_inputs"
+        cat "$RUNNER_TEMP/sanctifier_action_inputs" >> "$GITHUB_ENV"
+
     - name: Install Sanctifier CLI
       shell: bash
       run: |
@@ -62,15 +74,16 @@ runs:
     - name: Analyze project
       shell: bash
       run: |
-        if [ "${{ inputs.format }}" = "sarif" ]; then
-          sanctifier analyze "${{ inputs.path }}" \
+        if [ "$SANCTIFIER_ACTION_FORMAT" = "sarif" ]; then
+          mkdir -p "$(dirname "$SANCTIFIER_ACTION_SARIF_OUTPUT")"
+          sanctifier analyze "$SANCTIFIER_ACTION_PATH" \
             --format sarif \
-            --min-severity "${{ inputs.min-severity }}" \
-            --exit-code > "${{ inputs.sarif-output }}"
+            --min-severity "$SANCTIFIER_ACTION_MIN_SEVERITY" \
+            --exit-code > "$SANCTIFIER_ACTION_SARIF_OUTPUT"
         else
-          sanctifier analyze "${{ inputs.path }}" \
-            --format "${{ inputs.format }}" \
-            --min-severity "${{ inputs.min-severity }}" \
+          sanctifier analyze "$SANCTIFIER_ACTION_PATH" \
+            --format "$SANCTIFIER_ACTION_FORMAT" \
+            --min-severity "$SANCTIFIER_ACTION_MIN_SEVERITY" \
             --exit-code
         fi
 
@@ -78,57 +91,17 @@ runs:
       id: summarize
       shell: bash
       run: |
-        python - <<'PY'
-        import json
-        import os
-        import subprocess
-        import sys
-
-        fmt = os.environ.get("INPUT_FORMAT", "sarif")
-        path = os.environ.get("INPUT_PATH", ".")
-        sarif_path = os.environ.get("INPUT_SARIF_OUTPUT", "sanctifier-results.sarif")
-
-        findings_count = 0
-        if fmt == "sarif":
-          try:
-            with open(sarif_path, "r", encoding="utf-8") as f:
-              data = json.load(f)
-            findings_count = sum(len(run.get("results", []) or []) for run in (data.get("runs", []) or []))
-          except FileNotFoundError:
-            findings_count = 0
-        elif fmt == "json":
-          proc = subprocess.run(
-            ["sanctifier", "analyze", path, "--format", "json"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            check=False,
-          )
-          try:
-            data = json.loads(proc.stdout or "{}")
-            summary = data.get("summary") or {}
-            findings_count = summary.get("total_findings")
-            if findings_count is None:
-              findings_count = sum(int(summary.get(k, 0) or 0) for k in ("critical", "high", "medium", "low", "info"))
-          except json.JSONDecodeError:
-            findings_count = 0
-
-        out = os.environ.get("GITHUB_OUTPUT")
-        if not out:
-          sys.exit(0)
-        with open(out, "a", encoding="utf-8") as f:
-          f.write(f"findings-count={findings_count}\n")
-        PY
-      env:
-        INPUT_PATH: ${{ inputs.path }}
-        INPUT_FORMAT: ${{ inputs.format }}
-        INPUT_SARIF_OUTPUT: ${{ inputs.sarif-output }}
+        python "${{ github.action_path }}/scripts/action_summary.py" \
+          --format "$SANCTIFIER_ACTION_FORMAT" \
+          --path "$SANCTIFIER_ACTION_PATH" \
+          --min-severity "$SANCTIFIER_ACTION_MIN_SEVERITY" \
+          --sarif-output "$SANCTIFIER_ACTION_SARIF_OUTPUT"
 
     - name: Upload SARIF
       if: >-
-        ${{ inputs.format == 'sarif'
-          && inputs.upload-sarif == 'true'
+        ${{ env.SANCTIFIER_ACTION_FORMAT == 'sarif'
+          && env.SANCTIFIER_ACTION_UPLOAD_SARIF == 'true'
           && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: ${{ inputs.sarif-output }}
+        sarif_file: ${{ env.SANCTIFIER_ACTION_SARIF_OUTPUT }}

--- a/docs/github-action-support-matrix.md
+++ b/docs/github-action-support-matrix.md
@@ -35,3 +35,20 @@ Notes:
 
 The action inputs/outputs in `action.yml` are intended to remain stable across patch releases.
 If an input/output needs to change incompatibly, the change should be documented and released with an appropriate version bump.
+
+## Input validation and tests
+
+The composite action validates its inputs before installing or running the CLI:
+
+- `path` must be a relative path inside the checked-out repository and must exist.
+- `format` must be one of `text`, `json`, or `sarif`.
+- `min-severity` must be one of `critical`, `high`, `medium`, `low`, or `info`.
+- `upload-sarif` accepts boolean-like values and is normalized to `true` or `false`.
+- `sarif-output` must be a relative output path and cannot include path traversal segments.
+
+Action helper logic lives in `scripts/action_inputs.py`, `scripts/action_summary.py`, and `scripts/resolve_action_version.py`.
+Unit fixtures live under `tests/action/fixtures/`, and CI runs them with:
+
+```bash
+python -m unittest discover -s tests/action -p "test_*.py"
+```

--- a/docs/github-action-threat-model.md
+++ b/docs/github-action-threat-model.md
@@ -32,6 +32,7 @@ This document captures a lightweight threat model for the composite GitHub Actio
 **Mitigations**:
 
 - Prefer pinning a released action version tag (e.g. `HyperSafeD/Sanctifier@vX.Y.Z`) and, optionally, `with: version: X.Y.Z`.
+- Keep action inputs constrained to repository-relative paths and documented output formats before invoking shell commands.
 - Keep SARIF upload disabled on untrusted events (fork PRs are already handled).
 
 ### Data exfiltration via logs/artifacts

--- a/docs/vulnerability-database-format.md
+++ b/docs/vulnerability-database-format.md
@@ -2,6 +2,16 @@
 
 ## JSON Schema
 
+The canonical schema lives at `schemas/vulnerability-db.json`.
+JSON Schema enforces the document shape, while the CLI loader adds semantic checks that JSON Schema cannot express:
+
+- vulnerability IDs must be unique
+- vulnerability names must be unique, case-insensitively
+- overlapping signatures are rejected when entries share the same normalized `category`, normalized `severity`, and regex `pattern`
+- regex patterns must compile with Rust's `regex` crate
+
+Validation failures include the duplicate or overlapping entry indexes so contributors can fix data issues quickly.
+
 ```json
 {
   "version": "1.0.0",
@@ -154,12 +164,14 @@ To contribute new vulnerability patterns to the default database:
 1. Fork the repository
 2. Add your pattern to `tooling/sanctifier-cli/data/vulnerability-db.json`
 3. Add a test case in `tooling/sanctifier-cli/tests/vulndb/`
-4. Ensure all existing tests pass
-5. Submit a pull request
+4. Ensure the ID, name, and category/severity/pattern signature do not duplicate an existing entry
+5. Ensure all existing tests pass
+6. Submit a pull request
 
 ### Contribution Guidelines
 
 - **Unique IDs**: Use incrementing numbers or descriptive prefixes
+- **Unique Signatures**: Avoid adding multiple entries with the same category, severity, and regex pattern
 - **Clear Descriptions**: Explain the vulnerability in plain language
 - **Actionable Recommendations**: Provide specific fix instructions
 - **Verified References**: Include links to authoritative sources

--- a/schemas/vulnerability-db.json
+++ b/schemas/vulnerability-db.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/HyperSafeD/Sanctifier/main/schemas/vulnerability-db.json",
+  "title": "Sanctifier Vulnerability Database",
+  "description": "Schema for regex-based vulnerability databases consumed by `sanctifier analyze --vuln-db`.",
+  "type": "object",
+  "required": ["version", "last_updated", "description", "vulnerabilities"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Database format version in semantic-version form."
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date",
+      "description": "Date the database was last updated, in YYYY-MM-DD form."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "vulnerabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "description", "severity", "category", "pattern", "recommendation"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[A-Z0-9][A-Z0-9._-]*$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low", "info"]
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1
+          },
+          "pattern": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Rust regex crate compatible pattern. Regex compilation and overlap checks are enforced by the CLI loader."
+          },
+          "recommendation": {
+            "type": "string",
+            "minLength": 1
+          },
+          "references": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
+            "default": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/action_inputs.py
+++ b/scripts/action_inputs.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_ALLOWED_FORMATS = {"text", "json", "sarif"}
+_ALLOWED_SEVERITIES = {"critical", "high", "medium", "low", "info"}
+_SAFE_RELATIVE_PATH_RE = re.compile(r"^[A-Za-z0-9._/\-\\ ]+$")
+
+
+@dataclass(frozen=True)
+class ActionInputs:
+    path: str
+    min_severity: str
+    format: str
+    upload_sarif: str
+    sarif_output: str
+
+
+def _normalise_bool(value: str, *, name: str) -> str:
+    lowered = (value or "").strip().lower()
+    if lowered in {"true", "1", "yes"}:
+        return "true"
+    if lowered in {"false", "0", "no"}:
+        return "false"
+    raise ValueError(f"{name} must be true or false, got {value!r}")
+
+
+def _validate_path(value: str, *, name: str, allow_missing: bool) -> str:
+    raw = (value or "").strip()
+    if not raw:
+        raise ValueError(f"{name} must not be empty")
+    if "\x00" in raw or "\n" in raw or "\r" in raw:
+        raise ValueError(f"{name} must not contain control characters")
+    if raw.startswith("-"):
+        raise ValueError(f"{name} must not start with '-'")
+
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        raise ValueError(f"{name} must be relative to the checked-out repository")
+    if any(part == ".." for part in path.parts):
+        raise ValueError(f"{name} must not contain '..' path traversal segments")
+    if not _SAFE_RELATIVE_PATH_RE.match(raw):
+        raise ValueError(f"{name} contains unsupported characters")
+    if not allow_missing and not path.exists():
+        raise ValueError(f"{name} does not exist in the checked-out repository: {raw}")
+    return raw
+
+
+def validate_inputs(
+    *,
+    path: str,
+    min_severity: str,
+    format: str,
+    upload_sarif: str,
+    sarif_output: str,
+) -> ActionInputs:
+    fmt = (format or "").strip().lower()
+    if fmt not in _ALLOWED_FORMATS:
+        allowed = ", ".join(sorted(_ALLOWED_FORMATS))
+        raise ValueError(f"format must be one of {allowed}, got {format!r}")
+
+    severity = (min_severity or "").strip().lower()
+    if severity not in _ALLOWED_SEVERITIES:
+        allowed = ", ".join(sorted(_ALLOWED_SEVERITIES))
+        raise ValueError(f"min-severity must be one of {allowed}, got {min_severity!r}")
+
+    return ActionInputs(
+        path=_validate_path(path, name="path", allow_missing=False),
+        min_severity=severity,
+        format=fmt,
+        upload_sarif=_normalise_bool(upload_sarif, name="upload-sarif"),
+        sarif_output=_validate_path(sarif_output, name="sarif-output", allow_missing=True),
+    )
+
+
+def write_env_file(inputs: ActionInputs, output: Path) -> None:
+    output.write_text(
+        "\n".join(
+            [
+                f"SANCTIFIER_ACTION_PATH={inputs.path}",
+                f"SANCTIFIER_ACTION_MIN_SEVERITY={inputs.min_severity}",
+                f"SANCTIFIER_ACTION_FORMAT={inputs.format}",
+                f"SANCTIFIER_ACTION_UPLOAD_SARIF={inputs.upload_sarif}",
+                f"SANCTIFIER_ACTION_SARIF_OUTPUT={inputs.sarif_output}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", default=os.environ.get("INPUT_PATH", "."))
+    parser.add_argument("--min-severity", default=os.environ.get("INPUT_MIN_SEVERITY", "high"))
+    parser.add_argument("--format", default=os.environ.get("INPUT_FORMAT", "sarif"))
+    parser.add_argument("--upload-sarif", default=os.environ.get("INPUT_UPLOAD_SARIF", "true"))
+    parser.add_argument("--sarif-output", default=os.environ.get("INPUT_SARIF_OUTPUT", "sanctifier-results.sarif"))
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    try:
+        inputs = validate_inputs(
+            path=args.path,
+            min_severity=args.min_severity,
+            format=args.format,
+            upload_sarif=args.upload_sarif,
+            sarif_output=args.sarif_output,
+        )
+    except ValueError as exc:
+        print(f"Sanctifier action input error: {exc}", file=sys.stderr)
+        return 2
+
+    write_env_file(inputs, Path(args.output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/action_summary.py
+++ b/scripts/action_summary.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def count_sarif_findings(sarif_path: Path) -> int:
+    try:
+        data = json.loads(sarif_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return 0
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid SARIF JSON in {sarif_path}: {exc}") from exc
+
+    return sum(len(run.get("results", []) or []) for run in (data.get("runs", []) or []))
+
+
+def count_json_findings(payload: str) -> int:
+    try:
+        data = json.loads(payload or "{}")
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid Sanctifier JSON output: {exc}") from exc
+
+    summary = data.get("summary") or {}
+    total = summary.get("total_findings")
+    if total is not None:
+        return int(total)
+    return sum(int(summary.get(key, 0) or 0) for key in ("critical", "high", "medium", "low", "info"))
+
+
+def summarize_findings(*, fmt: str, path: str, min_severity: str, sarif_output: str) -> int:
+    if fmt == "sarif":
+        return count_sarif_findings(Path(sarif_output))
+    if fmt != "json":
+        return 0
+
+    proc = subprocess.run(
+        ["sanctifier", "analyze", path, "--format", "json", "--min-severity", min_severity],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    return count_json_findings(proc.stdout)
+
+
+def append_github_output(name: str, value: int) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as handle:
+        handle.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--format", default=os.environ.get("INPUT_FORMAT", "sarif"))
+    parser.add_argument("--path", default=os.environ.get("INPUT_PATH", "."))
+    parser.add_argument("--min-severity", default=os.environ.get("INPUT_MIN_SEVERITY", "high"))
+    parser.add_argument("--sarif-output", default=os.environ.get("INPUT_SARIF_OUTPUT", "sanctifier-results.sarif"))
+    args = parser.parse_args()
+
+    try:
+        findings_count = summarize_findings(
+            fmt=(args.format or "").strip().lower(),
+            path=args.path,
+            min_severity=(args.min_severity or "").strip().lower(),
+            sarif_output=args.sarif_output,
+        )
+    except ValueError as exc:
+        print(f"Sanctifier action summary error: {exc}", file=sys.stderr)
+        return 2
+
+    append_github_output("findings-count", findings_count)
+    print(f"findings-count={findings_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_action_version.py
+++ b/scripts/resolve_action_version.py
@@ -7,6 +7,7 @@ import sys
 
 
 _SEMVER_TAG_RE = re.compile(r"^v(?P<ver>\d+\.\d+\.\d+)$")
+_CRATES_VERSION_RE = re.compile(r"^(v)?(?P<ver>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$")
 
 
 def resolve_version(*, action_ref: str, requested: str) -> str:
@@ -15,10 +16,14 @@ def resolve_version(*, action_ref: str, requested: str) -> str:
     """
     req = (requested or "").strip()
     if req:
-        # Accept both "0.2.3" and "v0.2.3" for convenience.
-        if req.startswith("v"):
-            req = req[1:]
-        return req
+        # Accept both "0.2.3" and "v0.2.3" for convenience, but reject
+        # arbitrary cargo-install arguments before they reach the shell.
+        m = _CRATES_VERSION_RE.match(req)
+        if not m:
+            raise ValueError(
+                "version must be a crates.io semantic version such as 0.2.3 or v0.2.3"
+            )
+        return m.group("ver")
 
     ref = (action_ref or "").strip()
     m = _SEMVER_TAG_RE.match(ref)
@@ -35,7 +40,11 @@ def main() -> int:
     p.add_argument("--output", required=True)
     args = p.parse_args()
 
-    version = resolve_version(action_ref=args.action_ref, requested=args.requested)
+    try:
+        version = resolve_version(action_ref=args.action_ref, requested=args.requested)
+    except ValueError as exc:
+        print(f"Sanctifier action version error: {exc}", file=sys.stderr)
+        return 2
     with open(args.output, "w", encoding="utf-8") as f:
         f.write(version)
     return 0

--- a/tests/action/fixtures/summary-sarif.json
+++ b/tests/action/fixtures/summary-sarif.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "sanctifier"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "S001",
+          "message": {
+            "text": "missing auth"
+          }
+        },
+        {
+          "ruleId": "S002",
+          "message": {
+            "text": "panic"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/action/test_action_inputs.py
+++ b/tests/action/test_action_inputs.py
@@ -1,0 +1,64 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class ActionInputTests(unittest.TestCase):
+    def test_accepts_normalized_valid_inputs(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        got = validate_inputs(
+            path=".",
+            min_severity="HIGH",
+            format="SARIF",
+            upload_sarif="yes",
+            sarif_output="reports/results.sarif",
+        )
+
+        self.assertEqual(got.path, ".")
+        self.assertEqual(got.min_severity, "high")
+        self.assertEqual(got.format, "sarif")
+        self.assertEqual(got.upload_sarif, "true")
+        self.assertEqual(got.sarif_output, "reports/results.sarif")
+
+    def test_rejects_unknown_format(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        with self.assertRaisesRegex(ValueError, "format must be one of"):
+            validate_inputs(
+                path=".",
+                min_severity="high",
+                format="xml",
+                upload_sarif="true",
+                sarif_output="out.sarif",
+            )
+
+    def test_rejects_path_traversal(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        with self.assertRaisesRegex(ValueError, "path traversal"):
+            validate_inputs(
+                path="../outside",
+                min_severity="high",
+                format="sarif",
+                upload_sarif="true",
+                sarif_output="out.sarif",
+            )
+
+    def test_rejects_missing_scan_path(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        with self.assertRaisesRegex(ValueError, "does not exist"):
+            validate_inputs(
+                path="missing-contract-dir",
+                min_severity="high",
+                format="sarif",
+                upload_sarif="true",
+                sarif_output="out.sarif",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/action/test_action_summary.py
+++ b/tests/action/test_action_summary.py
@@ -1,0 +1,28 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class ActionSummaryTests(unittest.TestCase):
+    def test_counts_sarif_results(self) -> None:
+        from scripts.action_summary import count_sarif_findings
+
+        sarif = ROOT / "tests" / "action" / "fixtures" / "summary-sarif.json"
+        self.assertEqual(count_sarif_findings(sarif), 2)
+
+    def test_counts_json_total_findings(self) -> None:
+        from scripts.action_summary import count_json_findings
+
+        self.assertEqual(count_json_findings('{"summary":{"total_findings":7}}'), 7)
+
+    def test_counts_legacy_json_severity_buckets(self) -> None:
+        from scripts.action_summary import count_json_findings
+
+        payload = '{"summary":{"critical":1,"high":2,"medium":3,"low":4,"info":5}}'
+        self.assertEqual(count_json_findings(payload), 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/action/test_resolve_action_version.py
+++ b/tests/action/test_resolve_action_version.py
@@ -21,6 +21,12 @@ class ResolveActionVersionTests(unittest.TestCase):
                 )
                 self.assertEqual(got, case["expected"])
 
+    def test_rejects_non_semver_requested_version(self) -> None:
+        from scripts.resolve_action_version import resolve_version
+
+        with self.assertRaisesRegex(ValueError, "semantic version"):
+            resolve_version(action_ref="v0.2.3", requested="latest --git https://example.invalid")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/vulnerability_db/test_vulnerability_db_data.py
+++ b/tests/vulnerability_db/test_vulnerability_db_data.py
@@ -1,0 +1,51 @@
+import json
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DATABASES = [
+    ROOT / "data" / "vulnerability-db.json",
+    ROOT / "tooling" / "sanctifier-cli" / "data" / "vulnerability-db.json",
+]
+
+
+class VulnerabilityDatabaseDataTests(unittest.TestCase):
+    def test_schema_file_exists_and_declares_required_fields(self) -> None:
+        schema_path = ROOT / "schemas" / "vulnerability-db.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(schema["title"], "Sanctifier Vulnerability Database")
+        self.assertEqual(
+            schema["required"],
+            ["version", "last_updated", "description", "vulnerabilities"],
+        )
+
+    def test_database_entries_have_unique_ids_names_and_signatures(self) -> None:
+        for db_path in DATABASES:
+            with self.subTest(database=str(db_path.relative_to(ROOT))):
+                payload = json.loads(db_path.read_text(encoding="utf-8"))
+                entries = payload["vulnerabilities"]
+
+                ids = [entry["id"] for entry in entries]
+                names = [entry["name"].strip().lower() for entry in entries]
+                signatures = [
+                    (
+                        entry["category"].strip().lower(),
+                        entry["severity"].strip().lower(),
+                        entry["pattern"].strip(),
+                    )
+                    for entry in entries
+                ]
+
+                self.assertEqual(len(ids), len(set(ids)), "duplicate vulnerability IDs")
+                self.assertEqual(len(names), len(set(names)), "duplicate vulnerability names")
+                self.assertEqual(
+                    len(signatures),
+                    len(set(signatures)),
+                    "overlapping vulnerability signatures",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -111,7 +111,7 @@ pub(crate) struct FileAnalysisResult {
 // ── Entry point ──────────────────────────────────────────────────────────────
 
 pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
-    let mut path = args.path.clone();
+    let path = args.path.clone();
 
     #[cfg(not(windows))]
     {

--- a/tooling/sanctifier-cli/src/commands/diff.rs
+++ b/tooling/sanctifier-cli/src/commands/diff.rs
@@ -864,7 +864,7 @@ fn build_current_report(
 // ---------------------------------------------------------------------------
 
 pub fn exec(args: DiffArgs) -> anyhow::Result<()> {
-    let mut path = args.path.clone();
+    let path = args.path.clone();
 
     #[cfg(not(windows))]
     {

--- a/tooling/sanctifier-cli/src/commands/fix.rs
+++ b/tooling/sanctifier-cli/src/commands/fix.rs
@@ -77,7 +77,9 @@ pub fn exec(args: FixArgs) -> anyhow::Result<()> {
                             print_diff(&source, patch);
                         }
                         _ => {
-                            println!("  y=apply  n=skip  a=apply-all-remaining  d=show-diff  ?=help");
+                            println!(
+                                "  y=apply  n=skip  a=apply-all-remaining  d=show-diff  ?=help"
+                            );
                         }
                     }
                 }

--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -1,8 +1,8 @@
 pub mod analyze;
 pub mod badge;
-pub mod fix;
 pub mod complexity;
 pub mod diff;
+pub mod fix;
 
 pub mod init;
 pub mod reentrancy;

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -160,9 +160,6 @@ fn run() -> anyhow::Result<()> {
         Commands::Fix(args) => {
             commands::fix::exec(args)?;
         }
-        Commands::Fix(args) => {
-            commands::fix::exec(args)?;
-        }
         Commands::Update => {
             commands::update::exec()?;
         }

--- a/tooling/sanctifier-cli/src/vulndb.rs
+++ b/tooling/sanctifier-cli/src/vulndb.rs
@@ -1,5 +1,6 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -42,13 +43,87 @@ impl VulnDatabase {
     pub fn load(path: &Path) -> anyhow::Result<Self> {
         let content = fs::read_to_string(path)?;
         let db: VulnDatabase = serde_json::from_str(&content)?;
+        db.validate()?;
         Ok(db)
     }
 
     /// Load the embedded default vulnerability database.
     pub fn load_default() -> Self {
         let content = include_str!("../data/vulnerability-db.json");
-        serde_json::from_str(content).expect("embedded vulnerability-db.json is valid")
+        let db: VulnDatabase =
+            serde_json::from_str(content).expect("embedded vulnerability-db.json is valid JSON");
+        db.validate()
+            .expect("embedded vulnerability-db.json passes semantic validation");
+        db
+    }
+
+    /// Validate uniqueness and overlap constraints that JSON Schema cannot express.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.vulnerabilities.is_empty() {
+            anyhow::bail!("vulnerability database must contain at least one vulnerability");
+        }
+
+        let mut ids: HashMap<&str, usize> = HashMap::new();
+        let mut names: HashMap<String, usize> = HashMap::new();
+        let mut signatures: HashMap<String, usize> = HashMap::new();
+        let mut errors = Vec::new();
+
+        for (index, vuln) in self.vulnerabilities.iter().enumerate() {
+            if vuln.id.trim().is_empty() {
+                errors.push(format!("vulnerabilities[{index}].id must not be empty"));
+            }
+            if vuln.name.trim().is_empty() {
+                errors.push(format!("vulnerabilities[{index}].name must not be empty"));
+            }
+            if vuln.pattern.trim().is_empty() {
+                errors.push(format!(
+                    "vulnerabilities[{index}].pattern must not be empty"
+                ));
+            } else if let Err(err) = Regex::new(&vuln.pattern) {
+                errors.push(format!(
+                    "{} has invalid regex pattern: {err}",
+                    vuln.id.as_str()
+                ));
+            }
+
+            if let Some(first) = ids.insert(vuln.id.as_str(), index) {
+                errors.push(format!(
+                    "duplicate vulnerability id {:?} at vulnerabilities[{first}] and vulnerabilities[{index}]",
+                    vuln.id
+                ));
+            }
+
+            let name_key = vuln.name.trim().to_ascii_lowercase();
+            if !name_key.is_empty() {
+                if let Some(first) = names.insert(name_key, index) {
+                    errors.push(format!(
+                        "duplicate vulnerability name {:?} at vulnerabilities[{first}] and vulnerabilities[{index}]",
+                        vuln.name
+                    ));
+                }
+            }
+
+            let signature = format!(
+                "{}\x1f{}\x1f{}",
+                vuln.category.trim().to_ascii_lowercase(),
+                vuln.severity.trim().to_ascii_lowercase(),
+                vuln.pattern.trim()
+            );
+            if !vuln.pattern.trim().is_empty() {
+                if let Some(first) = signatures.insert(signature, index) {
+                    errors.push(format!(
+                        "overlapping vulnerability signature between {} at vulnerabilities[{first}] and {} at vulnerabilities[{index}]",
+                        self.vulnerabilities[first].id, vuln.id
+                    ));
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            anyhow::bail!("invalid vulnerability database:\n{}", errors.join("\n"));
+        }
+
+        Ok(())
     }
 
     /// Scan source code against all vulnerability patterns.
@@ -234,6 +309,109 @@ fn second() {
         assert_eq!(db.version, "0.1.0");
         assert_eq!(db.vulnerabilities.len(), 1);
         assert_eq!(db.vulnerabilities[0].id, "CUSTOM-001");
+    }
+
+    #[test]
+    fn test_validate_rejects_duplicate_ids() {
+        let db = VulnDatabase {
+            version: "0.1.0".to_string(),
+            last_updated: "2026-04-23".to_string(),
+            description: "duplicate ids".to_string(),
+            vulnerabilities: vec![
+                VulnEntry {
+                    id: "DUP-001".to_string(),
+                    name: "First".to_string(),
+                    description: "first".to_string(),
+                    severity: "low".to_string(),
+                    category: "test".to_string(),
+                    pattern: "first".to_string(),
+                    recommendation: "fix first".to_string(),
+                    references: vec![],
+                },
+                VulnEntry {
+                    id: "DUP-001".to_string(),
+                    name: "Second".to_string(),
+                    description: "second".to_string(),
+                    severity: "low".to_string(),
+                    category: "test".to_string(),
+                    pattern: "second".to_string(),
+                    recommendation: "fix second".to_string(),
+                    references: vec![],
+                },
+            ],
+        };
+
+        let err = db.validate().expect_err("duplicate IDs should fail");
+        assert!(err.to_string().contains("duplicate vulnerability id"));
+    }
+
+    #[test]
+    fn test_validate_rejects_overlapping_signatures() {
+        let db = VulnDatabase {
+            version: "0.1.0".to_string(),
+            last_updated: "2026-04-23".to_string(),
+            description: "overlapping signatures".to_string(),
+            vulnerabilities: vec![
+                VulnEntry {
+                    id: "SIG-001".to_string(),
+                    name: "First".to_string(),
+                    description: "first".to_string(),
+                    severity: "high".to_string(),
+                    category: "auth".to_string(),
+                    pattern: "require_auth".to_string(),
+                    recommendation: "fix first".to_string(),
+                    references: vec![],
+                },
+                VulnEntry {
+                    id: "SIG-002".to_string(),
+                    name: "Second".to_string(),
+                    description: "second".to_string(),
+                    severity: "HIGH".to_string(),
+                    category: "AUTH".to_string(),
+                    pattern: "require_auth".to_string(),
+                    recommendation: "fix second".to_string(),
+                    references: vec![],
+                },
+            ],
+        };
+
+        let err = db
+            .validate()
+            .expect_err("overlapping signatures should fail");
+        assert!(err
+            .to_string()
+            .contains("overlapping vulnerability signature"));
+    }
+
+    #[test]
+    fn test_load_rejects_invalid_regex_with_context() {
+        let custom_db_content = r#"{
+            "version": "0.1.0",
+            "last_updated": "2026-04-23",
+            "description": "Invalid regex database",
+            "vulnerabilities": [
+                {
+                    "id": "BAD-REGEX",
+                    "name": "Bad Regex",
+                    "description": "A bad regex",
+                    "severity": "low",
+                    "category": "test",
+                    "pattern": "(",
+                    "recommendation": "Fix it"
+                }
+            ]
+        }"#;
+
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        temp_file
+            .write_all(custom_db_content.as_bytes())
+            .expect("Failed to write temp file");
+        temp_file.flush().expect("Failed to flush");
+
+        let err = VulnDatabase::load(temp_file.path()).expect_err("invalid regex should fail");
+        assert!(err
+            .to_string()
+            .contains("BAD-REGEX has invalid regex pattern"));
     }
 
     #[test]

--- a/tooling/sanctifier-core/src/custom_yaml_rules.rs
+++ b/tooling/sanctifier-core/src/custom_yaml_rules.rs
@@ -1,4 +1,4 @@
-use crate::rules::{Rule, RuleViolation, Severity, Patch};
+use crate::rules::{Patch, Rule, RuleViolation, Severity};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use syn::spanned::Spanned;
@@ -21,9 +21,13 @@ pub struct YamlCustomRule {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+/// Severity values accepted in YAML-defined custom rules.
 pub enum YamlSeverity {
+    /// Emit an error-level violation.
     Error,
+    /// Emit a warning-level violation.
     Warning,
+    /// Emit an informational violation.
     Info,
 }
 
@@ -78,11 +82,10 @@ pub enum AstMatcher {
 
 /// Load custom rules from YAML file
 pub fn load_yaml_rules(path: &Path) -> Result<Vec<YamlCustomRule>, String> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("Failed to read YAML file: {}", e))?;
-    
-    serde_yaml::from_str(&content)
-        .map_err(|e| format!("Failed to parse YAML: {}", e))
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read YAML file: {}", e))?;
+
+    serde_yaml::from_str(&content).map_err(|e| format!("Failed to parse YAML: {}", e))
 }
 
 /// Wrapper that implements Rule trait for YAML-defined rules
@@ -91,12 +94,14 @@ pub struct YamlRuleWrapper {
 }
 
 impl YamlRuleWrapper {
+    /// Create a rule wrapper from a parsed YAML custom rule.
     pub fn new(rule: YamlCustomRule) -> Self {
         Self { rule }
     }
 }
 
 impl Rule for YamlRuleWrapper {
+    #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         &self.rule.id
     }
@@ -107,18 +112,15 @@ impl Rule for YamlRuleWrapper {
 
     fn check(&self, source: &str) -> Vec<RuleViolation> {
         match &self.rule.matcher {
-            AstMatcher::FunctionCall { name, .. } => {
-                check_function_calls(source, name, &self.rule)
-            }
+            AstMatcher::FunctionCall { name, .. } => check_function_calls(source, name, &self.rule),
             AstMatcher::MethodCall { method, receiver } => {
                 check_method_calls(source, method, receiver.as_deref(), &self.rule)
             }
-            AstMatcher::StorageOperation { operation, key_pattern } => {
-                check_storage_operations(source, operation, key_pattern.as_deref(), &self.rule)
-            }
-            AstMatcher::Regex { pattern } => {
-                check_regex_pattern(source, pattern, &self.rule)
-            }
+            AstMatcher::StorageOperation {
+                operation,
+                key_pattern,
+            } => check_storage_operations(source, operation, key_pattern.as_deref(), &self.rule),
+            AstMatcher::Regex { pattern } => check_regex_pattern(source, pattern, &self.rule),
         }
     }
 
@@ -131,7 +133,11 @@ impl Rule for YamlRuleWrapper {
     }
 }
 
-fn check_function_calls(source: &str, name_pattern: &str, rule: &YamlCustomRule) -> Vec<RuleViolation> {
+fn check_function_calls(
+    source: &str,
+    name_pattern: &str,
+    rule: &YamlCustomRule,
+) -> Vec<RuleViolation> {
     let file = match parse_str::<File>(source) {
         Ok(f) => f,
         Err(_) => return vec![],
@@ -139,7 +145,7 @@ fn check_function_calls(source: &str, name_pattern: &str, rule: &YamlCustomRule)
 
     let mut violations = Vec::new();
     let visitor = FunctionCallVisitor::new(name_pattern);
-    
+
     for item in &file.items {
         if let syn::Item::Impl(impl_item) = item {
             for impl_item_inner in &impl_item.items {
@@ -149,7 +155,7 @@ fn check_function_calls(source: &str, name_pattern: &str, rule: &YamlCustomRule)
             }
         }
     }
-    
+
     violations
 }
 
@@ -165,7 +171,7 @@ fn check_method_calls(
     };
 
     let mut violations = Vec::new();
-    
+
     for item in &file.items {
         if let syn::Item::Impl(impl_item) = item {
             for impl_item_inner in &impl_item.items {
@@ -181,7 +187,7 @@ fn check_method_calls(
             }
         }
     }
-    
+
     violations
 }
 
@@ -197,7 +203,7 @@ fn check_storage_operations(
     };
 
     let mut violations = Vec::new();
-    
+
     for item in &file.items {
         if let syn::Item::Impl(impl_item) = item {
             for impl_item_inner in &impl_item.items {
@@ -213,7 +219,7 @@ fn check_storage_operations(
             }
         }
     }
-    
+
     violations
 }
 
@@ -234,7 +240,7 @@ fn check_regex_pattern(source: &str, pattern: &str, rule: &YamlCustomRule) -> Ve
             ));
         }
     }
-    
+
     violations
 }
 
@@ -247,10 +253,15 @@ impl<'a> FunctionCallVisitor<'a> {
         Self { name_pattern }
     }
 
-    fn check_block(&self, block: &syn::Block, violations: &mut Vec<RuleViolation>, rule: &YamlCustomRule) {
+    fn check_block(
+        &self,
+        block: &syn::Block,
+        violations: &mut Vec<RuleViolation>,
+        rule: &YamlCustomRule,
+    ) {
         for stmt in &block.stmts {
             match stmt {
-                syn::Stmt::Expr(expr, _) | syn::Stmt::Expr(expr, None) => {
+                syn::Stmt::Expr(expr, _) => {
                     self.check_expr(expr, violations, rule);
                 }
                 syn::Stmt::Local(local) => {
@@ -263,7 +274,12 @@ impl<'a> FunctionCallVisitor<'a> {
         }
     }
 
-    fn check_expr(&self, expr: &syn::Expr, violations: &mut Vec<RuleViolation>, rule: &YamlCustomRule) {
+    fn check_expr(
+        &self,
+        expr: &syn::Expr,
+        violations: &mut Vec<RuleViolation>,
+        rule: &YamlCustomRule,
+    ) {
         match expr {
             syn::Expr::Call(call) => {
                 if let syn::Expr::Path(path) = &*call.func {
@@ -312,12 +328,24 @@ fn check_block_for_method_calls(
 ) {
     for stmt in &block.stmts {
         match stmt {
-            syn::Stmt::Expr(expr, _) | syn::Stmt::Expr(expr, None) => {
-                check_expr_for_method_calls(expr, method_pattern, receiver_pattern, violations, rule);
+            syn::Stmt::Expr(expr, _) => {
+                check_expr_for_method_calls(
+                    expr,
+                    method_pattern,
+                    receiver_pattern,
+                    violations,
+                    rule,
+                );
             }
             syn::Stmt::Local(local) => {
                 if let Some(init) = &local.init {
-                    check_expr_for_method_calls(&init.expr, method_pattern, receiver_pattern, violations, rule);
+                    check_expr_for_method_calls(
+                        &init.expr,
+                        method_pattern,
+                        receiver_pattern,
+                        violations,
+                        rule,
+                    );
                 }
             }
             _ => {}
@@ -340,7 +368,7 @@ fn check_expr_for_method_calls(
                 let receiver_matches = receiver_pattern
                     .map(|p| matches_pattern(&receiver_str, p))
                     .unwrap_or(true);
-                
+
                 if receiver_matches {
                     let span = m.span();
                     violations.push(RuleViolation::new(
@@ -351,25 +379,73 @@ fn check_expr_for_method_calls(
                     ));
                 }
             }
-            check_expr_for_method_calls(&m.receiver, method_pattern, receiver_pattern, violations, rule);
+            check_expr_for_method_calls(
+                &m.receiver,
+                method_pattern,
+                receiver_pattern,
+                violations,
+                rule,
+            );
             for arg in &m.args {
-                check_expr_for_method_calls(arg, method_pattern, receiver_pattern, violations, rule);
+                check_expr_for_method_calls(
+                    arg,
+                    method_pattern,
+                    receiver_pattern,
+                    violations,
+                    rule,
+                );
             }
         }
         syn::Expr::Block(b) => {
-            check_block_for_method_calls(&b.block, method_pattern, receiver_pattern, violations, rule);
+            check_block_for_method_calls(
+                &b.block,
+                method_pattern,
+                receiver_pattern,
+                violations,
+                rule,
+            );
         }
         syn::Expr::If(i) => {
-            check_expr_for_method_calls(&i.cond, method_pattern, receiver_pattern, violations, rule);
-            check_block_for_method_calls(&i.then_branch, method_pattern, receiver_pattern, violations, rule);
+            check_expr_for_method_calls(
+                &i.cond,
+                method_pattern,
+                receiver_pattern,
+                violations,
+                rule,
+            );
+            check_block_for_method_calls(
+                &i.then_branch,
+                method_pattern,
+                receiver_pattern,
+                violations,
+                rule,
+            );
             if let Some((_, else_expr)) = &i.else_branch {
-                check_expr_for_method_calls(else_expr, method_pattern, receiver_pattern, violations, rule);
+                check_expr_for_method_calls(
+                    else_expr,
+                    method_pattern,
+                    receiver_pattern,
+                    violations,
+                    rule,
+                );
             }
         }
         syn::Expr::Match(m) => {
-            check_expr_for_method_calls(&m.expr, method_pattern, receiver_pattern, violations, rule);
+            check_expr_for_method_calls(
+                &m.expr,
+                method_pattern,
+                receiver_pattern,
+                violations,
+                rule,
+            );
             for arm in &m.arms {
-                check_expr_for_method_calls(&arm.body, method_pattern, receiver_pattern, violations, rule);
+                check_expr_for_method_calls(
+                    &arm.body,
+                    method_pattern,
+                    receiver_pattern,
+                    violations,
+                    rule,
+                );
             }
         }
         _ => {}
@@ -385,12 +461,18 @@ fn check_block_for_storage_ops(
 ) {
     for stmt in &block.stmts {
         match stmt {
-            syn::Stmt::Expr(expr, _) | syn::Stmt::Expr(expr, None) => {
+            syn::Stmt::Expr(expr, _) => {
                 check_expr_for_storage_ops(expr, operation, key_pattern, violations, rule);
             }
             syn::Stmt::Local(local) => {
                 if let Some(init) = &local.init {
-                    check_expr_for_storage_ops(&init.expr, operation, key_pattern, violations, rule);
+                    check_expr_for_storage_ops(
+                        &init.expr,
+                        operation,
+                        key_pattern,
+                        violations,
+                        rule,
+                    );
                 }
             }
             _ => {}
@@ -409,7 +491,7 @@ fn check_expr_for_storage_ops(
         syn::Expr::MethodCall(m) => {
             let method_name = m.method.to_string();
             let receiver_str = quote::quote!(#m.receiver).to_string();
-            
+
             if receiver_str.contains("storage") && method_name == operation {
                 let key_matches = if let Some(pattern) = key_pattern {
                     m.args.iter().any(|arg| {
@@ -419,7 +501,7 @@ fn check_expr_for_storage_ops(
                 } else {
                     true
                 };
-                
+
                 if key_matches {
                     let span = m.span();
                     violations.push(RuleViolation::new(
@@ -430,7 +512,7 @@ fn check_expr_for_storage_ops(
                     ));
                 }
             }
-            
+
             check_expr_for_storage_ops(&m.receiver, operation, key_pattern, violations, rule);
             for arg in &m.args {
                 check_expr_for_storage_ops(arg, operation, key_pattern, violations, rule);
@@ -499,7 +581,7 @@ mod tests {
                 args: vec![],
             },
         };
-        
+
         let wrapper = YamlRuleWrapper::new(rule);
         let source = r#"
             impl MyContract {
@@ -508,7 +590,7 @@ mod tests {
                 }
             }
         "#;
-        
+
         let violations = wrapper.check(source);
         assert!(!violations.is_empty());
     }
@@ -525,7 +607,7 @@ mod tests {
                 receiver: Some("storage".to_string()),
             },
         };
-        
+
         let wrapper = YamlRuleWrapper::new(rule);
         let source = r#"
             impl MyContract {
@@ -534,7 +616,7 @@ mod tests {
                 }
             }
         "#;
-        
+
         let violations = wrapper.check(source);
         assert!(!violations.is_empty());
     }

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -64,7 +64,7 @@ pub const UNCHECKED_EXTERNAL_CALL: &str = "S019";
 /// Missing event emission for privileged state changes.
 pub const MISSING_STATE_EVENT: &str = "S020";
 /// Per-user or large dataset stored in Instance storage instead of Persistent.
-pub const INSTANCE_STORAGE_MISUSE: &str = "S019";
+pub const INSTANCE_STORAGE_MISUSE: &str = "S021";
 
 /// A single finding-code entry with machine-readable code, category, and
 /// human-readable description.
@@ -186,6 +186,8 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             code: MISSING_STATE_EVENT,
             category: "events",
             description: "Privileged state change (admin, pause, upgrade) without event emission breaks off-chain data integrity",
+        },
+        FindingCode {
             code: INSTANCE_STORAGE_MISUSE,
             category: "storage_type",
             description: "Per-user or large dataset stored in Instance storage instead of Persistent, causing ledger entry bloat",

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -23,10 +23,6 @@
 
 #![warn(missing_docs)]
 
-use soroban_sdk::Env;
-use std::collections::HashSet;
-use syn::{parse_str, File, Item, Type, Fields, Meta, ExprMethodCall, Macro};
-use syn::visit::{self, Visit};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::panic::catch_unwind;
@@ -82,9 +78,6 @@ pub use rules::{Rule, RuleRegistry, RuleViolation, Severity};
 pub use sep41::{Sep41Issue, Sep41IssueKind, Sep41VerificationReport};
 pub use smt::SmtInvariantIssue;
 
-use syn::spanned::Spanned;
-
-// Redundant imports removed
 use crate::rules::arithmetic_overflow::ArithVisitor;
 use crate::rules::truncation_bounds::TruncationBoundsVisitor;
 
@@ -574,7 +567,10 @@ impl Analyzer {
     }
 
     /// Detect Soroban SDK version and check for deprecations.
-    pub fn detect_sdk_version(&self, cargo_toml_path: &std::path::Path) -> sdk_version::SdkVersionInfo {
+    pub fn detect_sdk_version(
+        &self,
+        cargo_toml_path: &std::path::Path,
+    ) -> sdk_version::SdkVersionInfo {
         sdk_version::detect_sdk_version(cargo_toml_path)
     }
 

--- a/tooling/sanctifier-core/src/rules/missing_state_event.rs
+++ b/tooling/sanctifier-core/src/rules/missing_state_event.rs
@@ -6,6 +6,7 @@ use syn::{parse_str, File, Item};
 pub struct MissingStateEventRule;
 
 impl MissingStateEventRule {
+    /// Create a new missing-state-event rule.
     pub fn new() -> Self {
         Self
     }
@@ -41,9 +42,13 @@ impl Rule for MissingStateEventRule {
                         if is_privileged_function(&fn_name) {
                             let mut has_privileged_mutation = false;
                             let mut has_event_emission = false;
-                            
-                            check_function_body(&f.block, &mut has_privileged_mutation, &mut has_event_emission);
-                            
+
+                            check_function_body(
+                                &f.block,
+                                &mut has_privileged_mutation,
+                                &mut has_event_emission,
+                            );
+
                             if has_privileged_mutation && !has_event_emission {
                                 let span = f.sig.span();
                                 violations.push(
@@ -97,7 +102,7 @@ fn check_function_body(
 ) {
     for stmt in &block.stmts {
         match stmt {
-            syn::Stmt::Expr(expr, _) | syn::Stmt::Expr(expr, None) => {
+            syn::Stmt::Expr(expr, _) => {
                 check_expr(expr, has_privileged_mutation, has_event_emission);
             }
             syn::Stmt::Local(local) => {
@@ -110,15 +115,11 @@ fn check_function_body(
     }
 }
 
-fn check_expr(
-    expr: &syn::Expr,
-    has_privileged_mutation: &mut bool,
-    has_event_emission: &mut bool,
-) {
+fn check_expr(expr: &syn::Expr, has_privileged_mutation: &mut bool, has_event_emission: &mut bool) {
     match expr {
         syn::Expr::MethodCall(m) => {
             let method_name = m.method.to_string();
-            
+
             // Check for storage mutations on privileged keys
             if method_name == "set" || method_name == "update" || method_name == "remove" {
                 let receiver_str = quote::quote!(#m.receiver).to_string();
@@ -132,7 +133,7 @@ fn check_expr(
                     }
                 }
             }
-            
+
             // Check for event emission
             if method_name == "publish" {
                 let receiver_str = quote::quote!(#m.receiver).to_string();
@@ -140,7 +141,7 @@ fn check_expr(
                     *has_event_emission = true;
                 }
             }
-            
+
             check_expr(&m.receiver, has_privileged_mutation, has_event_emission);
             for arg in &m.args {
                 check_expr(arg, has_privileged_mutation, has_event_emission);
@@ -195,7 +196,10 @@ mod tests {
             }
         "#;
         let violations = rule.check(source);
-        assert!(!violations.is_empty(), "admin change without event should be flagged");
+        assert!(
+            !violations.is_empty(),
+            "admin change without event should be flagged"
+        );
     }
 
     #[test]
@@ -210,7 +214,10 @@ mod tests {
             }
         "#;
         let violations = rule.check(source);
-        assert!(violations.is_empty(), "admin change with event should not be flagged");
+        assert!(
+            violations.is_empty(),
+            "admin change with event should not be flagged"
+        );
     }
 
     #[test]
@@ -224,6 +231,9 @@ mod tests {
             }
         "#;
         let violations = rule.check(source);
-        assert!(violations.is_empty(), "non-privileged function should not be flagged");
+        assert!(
+            violations.is_empty(),
+            "non-privileged function should not be flagged"
+        );
     }
 }

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -19,6 +19,8 @@ pub mod panic_detection;
 pub mod reentrancy;
 /// Shadow storage pattern detection.
 pub mod shadow_storage;
+/// Detect usage of env.storage().instance().update() without state check.
+pub mod storage_update_state_check;
 /// Integer truncation and unchecked bounds detection.
 pub mod truncation_bounds;
 /// Unchecked external call detection.
@@ -29,8 +31,6 @@ pub mod unhandled_result;
 pub mod unsafe_prng;
 /// Unused local variables.
 pub mod unused_variable;
-/// Detect usage of env.storage().instance().update() without state check.
-pub mod storage_update_state_check;
 
 /// Variable shadowing in nested scopes.
 pub mod variable_shadowing;

--- a/tooling/sanctifier-core/src/rules/storage_update_state_check.rs
+++ b/tooling/sanctifier-core/src/rules/storage_update_state_check.rs
@@ -1,6 +1,6 @@
 use crate::rules::{Rule, RuleViolation, Severity};
-use syn::{parse_str, File, Item, Stmt, Expr};
 use quote::ToTokens;
+use syn::{parse_str, Expr, File, Item, Stmt};
 
 /// Rule to detect usage of env.storage().instance().update() without a state check.
 pub struct StorageUpdateStateCheckRule;
@@ -99,32 +99,29 @@ fn check_for_state_check(stmt: &Stmt) -> bool {
 }
 
 fn check_for_vulnerable_update(stmt: &Stmt, has_check: bool) -> bool {
-    match stmt {
-        Stmt::Expr(expr, _) => {
-            if is_storage_update_call(expr) {
-                return !has_check;
+    if let Stmt::Expr(expr, _) = stmt {
+        if is_storage_update_call(expr) {
+            return !has_check;
+        }
+        if let Expr::If(expr_if) = expr {
+            if is_storage_has_call(&expr_if.cond) {
+                return false;
             }
-            if let Expr::If(expr_if) = expr {
-                if is_storage_has_call(&expr_if.cond) {
-                    return false;
+            for s in &expr_if.then_branch.stmts {
+                if check_for_vulnerable_update(s, has_check) {
+                    return true;
                 }
-                for s in &expr_if.then_branch.stmts {
-                    if check_for_vulnerable_update(s, has_check) {
-                        return true;
-                    }
-                }
-                if let Some((_, else_branch)) = &expr_if.else_branch {
-                    if let Expr::Block(expr_block) = else_branch.as_ref() {
-                        for s in &expr_block.block.stmts {
-                            if check_for_vulnerable_update(s, has_check) {
-                                return true;
-                            }
+            }
+            if let Some((_, else_branch)) = &expr_if.else_branch {
+                if let Expr::Block(expr_block) = else_branch.as_ref() {
+                    for s in &expr_block.block.stmts {
+                        if check_for_vulnerable_update(s, has_check) {
+                            return true;
                         }
                     }
                 }
             }
         }
-        _ => {}
     }
     false
 }

--- a/tooling/sanctifier-core/src/rules/unchecked_external_call.rs
+++ b/tooling/sanctifier-core/src/rules/unchecked_external_call.rs
@@ -6,6 +6,7 @@ use syn::{parse_str, File, Item};
 pub struct UncheckedExternalCallRule;
 
 impl UncheckedExternalCallRule {
+    /// Create a new unchecked-external-call rule.
     pub fn new() -> Self {
         Self
     }
@@ -207,7 +208,10 @@ mod tests {
             }
         "#;
         let violations = rule.check(source);
-        assert!(!violations.is_empty(), "unchecked external call should be flagged");
+        assert!(
+            !violations.is_empty(),
+            "unchecked external call should be flagged"
+        );
     }
 
     #[test]
@@ -222,7 +226,10 @@ mod tests {
             }
         "#;
         let violations = rule.check(source);
-        assert!(violations.is_empty(), "checked external call should not be flagged");
+        assert!(
+            violations.is_empty(),
+            "checked external call should not be flagged"
+        );
     }
 
     #[test]
@@ -236,6 +243,9 @@ mod tests {
             }
         "#;
         let violations = rule.check(source);
-        assert!(violations.is_empty(), "read-only methods should not be flagged");
+        assert!(
+            violations.is_empty(),
+            "read-only methods should not be flagged"
+        );
     }
 }

--- a/tooling/sanctifier-core/src/sdk_version.rs
+++ b/tooling/sanctifier-core/src/sdk_version.rs
@@ -15,6 +15,7 @@ pub struct SdkVersionInfo {
 }
 
 impl SdkVersionInfo {
+    /// Return an SDK version result for cases where no version could be detected.
     pub fn unknown() -> Self {
         Self {
             version: None,
@@ -33,7 +34,7 @@ pub fn detect_sdk_version(cargo_toml_path: &Path) -> SdkVersionInfo {
     };
 
     let version = extract_soroban_sdk_version(&content);
-    
+
     match version {
         Some(v) => analyze_version(&v),
         None => SdkVersionInfo::unknown(),
@@ -93,22 +94,24 @@ fn analyze_version(version: &str) -> SdkVersionInfo {
             version, info.recommended_version.as_ref().unwrap()
         ));
         info.warnings.push(
-            "SDK v20 has known issues with storage TTL management and event emission.".to_string()
+            "SDK v20 has known issues with storage TTL management and event emission.".to_string(),
         );
     } else if major == 21 && minor < 5 {
         info.warnings.push(format!(
             "Soroban SDK {} has known issues. Upgrade to {} recommended.",
-            version, info.recommended_version.as_ref().unwrap()
+            version,
+            info.recommended_version.as_ref().unwrap()
         ));
         info.warnings.push(
-            "Early v21 releases had bugs in authorization and cross-contract calls.".to_string()
+            "Early v21 releases had bugs in authorization and cross-contract calls.".to_string(),
         );
     }
 
     // Check for insecure patterns in specific versions
     if version == "21.0.0" || version == "21.1.0" {
         info.warnings.push(
-            "This SDK version has a critical bug in require_auth() - upgrade immediately!".to_string()
+            "This SDK version has a critical bug in require_auth() - upgrade immediately!"
+                .to_string(),
         );
     }
 


### PR DESCRIPTION
## Description
Harden the GitHub composite action and vulnerability database validation paths with testable helper scripts, CI coverage, schema documentation, and narrow compile/lint fixes needed for the touched CI surface.

Closes #644
Closes #650
Closes #633
Closes #637

## Changes proposed

### What were you told to do?
Address action.yml action-test coverage, action.yml supply-chain/self-hosted input hardening, and data/schemas duplicate or overlapping vulnerability signatures in one PR with tests, CI wiring, and documentation.

### What did I do?
#### GitHub Action Hardening
- Extracted action input validation and findings summary logic into tested Python helpers.
- Added action unit tests and SARIF fixtures, then wired them into CI.
- Constrained action inputs to supported formats, severities, booleans, repo-relative paths, and semver install versions.

#### Vulnerability Database Validation
- Added semantic validation for duplicate IDs, duplicate names, invalid regex patterns, and overlapping category/severity/pattern signatures.
- Added Rust unit tests and standard-library Python data tests for both vulnerability DB copies.
- Added `schemas/vulnerability-db.json` and documented the validation contract.

#### CI Reliability Fixes
- Fixed existing compile and Clippy blockers in the core/CLI surface so the relevant CI checks can pass.
- Applied workspace formatting for files touched by formatter checks.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated locally:

- `python -m unittest discover -s tests/action -p test_*.py` using bundled Python: 9 passed.
- `python -m unittest discover -s tests/vulnerability_db -p test_*.py` using bundled Python: 2 passed.
- `cargo fmt --all --check`: passed.
- `cargo clippy -p sanctifier-cli --all-targets --no-default-features -- -D warnings`: passed.
- `cargo clippy -p sanctifier-core --all-targets --no-default-features -- -D warnings`: passed.
- `cargo test -p sanctifier-cli`: passed, 46 lib tests plus integration/doc tests.
- `cargo test -p sanctifier-core --no-default-features`: passed, 174 lib tests plus integration/doc tests.

Note: local Windows all-features Clippy cannot complete because `z3.h` is not installed on this machine; CI installs Z3 before running the all-features checks.