### PR TITLE
docs(frontend)+fixtures(contracts): behavior notes and finding-code fixtures

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -88,6 +88,22 @@
 - Integration examples
 - Troubleshooting
 
+### Frontend Report and Offline Behavior
+
+**[frontend/docs/report-export.md](frontend/docs/report-export.md)**  
+**[frontend/docs/offline-dev-mode.md](frontend/docs/offline-dev-mode.md)**
+
+- Report export behavior (PDF/CSV/JSON)
+- Offline/local JSON workflow vs contract-upload mode
+- Contributor guardrails for frontend parsing and export paths
+
+### Finding-Code Fixtures
+
+**[contracts/fixtures/finding-codes/README.md](contracts/fixtures/finding-codes/README.md)**
+
+- Fixture matrix for finding codes `S001` through `S012`
+- Upgrade/admin risk fixture notes for hardened validation paths
+
 ### Sanctifier CLI Deploy Command
 
 **Location:** `tooling/sanctifier-cli/src/commands/deploy.rs`

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -4,7 +4,7 @@ This directory contains the Soroban smart contracts for the project.
 
 ## Structure
 - `vulnerable-contract/`: A reference implementation demonstrating common security pitfalls Sanctifier can detect.
-- `guarded-contract/`: A secure implementation using Sanctifier's runtime guards.
+- `fixtures/finding-codes/`: Scan fixtures mapped to `S001` through `S012`.
 
 ## Development
 
@@ -17,4 +17,9 @@ cargo test
 Run the Sanctifier analysis tool on these contracts:
 ```bash
 sanctifier analyze .
+```
+
+For finding-code focused fixture scans:
+```bash
+sanctifier analyze contracts/fixtures/finding-codes --format json
 ```

--- a/contracts/fixtures/finding-codes/README.md
+++ b/contracts/fixtures/finding-codes/README.md
@@ -1,0 +1,36 @@
+# Finding Code Fixture Contracts
+
+This directory contains fixture source files used as deterministic scan inputs for Sanctifier finding codes.
+
+## Goals
+
+- Keep one fixture per core `S***` finding code.
+- Keep fixtures intentionally small and readable.
+- Preserve stable scanner input text for contributor docs and manual verification.
+
+## Fixture index
+
+| Finding code | Fixture file |
+| --- | --- |
+| `S001` | `s001_authentication.rs` |
+| `S002` | `s002_panic_handling.rs` |
+| `S003` | `s003_arithmetic.rs` |
+| `S004` | `s004_storage_limits.rs` |
+| `S005` | `s005_storage_keys.rs` |
+| `S006` | `s006_unsafe_patterns.rs` |
+| `S007` | `s007_custom_rule.rs` |
+| `S008` | `s008_events.rs` |
+| `S009` | `s009_logic_result_handling.rs` |
+| `S010` | `s010_upgrade_admin.rs` |
+| `S011` | `s011_formal_verification.rs` |
+| `S012` | `s012_token_interface.rs` |
+
+## Usage
+
+From repository root:
+
+```bash
+sanctifier analyze contracts/fixtures/finding-codes --format json
+```
+
+These files are fixture sources, not deployable production contracts.

--- a/contracts/fixtures/finding-codes/s001_authentication.rs
+++ b/contracts/fixtures/finding-codes/s001_authentication.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct AuthGapFixture;
+
+#[contractimpl]
+impl AuthGapFixture {
+    pub fn set_owner(env: Env, owner: Symbol) {
+        env.storage().instance().set(&symbol_short!("OWNER"), &owner);
+    }
+}

--- a/contracts/fixtures/finding-codes/s002_panic_handling.rs
+++ b/contracts/fixtures/finding-codes/s002_panic_handling.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct PanicFixture;
+
+#[contractimpl]
+impl PanicFixture {
+    pub fn unwrap_like(_env: Env, items: [u32; 1], index: u32) -> u32 {
+        let maybe = items.get(index as usize);
+        maybe.expect("index out of range")
+    }
+}

--- a/contracts/fixtures/finding-codes/s003_arithmetic.rs
+++ b/contracts/fixtures/finding-codes/s003_arithmetic.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct ArithmeticFixture;
+
+#[contractimpl]
+impl ArithmeticFixture {
+    pub fn unchecked_add(_env: Env, a: u32, b: u32) -> u32 {
+        a + b
+    }
+}

--- a/contracts/fixtures/finding-codes/s004_storage_limits.rs
+++ b/contracts/fixtures/finding-codes/s004_storage_limits.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, Env};
+
+#[contract]
+pub struct StorageLimitFixture;
+
+#[contractimpl]
+impl StorageLimitFixture {
+    pub fn write_large_blob(env: Env, payload: Bytes) {
+        env.storage().instance().set(&"large_payload", &payload);
+    }
+}

--- a/contracts/fixtures/finding-codes/s005_storage_keys.rs
+++ b/contracts/fixtures/finding-codes/s005_storage_keys.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct StorageKeyFixture;
+
+#[contractimpl]
+impl StorageKeyFixture {
+    pub fn write_mixed_keys(env: Env, user_key: Symbol, value: Symbol) {
+        env.storage().instance().set(&symbol_short!("DATA"), &value);
+        env.storage().instance().set(&user_key, &value);
+    }
+}

--- a/contracts/fixtures/finding-codes/s006_unsafe_patterns.rs
+++ b/contracts/fixtures/finding-codes/s006_unsafe_patterns.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct UnsafePatternFixture;
+
+#[contractimpl]
+impl UnsafePatternFixture {
+    pub fn low_level_pointer(_env: Env, pointer_like: u64) -> u64 {
+        pointer_like
+    }
+}

--- a/contracts/fixtures/finding-codes/s007_custom_rule.rs
+++ b/contracts/fixtures/finding-codes/s007_custom_rule.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct CustomRuleFixture;
+
+#[contractimpl]
+impl CustomRuleFixture {
+    pub fn todo_pattern(_env: Env) {
+        let _marker = "TODO: replace debug bypass";
+    }
+}

--- a/contracts/fixtures/finding-codes/s008_events.rs
+++ b/contracts/fixtures/finding-codes/s008_events.rs
@@ -1,0 +1,13 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+#[contract]
+pub struct EventTopicFixture;
+
+#[contractimpl]
+impl EventTopicFixture {
+    pub fn emit_inconsistent_topics(env: Env, amount: u64) {
+        env.events().publish((symbol_short!("transfer"),), amount);
+        env.events().publish((symbol_short!("transfer"), symbol_short!("extra")), amount);
+    }
+}

--- a/contracts/fixtures/finding-codes/s009_logic_result_handling.rs
+++ b/contracts/fixtures/finding-codes/s009_logic_result_handling.rs
@@ -1,0 +1,16 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct ResultHandlingFixture;
+
+#[contractimpl]
+impl ResultHandlingFixture {
+    pub fn ignore_result(_env: Env) {
+        let _ = parse_number();
+    }
+}
+
+fn parse_number() -> Result<u32, ()> {
+    Err(())
+}

--- a/contracts/fixtures/finding-codes/s010_upgrade_admin.rs
+++ b/contracts/fixtures/finding-codes/s010_upgrade_admin.rs
@@ -1,0 +1,76 @@
+#![no_std]
+use soroban_sdk::{contract, contracterror, contractimpl, symbol_short, Address, BytesN, Env, Symbol};
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+const IMPL_HASH: Symbol = symbol_short!("IMPLHASH");
+
+#[contracterror]
+#[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+pub enum UpgradeAdminError {
+    NotInitialized = 1,
+    Unauthorized = 2,
+    SameImplementationHash = 3,
+    SameAdmin = 4,
+}
+
+#[contract]
+pub struct UpgradeAdminFixture;
+
+#[contractimpl]
+impl UpgradeAdminFixture {
+    pub fn initialize(env: Env, admin: Address, impl_hash: BytesN<32>) {
+        env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&IMPL_HASH, &impl_hash);
+    }
+
+    pub fn insecure_upgrade(env: Env, new_hash: BytesN<32>) {
+        env.storage().instance().set(&IMPL_HASH, &new_hash);
+    }
+
+    pub fn secure_upgrade(env: Env, caller: Address, new_hash: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .unwrap_or_else(|| env.panic_with_error(UpgradeAdminError::NotInitialized));
+
+        caller.require_auth();
+        if caller != admin {
+            env.panic_with_error(UpgradeAdminError::Unauthorized);
+        }
+
+        let current: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&IMPL_HASH)
+            .unwrap_or_else(|| env.panic_with_error(UpgradeAdminError::NotInitialized));
+        if current == new_hash {
+            env.panic_with_error(UpgradeAdminError::SameImplementationHash);
+        }
+
+        env.storage().instance().set(&IMPL_HASH, &new_hash);
+    }
+
+    pub fn insecure_transfer_admin(env: Env, new_admin: Address) {
+        env.storage().instance().set(&ADMIN, &new_admin);
+    }
+
+    pub fn secure_transfer_admin(env: Env, caller: Address, new_admin: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN)
+            .unwrap_or_else(|| env.panic_with_error(UpgradeAdminError::NotInitialized));
+
+        caller.require_auth();
+        if caller != admin {
+            env.panic_with_error(UpgradeAdminError::Unauthorized);
+        }
+        if new_admin == admin {
+            env.panic_with_error(UpgradeAdminError::SameAdmin);
+        }
+
+        env.storage().instance().set(&ADMIN, &new_admin);
+    }
+}

--- a/contracts/fixtures/finding-codes/s011_formal_verification.rs
+++ b/contracts/fixtures/finding-codes/s011_formal_verification.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct FormalVerificationFixture;
+
+#[contractimpl]
+impl FormalVerificationFixture {
+    pub fn invariant_candidate(_env: Env, total_supply: i128, reserves: i128) -> bool {
+        reserves >= total_supply
+    }
+}

--- a/contracts/fixtures/finding-codes/s012_token_interface.rs
+++ b/contracts/fixtures/finding-codes/s012_token_interface.rs
@@ -1,0 +1,12 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct TokenInterfaceFixture;
+
+#[contractimpl]
+impl TokenInterfaceFixture {
+    pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {
+        // Intentionally minimal fixture for interface checks.
+    }
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,3 +23,7 @@ The web interface for interacting with the Sanctifier suite.
 - Upload WASM files for analysis.
 - View real-time security reports.
 - Dashboard for tracked contracts.
+
+## Behavior Notes
+- [Report export (PDF/CSV/JSON)](docs/report-export.md)
+- [Offline and dev mode](docs/offline-dev-mode.md)

--- a/frontend/docs/offline-dev-mode.md
+++ b/frontend/docs/offline-dev-mode.md
@@ -1,0 +1,32 @@
+# Frontend Offline and Dev Mode
+
+This note documents how the dashboard behaves when backend analysis is unavailable and how contributors should develop safely in local/offline workflows.
+
+## Scope and owner files
+
+- Analyze API route: `frontend/app/api/analyze/route.ts`
+- Dashboard upload/parse flow: `frontend/app/dashboard/page.tsx`
+- Upload controls: `frontend/app/components/DashboardHeader.tsx`
+
+## Operational modes
+
+### Local JSON-only mode (offline-safe)
+
+- Users can still work fully from local JSON reports without calling backend analysis.
+- Uploading or pasting JSON works without the `sanctifier` binary.
+- This mode is ideal for UI iteration, triage review, and reproducible demos.
+
+### Contract upload mode (requires local tooling)
+
+- Contract upload posts source to `/api/analyze`.
+- The route executes `sanctifier analyze --format json` using:
+  - `SANCTIFIER_BIN` if set
+  - `sanctifier` in PATH otherwise
+- Missing binary, timeout, invalid content type, unsupported extension, invalid UTF-8, and oversized payloads return explicit API errors.
+
+## Dev guardrails
+
+- Keep JSON parsing (`parseReport`) independent from runtime analysis so UI workflows remain available during backend outages.
+- Preserve input limits and extension checks in the API route.
+- Keep error strings user-readable because they are surfaced directly in the dashboard.
+- If adding new dev flags or env vars, document defaults and fallback behavior in this file.

--- a/frontend/docs/report-export.md
+++ b/frontend/docs/report-export.md
@@ -1,0 +1,42 @@
+# Frontend Report Export (PDF/CSV/JSON)
+
+This note documents the current report export behavior in `frontend` and the guardrails contributors should keep when extending it.
+
+## Scope and owner files
+
+- Dashboard orchestration: `frontend/app/dashboard/page.tsx`
+- Export controls: `frontend/app/components/DashboardHeader.tsx`
+- PDF generation logic: `frontend/app/lib/export-pdf.ts`
+
+## Current behavior
+
+### JSON
+
+- JSON is the source of truth for the dashboard state.
+- Users can load JSON by:
+  - pasting report JSON into the dashboard text area
+  - uploading a `.json` file
+  - uploading a Rust contract (`.rs`) and letting `/api/analyze` return findings
+- Parsed data is normalized and transformed before rendering.
+
+### PDF
+
+- `Export PDF` is enabled only when findings/callgraph data exists.
+- PDF generation is client-side via `jspdf` in `export-pdf.ts`.
+- PDF output includes:
+  - header metadata (generated timestamp, finding count)
+  - score and severity summary
+  - grouped findings with category/location/snippet/suggestion
+- If `jspdf` import fails, the UI falls back to `window.print()`.
+
+### CSV
+
+- Dedicated CSV export is not implemented yet.
+- To avoid format drift, contributors should treat JSON as canonical and derive CSV from normalized findings only.
+
+## Contribution notes
+
+- Keep export behavior deterministic for the same normalized report input.
+- Avoid introducing divergent parsing paths between upload/paste/API results.
+- Add new exports behind explicit controls in `DashboardHeader` and reuse normalized findings from `page.tsx`.
+- Keep generated filename conventions stable unless a migration note is added.


### PR DESCRIPTION
## Summary
- document frontend report export behavior (PDF/CSV/JSON) and contributor guardrails
- document frontend offline/dev mode behavior and fallback expectations
- add finding-code fixture contracts for S001 through S012
- add explicit upgrade/admin fixture validation and structured error codes in S010 fixture
- link new docs from frontend/README.md, contracts/README.md, and DOCUMENTATION_INDEX.md

Closes #564
Closes #573
Closes #582
Closes #584
