### PR TITLE
fix: resolve contracts fixture hardening issues #585 #586 #591 #595

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -88,6 +88,15 @@
 - Integration examples
 - Troubleshooting
 
+### Contracts Fixture Catalog
+
+**[contracts/README.md](contracts/README.md)**
+
+- Per-contract ownership map
+- Event-emission fixture references
+- Storage-collision fixture references
+- Unhandled-`Result` fixture references
+
 ### Sanctifier CLI Deploy Command
 
 **Location:** `tooling/sanctifier-cli/src/commands/deploy.rs`

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,20 +1,43 @@
 # Contracts
 
-This directory contains the Soroban smart contracts for the project.
+This directory contains the Soroban contracts used by Sanctifier for analysis, fixture generation, and security regression testing.
 
-## Structure
-- `vulnerable-contract/`: A reference implementation demonstrating common security pitfalls Sanctifier can detect.
-- `guarded-contract/`: A secure implementation using Sanctifier's runtime guards.
+## Contract catalog
+
+- `amm-pool`: Automated market-maker fixture for slippage and reserve-invariant checks.
+- `bridge`: Cross-domain transfer fixture for authorization and replay analysis.
+- `flashloan-token`: Flash-loan execution fixture for temporary-balance safety checks.
+- `governance`: Proposal and voting fixture for control-plane validation.
+- `kani-poc`: Model-checking fixture used by formal verification workflows.
+- `multisig`: Multi-party authorization fixture for threshold and signer-order checks.
+- `my-contract`: Baseline token-like contract used for deterministic testing/fuzzing examples.
+- `oracle`: Price-feed fixture for stale-data and trust-boundary validation.
+- `proxy`: Upgradeability fixture that emits governance-relevant upgrade/admin events.
+- `reentrancy-guard`: Reentrancy defense fixture contract.
+- `runtime-guard-wrapper`: Runtime guard and monitoring wrapper fixture.
+- `shadowing-example`: Demonstrates variable-shadowing patterns and safer alternatives.
+- `timelock`: Delayed execution fixture for governance sequencing.
+- `token-with-bugs`: Intentionally vulnerable token fixture for negative-path validation.
+- `unsafe-prng-example`: Fixture exposing predictable randomness usage.
+- `vesting`: Vesting flow fixture for time-gated token release logic.
+- `vulnerable-contract`: Intentionally unsafe contract used to verify detector coverage.
+
+## Fixture notes
+
+- Event-emission fixture notes live in `runtime-guard-wrapper` and `proxy`.
+- Storage-collision fixture notes live in `runtime-guard-wrapper` and `shadowing-example`.
+- Unhandled-`Result` fixture notes live in `runtime-guard-wrapper` and `token-with-bugs`.
 
 ## Development
 
+Run tests for one contract:
+
 ```bash
-cd vulnerable-contract
-cargo test
+cargo test -p runtime-guard-wrapper
 ```
 
-## Security
-Run the Sanctifier analysis tool on these contracts:
+Run analysis for the full contracts tree:
+
 ```bash
-sanctifier analyze .
+sanctifier analyze contracts
 ```

--- a/contracts/runtime-guard-wrapper/README.md
+++ b/contracts/runtime-guard-wrapper/README.md
@@ -207,6 +207,24 @@ First: Event name (e.g., "guard_wrapper", "pre_exec_guard")
 Second: Status (e.g., "success", "passed", "failure")
 ```
 
+### Event-emission fixture behavior
+
+- All runtime-guard events use the `guard_wrapper` topic.
+- Event name and status are emitted as symbol pairs and are intended to stay stable for downstream parsers.
+- Failure paths emit `guard_failure` with a status that maps to the failure class (argument mismatch, missing function, wrapped-call error).
+
+### Storage-collision fixture behavior
+
+- Runtime state is segmented into instance and persistent storage namespaces.
+- Fixed keys are intentionally centralized to avoid accidental key reuse across guard statistics and execution metadata.
+- Health checks treat abnormal key growth as a fixture failure signal.
+
+### Unhandled-`Result` fixture behavior
+
+- Guarded execution returns Soroban `Error` values for invalid function names, argument mismatches, and wrapped-call decoding failures.
+- Wrapped-call conversion failures are explicitly recorded as guard failures before returning the error.
+- Successful executions increment invariant counters and append execution log entries; failed executions do not mutate those success-only counters.
+
 ## Integration Guide
 
 ### 1. Build the Contract
@@ -290,6 +308,14 @@ Test coverage:
 - Health checks
 - Event emission
 - Storage validation
+- Unhandled-`Result` fixture behavior
+- Event-emission fixture boundaries
+
+## Contribution notes
+
+- Keep event names/status values stable unless there is a migration note and consumer update.
+- When adding new failure paths, record the failure category before returning `Err`.
+- Prefer extending `tests/integration_tests.rs` with fixture-style tests that assert both return value and `get_stats()` effects.
 
 ## Security Considerations
 

--- a/contracts/runtime-guard-wrapper/src/lib.rs
+++ b/contracts/runtime-guard-wrapper/src/lib.rs
@@ -12,6 +12,31 @@ const GUARD_FAILURES: &str = "guard_failures";
 const EXECUTION_METRICS: &str = "exec_metrics";
 const HEALTHY_STORAGE_LIMIT: u32 = 64;
 
+mod event_fixtures {
+    use soroban_sdk::{Env, Symbol};
+
+    pub const TOPIC_GUARD_WRAPPER: &str = "guard_wrapper";
+    pub const EVENT_WRAPPER_INITIALIZED: &str = "wrapper_initialized";
+    pub const EVENT_PRE_EXEC_GUARD: &str = "pre_exec_guard";
+    pub const EVENT_POST_EXEC_GUARD: &str = "post_exec_guard";
+    pub const EVENT_EXECUTION_LOGGED: &str = "execution_logged";
+    pub const EVENT_GUARD_FAILURE: &str = "guard_failure";
+
+    pub const STATUS_IDEMPOTENT: &str = "idempotent";
+    pub const STATUS_SUCCESS: &str = "success";
+    pub const STATUS_PASSED: &str = "passed";
+    pub const STATUS_RECORDED: &str = "recorded";
+    pub const STATUS_WRAPPED_NOT_SET: &str = "wrapped_contract_not_set";
+    pub const STATUS_WRAPPED_CALL_ERROR: &str = "wrapped_call_error";
+
+    pub fn emit(env: &Env, event_name: &str, status: &str) {
+        env.events().publish(
+            (Symbol::new(env, TOPIC_GUARD_WRAPPER),),
+            (Symbol::new(env, event_name), Symbol::new(env, status)),
+        );
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct GuardConfig {
     pub check_storage_invariants: bool,
@@ -52,7 +77,11 @@ impl RuntimeGuardWrapper {
             .instance()
             .has(&Symbol::new(&env, WRAPPED_CONTRACT_ADDRESS))
         {
-            Self::emit_guard_event(env, "wrapper_initialized", "idempotent");
+            Self::emit_guard_event(
+                env,
+                event_fixtures::EVENT_WRAPPER_INITIALIZED,
+                event_fixtures::STATUS_IDEMPOTENT,
+            );
             return;
         }
 
@@ -87,7 +116,11 @@ impl RuntimeGuardWrapper {
             &Vec::<(u32, bool, u64, u64)>::new(&env),
         );
 
-        Self::emit_guard_event(env, "wrapper_initialized", "success");
+        Self::emit_guard_event(
+            env,
+            event_fixtures::EVENT_WRAPPER_INITIALIZED,
+            event_fixtures::STATUS_SUCCESS,
+        );
     }
 
     pub fn get_wrapped_contract(env: Env) -> Address {
@@ -111,7 +144,11 @@ impl RuntimeGuardWrapper {
             .instance()
             .get::<Symbol, Address>(&Symbol::new(&env, WRAPPED_CONTRACT_ADDRESS));
         if wrapped.is_none() {
-            Self::emit_guard_event(env, "pre_exec_guard", "wrapped_contract_not_set");
+            Self::emit_guard_event(
+                env,
+                event_fixtures::EVENT_PRE_EXEC_GUARD,
+                event_fixtures::STATUS_WRAPPED_NOT_SET,
+            );
             return Err(Error::from_contract_error(1));
         }
 
@@ -121,7 +158,11 @@ impl RuntimeGuardWrapper {
 
     fn post_execution_guards(env: Env) -> Result<(), Error> {
         Self::verify_storage_invariants(env.clone())?;
-        Self::emit_guard_event(env, "post_exec_guard", "passed");
+        Self::emit_guard_event(
+            env,
+            event_fixtures::EVENT_POST_EXEC_GUARD,
+            event_fixtures::STATUS_PASSED,
+        );
         Ok(())
     }
 
@@ -166,7 +207,16 @@ impl RuntimeGuardWrapper {
         }
 
         let start_tick = env.ledger().timestamp();
-        let result = Self::simulate_wrapped_call(env.clone(), function_name, args)?;
+        let result = match Self::simulate_wrapped_call(env.clone(), function_name, args) {
+            Ok(val) => val,
+            Err(err) => {
+                Self::record_guard_failure(
+                    env.clone(),
+                    Symbol::new(&env, event_fixtures::STATUS_WRAPPED_CALL_ERROR),
+                );
+                return Err(err);
+            }
+        };
         let val: Val = function_name.clone().into_val(&env);
         let call_hash = (val.get_payload().wrapping_mul(31) ^ start_tick.wrapping_mul(17)) as u32;
 
@@ -241,7 +291,11 @@ impl RuntimeGuardWrapper {
             persistent.set(&call_log_symbol, &log);
         }
 
-        Self::emit_guard_event(env, "execution_logged", "success");
+        Self::emit_guard_event(
+            env,
+            event_fixtures::EVENT_EXECUTION_LOGGED,
+            event_fixtures::STATUS_SUCCESS,
+        );
     }
 
     fn record_metrics(env: Env, metrics: ExecutionMetrics) {
@@ -277,14 +331,15 @@ impl RuntimeGuardWrapper {
             .unwrap_or_else(|| Vec::new(&env));
         failures.push_back(failure);
         persistent.set(&failure_symbol, &failures);
-        Self::emit_guard_event(env, "guard_failure", "recorded");
+        Self::emit_guard_event(
+            env,
+            event_fixtures::EVENT_GUARD_FAILURE,
+            event_fixtures::STATUS_RECORDED,
+        );
     }
 
     fn emit_guard_event(env: Env, event_name: &str, status: &str) {
-        env.events().publish(
-            (Symbol::new(&env, "guard_wrapper"),),
-            (Symbol::new(&env, event_name), Symbol::new(&env, status)),
-        );
+        event_fixtures::emit(&env, event_name, status);
     }
 
     pub fn get_stats(env: Env) -> (u32, u32, u32) {

--- a/contracts/runtime-guard-wrapper/tests/integration_tests.rs
+++ b/contracts/runtime-guard-wrapper/tests/integration_tests.rs
@@ -112,3 +112,19 @@ fn get_stats_tracks_successes_and_failures() {
 
     assert_eq!(client.get_stats(), (3, 3, 0));
 }
+
+#[test]
+fn execute_guarded_tracks_wrapped_call_result_errors() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let invalid_sum_args = vec![
+        &env,
+        Symbol::new(&env, "badarg").into_val(&env),
+        3u32.into_val(&env),
+    ];
+
+    let result = client.try_execute_guarded(&Symbol::new(&env, "sum"), &invalid_sum_args);
+
+    assert!(result.is_err());
+    assert_eq!(client.get_stats(), (0, 0, 0));
+}


### PR DESCRIPTION
## Summary
- refactor `runtime-guard-wrapper` event emission into a dedicated fixture module to make event boundaries explicit and maintainable (#585)
- add integration coverage for wrapped-call `Result` error handling and keep failure-path semantics stable (#591)
- document storage-collision, event-emission, and unhandled-`Result` fixture behavior in contract docs with contribution notes (#586, #595)
- expand `contracts/README.md` into a per-contract ownership/fixture catalog and link it from `DOCUMENTATION_INDEX.md`

## Test plan
- [x] `cargo test -p runtime-guard-wrapper`

## Closes
- Closes #585
- Closes #586
- Closes #591
- Closes #595

