### PR TITLE
feat: resolve #581 #583 #555 #570 (frontend/wasm/ci hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,28 @@ jobs:
           path: frontend/coverage/
           retention-days: 7
 
+  contracts-sep41-fixtures:
+    name: Contracts SEP-41 Fixture Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Sanctifier CLI
+        run: cargo build -p sanctifier-cli
+
+      - name: Run SEP-41 fixture contract tests
+        run: cargo test -p my-contract
+
+      - name: Validate S012 fixture output via CLI
+        run: |
+          cargo run --quiet --bin sanctifier -- analyze contracts/fixtures/finding-codes/s012_token_interface.rs --format json > /tmp/s012-report.json
+          grep -q '"S012"' /tmp/s012-report.json
+
   frontend-e2e:
     name: Frontend E2E Tests (Playwright)
     runs-on: ubuntu-latest
@@ -191,6 +213,36 @@ jobs:
             frontend/playwright-report/
             frontend/test-results/
           retention-days: 7
+
+  frontend-schema-e2e:
+    name: Frontend Schema Rendering E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build WASM stub
+        run: |
+          mkdir -p tooling/sanctifier-wasm/pkg
+          echo '{"name":"@sanctifier/wasm","version":"0.0.0","main":"index.js"}' > tooling/sanctifier-wasm/pkg/package.json
+          echo 'module.exports = {};' > tooling/sanctifier-wasm/pkg/index.js
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install --with-deps chromium
+
+      - name: Run schema rendering e2e suite
+        run: cd frontend && npm run test:e2e:schema
 
   commitlint:
     name: Lint Commit Messages

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -100,9 +100,11 @@
 
 **[frontend/docs/report-export.md](frontend/docs/report-export.md)**  
 **[frontend/docs/offline-dev-mode.md](frontend/docs/offline-dev-mode.md)**
+**[frontend/docs/self-hosting.md](frontend/docs/self-hosting.md)**
 
 - Report export behavior (PDF/CSV/JSON)
 - Offline/local JSON workflow vs contract-upload mode
+- Self-hosting runtime boundaries and safe defaults
 - Contributor guardrails for frontend parsing and export paths
 
 ### Finding-Code Fixtures
@@ -111,6 +113,7 @@
 
 - Fixture matrix for finding codes `S001` through `S012`
 - Upgrade/admin risk fixture notes for hardened validation paths
+- SEP-41 conformance fixture entrypoint: `s012_token_interface.rs`
 
 ### Sanctifier CLI Deploy Command
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -27,6 +27,7 @@ This directory contains the Soroban contracts used by Sanctifier for analysis, f
 - Event-emission fixture notes live in `runtime-guard-wrapper` and `proxy`.
 - Storage-collision fixture notes live in `runtime-guard-wrapper` and `shadowing-example`.
 - Unhandled-`Result` fixture notes live in `runtime-guard-wrapper` and `token-with-bugs`.
+- SEP-41 conformance fixtures live in `my-contract` and `fixtures/finding-codes/s012_token_interface.rs`.
 ## Structure
 - `vulnerable-contract/`: A reference implementation demonstrating common security pitfalls Sanctifier can detect.
 - `fixtures/finding-codes/`: Scan fixtures mapped to `S001` through `S012`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,3 +27,4 @@ The web interface for interacting with the Sanctifier suite.
 ## Behavior Notes
 - [Report export (PDF/CSV/JSON)](docs/report-export.md)
 - [Offline and dev mode](docs/offline-dev-mode.md)
+- [Self-hosting guide](docs/self-hosting.md)

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,8 +2,15 @@
 
 import { useState, useCallback, useTransition, useMemo } from "react";
 import dynamic from "next/dynamic";
-import type { CallGraphNode, CallGraphEdge, Finding, Severity, WorkspaceSummary } from "../types";
+import type { Severity } from "../types";
 import { transformReport, extractCallGraph, normalizeReport } from "../lib/transform";
+import {
+  createWorkspaceFromSingleReport,
+  extractErrorMessage,
+  isWorkspaceSummary,
+  parseJsonInput,
+  SAMPLE_JSON,
+} from "../lib/report-ingestion";
 import { exportToPdf } from "../lib/export-pdf";
 import { SeverityFilter } from "../components/SeverityFilter";
 import { FindingsList } from "../components/FindingsList";
@@ -23,35 +30,10 @@ const CallGraph = dynamic(() => import("../components/CallGraph").then((m) => m.
   ),
 });
 
-const SAMPLE_JSON = `{
-  "size_warnings": [],
-  "unsafe_patterns": [],
-  "auth_gaps": [],
-  "panic_issues": [],
-  "arithmetic_issues": []
-}`;
-
 type Tab = "findings" | "callgraph";
 
-function extractErrorMessage(payload: unknown, fallback: string): string {
-  if (typeof payload === "string" && payload.trim()) {
-    return payload;
-  }
-
-  if (
-    typeof payload === "object" &&
-    payload !== null &&
-    "error" in payload &&
-    typeof payload.error === "string"
-  ) {
-    return payload.error;
-  }
-
-  return fallback;
-}
-
 export default function DashboardPage() {
-  const { workspace, selectedContract, setWorkspace, updateContractReport } = useWorkspace();
+  const { selectedContract, setWorkspace } = useWorkspace();
   const [severityFilter, setSeverityFilter] = useState<Severity | "all">("all");
   const [error, setError] = useState<string | null>(null);
   const [jsonInput, setJsonInput] = useState("");
@@ -73,22 +55,10 @@ export default function DashboardPage() {
 
   const applyReport = useCallback((rawReport: unknown) => {
     startTransition(() => {
-      // Check if it's a workspace summary or a single report
-      if (typeof rawReport === "object" && rawReport !== null && "contracts" in rawReport && Array.isArray((rawReport as any).contracts)) {
-        setWorkspace(rawReport as WorkspaceSummary);
+      if (isWorkspaceSummary(rawReport)) {
+        setWorkspace(rawReport);
       } else {
-        // Create a synthetic workspace for a single report
-        const report = normalizeReport(rawReport);
-        setWorkspace({
-          workspace: "Uploaded Report",
-          contracts: [{
-            name: "current-contract",
-            total_findings: transformReport(report).length,
-            report: report
-          }],
-          shared_libs: [],
-          grand_total_findings: transformReport(report).length
-        });
+        setWorkspace(createWorkspaceFromSingleReport(rawReport));
       }
     });
   }, [setWorkspace]);
@@ -97,7 +67,7 @@ export default function DashboardPage() {
     setError(null);
     setUploadStatus(null);
     try {
-      applyReport(JSON.parse(text || SAMPLE_JSON));
+      applyReport(parseJsonInput(text));
     } catch (e) {
       setError(e instanceof Error ? e.message : "Invalid JSON");
       setWorkspace(null);

--- a/frontend/app/lib/report-ingestion.ts
+++ b/frontend/app/lib/report-ingestion.ts
@@ -1,0 +1,58 @@
+import type { WorkspaceSummary } from "../types";
+import { normalizeReport, transformReport } from "./transform";
+
+export const SAMPLE_JSON = `{
+  "size_warnings": [],
+  "unsafe_patterns": [],
+  "auth_gaps": [],
+  "panic_issues": [],
+  "arithmetic_issues": []
+}`;
+
+export function extractErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === "string" && payload.trim()) {
+    return payload;
+  }
+
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in payload &&
+    typeof payload.error === "string"
+  ) {
+    return payload.error;
+  }
+
+  return fallback;
+}
+
+export function isWorkspaceSummary(payload: unknown): payload is WorkspaceSummary {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "contracts" in payload &&
+    Array.isArray((payload as { contracts?: unknown }).contracts)
+  );
+}
+
+export function createWorkspaceFromSingleReport(rawReport: unknown): WorkspaceSummary {
+  const report = normalizeReport(rawReport);
+  const findingCount = transformReport(report).length;
+
+  return {
+    workspace: "Uploaded Report",
+    contracts: [
+      {
+        name: "current-contract",
+        total_findings: findingCount,
+        report,
+      },
+    ],
+    shared_libs: [],
+    grand_total_findings: findingCount,
+  };
+}
+
+export function parseJsonInput(input: string): unknown {
+  return JSON.parse(input || SAMPLE_JSON);
+}

--- a/frontend/app/lib/scan-progress.ts
+++ b/frontend/app/lib/scan-progress.ts
@@ -1,0 +1,13 @@
+export const SCAN_PROGRESS_PHASES = [
+  "Parsing Soroban SDK attributes...",
+  "Building intermediate representation...",
+  "Traversing call graph...",
+  "Running static analysis rules...",
+  "Checking for authorization gaps...",
+  "Verifying arithmetic safety...",
+  "Estimating ledger footprint...",
+] as const;
+
+export function nextScanProgressPhase(index: number): string {
+  return SCAN_PROGRESS_PHASES[index % SCAN_PROGRESS_PHASES.length];
+}

--- a/frontend/app/scan/page.tsx
+++ b/frontend/app/scan/page.tsx
@@ -7,6 +7,7 @@ import { SanctityScore } from "../components/SanctityScore";
 import { FindingsList } from "../components/FindingsList";
 import { SeverityFilter } from "../components/SeverityFilter";
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { nextScanProgressPhase } from "../lib/scan-progress";
 import type { Finding, Severity } from "../types";
 import Link from "next/link";
 
@@ -57,18 +58,11 @@ export default function ScanPage() {
       formData.append("contract", selectedFile);
 
       // We start a "simulated" log stream since our POST is atomic
+      let phaseIndex = 0;
       const logsTimer = setInterval(() => {
-        const phases = [
-          "Parsing Soroban SDK attributes...",
-          "Building intermediate representation...",
-          "Traversing call graph...",
-          "Running static analysis rules...",
-          "Checking for authorization gaps...",
-          "Verifying arithmetic safety...",
-          "Estimating ledger footprint...",
-        ];
-        const randomPhase = phases[Math.floor(Math.random() * phases.length)];
-        setLogs((prev) => [...prev, `[${new Date().toLocaleTimeString()}] [INFO] ${randomPhase}`]);
+        const phase = nextScanProgressPhase(phaseIndex);
+        phaseIndex += 1;
+        setLogs((prev) => [...prev, `[${new Date().toLocaleTimeString()}] [INFO] ${phase}`]);
       }, 1500);
 
       const response = await fetch("/api/analyze", {

--- a/frontend/docs/self-hosting.md
+++ b/frontend/docs/self-hosting.md
@@ -1,0 +1,37 @@
+# Self-hosting Sanctifier Frontend
+
+This guide describes the safe defaults and module boundaries to keep when running the frontend in your own infrastructure.
+
+## Runtime boundaries
+
+- `app/api/analyze/route.ts` owns contract upload validation, rate limiting, and process execution.
+- `app/lib/report-ingestion.ts` owns JSON parsing and workspace normalization for dashboard rendering.
+- `app/lib/scan-progress.ts` owns deterministic scan progress phases for the scanner UI.
+- `app/lib/transform.ts` owns schema normalization and finding transformation.
+
+Keeping these boundaries avoids UI regressions when API payloads evolve.
+
+## Environment variables
+
+- `SANCTIFIER_BIN`: path or command name for the Sanctifier CLI binary used by `/api/analyze`.
+  - Default: `sanctifier`
+  - Example: `SANCTIFIER_BIN=/usr/local/bin/sanctifier`
+
+## Deployment defaults
+
+- Keep upload validation enabled (`.rs` only, UTF-8, size limits).
+- Keep rate limiting enabled for `/api/analyze`.
+- Keep `runtime = "nodejs"` for the analyze route.
+- Keep deterministic progress phases in `scan-progress.ts` for predictable user output and easier debugging.
+
+## Quick verification
+
+From `frontend/`:
+
+```bash
+npm ci
+npm run build
+npm run test:e2e:schema
+```
+
+This verifies schema-driven dashboard rendering paths used by uploaded/parsed reports.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:schema": "playwright test tests/e2e/dashboard.spec.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky"

--- a/tooling/sanctifier-wasm/src/lib.rs
+++ b/tooling/sanctifier-wasm/src/lib.rs
@@ -7,9 +7,11 @@
 //!
 //! * [`analyze`] — run all analysis passes with default config.
 //! * [`analyze_with_config`] — run with a JSON-serialised [`SanctifyConfig`].
+//! * [`analyze_with_progress`] — run analysis and emit deterministic progress events.
 //! * [`version`] — return the WASM module version.
 //! * [`schema_version`] — return the analysis output schema version.
 //! * [`finding_codes`] — return the finding code catalogue.
+//! * [`default_config_json`] — return default config JSON for easy customization.
 
 use sanctifier_core::{
     finding_codes, Analyzer, ArithmeticIssue, AuthGapIssue, EventIssue, PanicIssue, SanctifyConfig,
@@ -42,18 +44,18 @@ fn set_panic_hook() {
 /// Returns a descriptive error message if validation fails.
 fn validate_source(source: &str) -> Result<(), String> {
     let len = source.len();
-    
+
     if len < MIN_SOURCE_SIZE {
         return Err("Source code cannot be empty".to_string());
     }
-    
+
     if len > MAX_SOURCE_SIZE {
         return Err(format!(
             "Source code exceeds maximum size of {} bytes (got {} bytes)",
             MAX_SOURCE_SIZE, len
         ));
     }
-    
+
     Ok(())
 }
 
@@ -63,13 +65,13 @@ fn validate_source(source: &str) -> Result<(), String> {
 /// Returns a descriptive error message if validation fails.
 fn validate_config_json(config_json: &str) -> Result<(), String> {
     if config_json.trim().is_empty() {
-        return Err("Configuration JSON cannot be empty".to_string());
+        return Ok(());
     }
-    
+
     if config_json.len() > 1024 * 1024 {
         return Err("Configuration JSON exceeds maximum size of 1 MB".to_string());
     }
-    
+
     Ok(())
 }
 
@@ -127,6 +129,21 @@ pub struct Summary {
     pub sep41_issues: usize,
     pub has_critical: bool,
     pub has_high: bool,
+}
+
+/// Progress event emitted by [`analyze_with_progress`].
+#[derive(Serialize)]
+pub struct ProgressEvent {
+    pub phase: &'static str,
+    pub percent: u8,
+    pub findings_so_far: usize,
+}
+
+/// Progressive response shape for browsers rendering partial progress.
+#[derive(Serialize)]
+pub struct ProgressiveAnalysisResult {
+    pub events: Vec<ProgressEvent>,
+    pub result: AnalysisResult,
 }
 
 // ── Helpers to convert core types into Finding ───────────────────────────────
@@ -289,6 +306,26 @@ fn run_analysis(analyzer: &Analyzer, source: &str) -> AnalysisResult {
     }
 }
 
+const PROGRESS_PHASES: [(&str, u8); 5] = [
+    ("Validating source input", 10),
+    ("Parsing and indexing contract", 30),
+    ("Running security passes", 60),
+    ("Aggregating findings", 85),
+    ("Finalizing schema output", 100),
+];
+
+fn build_progress_events(total_findings: usize) -> Vec<ProgressEvent> {
+    PROGRESS_PHASES
+        .iter()
+        .enumerate()
+        .map(|(idx, (phase, percent))| ProgressEvent {
+            phase,
+            percent: *percent,
+            findings_so_far: ((idx + 1) * total_findings) / PROGRESS_PHASES.len(),
+        })
+        .collect()
+}
+
 // ── Public WASM API ───────────────────────────────────────────────────────────
 
 /// Analyse Soroban contract source code with default configuration.
@@ -307,7 +344,7 @@ fn run_analysis(analyzer: &Analyzer, source: &str) -> AnalysisResult {
 #[wasm_bindgen]
 pub fn analyze(source: &str) -> JsValue {
     set_panic_hook();
-    
+
     if let Err(err) = validate_source(source) {
         let error = ErrorResponse {
             error_code: "INVALID_INPUT".to_string(),
@@ -316,7 +353,7 @@ pub fn analyze(source: &str) -> JsValue {
         };
         return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
     }
-    
+
     let analyzer = Analyzer::new(SanctifyConfig::default());
     let result = run_analysis(&analyzer, source);
     serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
@@ -331,7 +368,7 @@ pub fn analyze(source: &str) -> JsValue {
 #[wasm_bindgen]
 pub fn analyze_with_config(config_json: &str, source: &str) -> JsValue {
     set_panic_hook();
-    
+
     if let Err(err) = validate_config_json(config_json) {
         let error = ErrorResponse {
             error_code: "INVALID_CONFIG".to_string(),
@@ -340,7 +377,7 @@ pub fn analyze_with_config(config_json: &str, source: &str) -> JsValue {
         };
         return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
     }
-    
+
     if let Err(err) = validate_source(source) {
         let error = ErrorResponse {
             error_code: "INVALID_INPUT".to_string(),
@@ -349,11 +386,38 @@ pub fn analyze_with_config(config_json: &str, source: &str) -> JsValue {
         };
         return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
     }
-    
+
     let config: SanctifyConfig = serde_json::from_str(config_json).unwrap_or_default();
     let analyzer = Analyzer::new(config);
     let result = run_analysis(&analyzer, source);
     serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+}
+
+/// Analyse with deterministic progress snapshots for streaming-like UX.
+///
+/// This returns both progress events and the final [`AnalysisResult`], allowing
+/// frontend clients to show partial progress while keeping output deterministic.
+#[wasm_bindgen]
+pub fn analyze_with_progress(source: &str) -> JsValue {
+    set_panic_hook();
+
+    if let Err(err) = validate_source(source) {
+        let error = ErrorResponse {
+            error_code: "INVALID_INPUT".to_string(),
+            message: err,
+            schema_version: SCHEMA_VERSION,
+        };
+        return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
+    }
+
+    let analyzer = Analyzer::new(SanctifyConfig::default());
+    let result = run_analysis(&analyzer, source);
+    let progressive = ProgressiveAnalysisResult {
+        events: build_progress_events(result.summary.total),
+        result,
+    };
+
+    serde_wasm_bindgen::to_value(&progressive).unwrap_or(JsValue::NULL)
 }
 
 /// Return the full finding-code catalogue as a JS array.
@@ -378,4 +442,10 @@ pub fn version() -> String {
 #[wasm_bindgen]
 pub fn schema_version() -> String {
     SCHEMA_VERSION.to_string()
+}
+
+/// Return default config JSON for easy copy/edit in browser tooling.
+#[wasm_bindgen]
+pub fn default_config_json() -> String {
+    serde_json::to_string_pretty(&SanctifyConfig::default()).unwrap_or_else(|_| "{}".to_string())
 }


### PR DESCRIPTION
## Summary
- refactored frontend report/scan responsibilities into dedicated modules (`report-ingestion` and `scan-progress`) for clearer module boundaries and predictable behavior
- added frontend self-hosting documentation and indexed it from frontend and root documentation maps
- hardened WASM UX/DX defaults by allowing empty config fallback, adding `default_config_json`, and exporting deterministic progress snapshots via `analyze_with_progress`
- added explicit CI jobs for SEP-41 fixture coverage and schema-rendering E2E coverage

## Validation
- `cargo test -p sanctifier-wasm --no-run`
- `cd frontend && npm run test`
- `cd frontend && npx eslint app/dashboard/page.tsx app/scan/page.tsx app/lib/report-ingestion.ts app/lib/scan-progress.ts`
- `cd frontend && npx tsc --noEmit` *(fails due to pre-existing `frontend/app/playground/page.tsx` syntax issue, unrelated to this PR)*

Closes #581
Closes #583
Closes #555
Closes #570
