### PR TITLE
Harden finding code filtering, upload UX, and wasm cache metadata

### DIFF
--- a/frontend/app/components/FindingsList.tsx
+++ b/frontend/app/components/FindingsList.tsx
@@ -6,10 +6,12 @@ import type { Finding, Severity } from "../types";
 import { CodeSnippet } from "./CodeSnippet";
 import { Sparkles } from "lucide-react";
 import { AiFixPanel } from "./AiFixPanel";
+import { filterFindings } from "../lib/finding-filters";
 
 interface FindingsListProps {
   findings: Finding[];
   severityFilter: Severity | "all";
+  codeFilter?: string;
 }
 
 /** Height reserved for each finding row in the virtual list (px). */
@@ -68,18 +70,17 @@ function FindingCard({ finding }: { finding: Finding }) {
   );
 }
 
-export function FindingsList({ findings, severityFilter }: FindingsListProps) {
+export function FindingsList({ findings, severityFilter, codeFilter = "" }: FindingsListProps) {
   const listRef = useRef<FixedSizeList>(null);
   const filtered = useMemo(() => {
-    return severityFilter === "all"
-      ? findings
-      : findings.filter((f) => f.severity === severityFilter);
-  }, [findings, severityFilter]);
+    return filterFindings(findings, severityFilter, codeFilter);
+  }, [codeFilter, findings, severityFilter]);
 
   // Scroll back to top whenever the filter changes.
-  const prevFilterRef = useRef(severityFilter);
-  if (prevFilterRef.current !== severityFilter) {
-    prevFilterRef.current = severityFilter;
+  const prevFiltersRef = useRef(`${severityFilter}:${codeFilter}`);
+  const currentFilters = `${severityFilter}:${codeFilter}`;
+  if (prevFiltersRef.current !== currentFilters) {
+    prevFiltersRef.current = currentFilters;
     listRef.current?.scrollToItem(0);
   }
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -4,6 +4,8 @@ import { useState, useCallback, useTransition, useMemo } from "react";
 import dynamic from "next/dynamic";
 import type { Severity } from "../types";
 import { transformReport, extractCallGraph, normalizeReport } from "../lib/transform";
+import { normalizeFindingCodeQuery, validateFindingCodeQuery } from "../lib/finding-filters";
+import { validateContractUpload } from "../lib/upload-validation";
 import {
   createWorkspaceFromSingleReport,
   extractErrorMessage,
@@ -40,6 +42,8 @@ export default function DashboardPage() {
   const [activeTab, setActiveTab] = useState<Tab>("findings");
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
   const [isUploadingContract, setIsUploadingContract] = useState(false);
+  const [codeFilterInput, setCodeFilterInput] = useState("");
+  const [codeFilterError, setCodeFilterError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const currentReport = selectedContract?.report;
@@ -100,6 +104,13 @@ export default function DashboardPage() {
       return;
     }
 
+    const validationError = validateContractUpload(file);
+    if (validationError) {
+      setUploadStatus(null);
+      setError(validationError);
+      return;
+    }
+
     setError(null);
     setUploadStatus(`Analyzing ${file.name}...`);
     setIsUploadingContract(true);
@@ -139,6 +150,12 @@ export default function DashboardPage() {
       setIsUploadingContract(false);
     }
   }, [applyReport]);
+
+  const handleCodeFilterChange = useCallback((input: string) => {
+    const normalized = normalizeFindingCodeQuery(input);
+    setCodeFilterInput(normalized);
+    setCodeFilterError(validateFindingCodeQuery(normalized));
+  }, []);
 
   const hasData = findings.length > 0 || callGraphNodes.length > 0 || callGraphEdges.length > 0;
   const isProcessing = isPending || isUploadingContract;
@@ -208,14 +225,45 @@ export default function DashboardPage() {
                 {activeTab === "findings" && (
                   <>
                     <section>
-                      <h2 className="text-lg font-semibold mb-4">Filter by Severity</h2>
-                      <SeverityFilter selected={severityFilter} onChange={setSeverityFilter} />
+                      <h2 className="text-lg font-semibold mb-4">Filter Findings</h2>
+                      <div className="space-y-4">
+                        <SeverityFilter selected={severityFilter} onChange={setSeverityFilter} />
+                        <div className="max-w-xs">
+                          <label htmlFor="finding-code-filter" className="mb-1 block text-sm font-medium">
+                            Search by finding code
+                          </label>
+                          <input
+                            id="finding-code-filter"
+                            type="text"
+                            value={codeFilterInput}
+                            onChange={(event) => handleCodeFilterChange(event.target.value)}
+                            placeholder="S001"
+                            inputMode="text"
+                            autoCapitalize="characters"
+                            autoComplete="off"
+                            spellCheck={false}
+                            aria-invalid={Boolean(codeFilterError)}
+                            aria-describedby="finding-code-filter-help"
+                            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 font-mono text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-zinc-400 dark:border-zinc-600 dark:bg-zinc-950"
+                          />
+                          <p
+                            id="finding-code-filter-help"
+                            className={`mt-1 text-xs ${codeFilterError ? "text-red-600 dark:text-red-400" : "text-zinc-500 dark:text-zinc-400"}`}
+                          >
+                            {codeFilterError ?? "Use exact finding codes like S001, S012, or S020."}
+                          </p>
+                        </div>
+                      </div>
                     </section>
 
                     <section id="findings-panel" role="tabpanel" aria-labelledby="findings-tab">
                       <h2 className="text-lg font-semibold mb-4">Findings</h2>
                       <ErrorBoundary>
-                        <FindingsList findings={findings} severityFilter={severityFilter} />
+                        <FindingsList
+                          findings={findings}
+                          severityFilter={severityFilter}
+                          codeFilter={codeFilterError ? "" : codeFilterInput}
+                        />
                       </ErrorBoundary>
                     </section>
                   </>

--- a/frontend/app/lib/finding-filters.ts
+++ b/frontend/app/lib/finding-filters.ts
@@ -1,0 +1,66 @@
+import type { Finding, Severity } from "../types";
+
+const LEGACY_CODE_MAP: Record<string, string> = {
+  AUTH_GAP: "S001",
+  PANIC_USAGE: "S002",
+  ARITHMETIC_OVERFLOW: "S003",
+  LEDGER_SIZE_RISK: "S004",
+  STORAGE_COLLISION: "S005",
+  UNSAFE_PATTERN: "S006",
+  CUSTOM_RULE: "S007",
+  CUSTOM_RULE_MATCH: "S007",
+  EVENT_INCONSISTENCY: "S008",
+  UNHANDLED_RESULT: "S009",
+  UPGRADE_RISK: "S010",
+  SMT_INVARIANT_VIOLATION: "S011",
+  SEP41_INTERFACE_DEVIATION: "S012",
+};
+
+export const FINDING_CODE_PATTERN = /^S\d{3}$/;
+
+export function canonicalizeFindingCode(code: string): string {
+  const normalized = code.trim().toUpperCase();
+  if (!normalized) {
+    return "";
+  }
+
+  if (FINDING_CODE_PATTERN.test(normalized)) {
+    return normalized;
+  }
+
+  return LEGACY_CODE_MAP[normalized] ?? normalized;
+}
+
+export function normalizeFindingCodeQuery(input: string): string {
+  return input.trim().toUpperCase();
+}
+
+export function validateFindingCodeQuery(query: string): string | null {
+  if (!query) {
+    return null;
+  }
+
+  if (!FINDING_CODE_PATTERN.test(query)) {
+    return "Use finding code format S### (for example: S001).";
+  }
+
+  return null;
+}
+
+export function filterFindings(
+  findings: Finding[],
+  severityFilter: Severity | "all",
+  codeFilter: string
+): Finding[] {
+  return findings.filter((finding) => {
+    if (severityFilter !== "all" && finding.severity !== severityFilter) {
+      return false;
+    }
+
+    if (codeFilter && canonicalizeFindingCode(finding.code) !== codeFilter) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/frontend/app/lib/transform.ts
+++ b/frontend/app/lib/transform.ts
@@ -12,6 +12,7 @@ import type {
   UpgradeFinding,
   VulnMatch,
 } from "../types";
+import { canonicalizeFindingCode } from "./finding-filters";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -93,7 +94,7 @@ function toFinding(
 ): Finding {
   return {
     id,
-    code,
+    code: canonicalizeFindingCode(code),
     severity,
     category,
     title,

--- a/frontend/app/lib/upload-validation.ts
+++ b/frontend/app/lib/upload-validation.ts
@@ -1,0 +1,20 @@
+const SUPPORTED_CONTRACT_EXTENSIONS = new Set([".rs"]);
+const MAX_CONTRACT_UPLOAD_SIZE_BYTES = 250 * 1024;
+
+function getFileExtension(name: string): string {
+  const idx = name.lastIndexOf(".");
+  return idx >= 0 ? name.slice(idx).toLowerCase() : "";
+}
+
+export function validateContractUpload(file: File): string | null {
+  if (file.size > MAX_CONTRACT_UPLOAD_SIZE_BYTES) {
+    return `File size exceeds ${MAX_CONTRACT_UPLOAD_SIZE_BYTES / 1024} KB.`;
+  }
+
+  const extension = getFileExtension(file.name);
+  if (!SUPPORTED_CONTRACT_EXTENSIONS.has(extension)) {
+    return "Only .rs contract source files are supported.";
+  }
+
+  return null;
+}

--- a/frontend/docs/offline-dev-mode.md
+++ b/frontend/docs/offline-dev-mode.md
@@ -7,6 +7,8 @@ This note documents how the dashboard behaves when backend analysis is unavailab
 - Analyze API route: `frontend/app/api/analyze/route.ts`
 - Dashboard upload/parse flow: `frontend/app/dashboard/page.tsx`
 - Upload controls: `frontend/app/components/DashboardHeader.tsx`
+- Finding filter logic: `frontend/app/lib/finding-filters.ts`
+- Upload validation: `frontend/app/lib/upload-validation.ts`
 
 ## Operational modes
 
@@ -23,6 +25,13 @@ This note documents how the dashboard behaves when backend analysis is unavailab
   - `SANCTIFIER_BIN` if set
   - `sanctifier` in PATH otherwise
 - Missing binary, timeout, invalid content type, unsupported extension, invalid UTF-8, and oversized payloads return explicit API errors.
+- The dashboard now validates extension and size client-side before upload and surfaces errors immediately.
+
+### Finding-code filtering mode
+
+- The findings panel supports exact finding-code search using canonical format `S###` (example: `S001`).
+- Input is normalized to uppercase and validated before filtering.
+- Legacy non-canonical codes are normalized to canonical `S` codes at transform time to keep filtering predictable.
 
 ## Dev guardrails
 

--- a/tooling/sanctifier-wasm/README.md
+++ b/tooling/sanctifier-wasm/README.md
@@ -1,0 +1,19 @@
+# sanctifier-wasm
+
+WebAssembly bindings for Sanctifier analysis.
+
+## Exported API
+
+- `analyze(source)`
+- `analyze_with_config(config_json, source)`
+- `analyze_with_progress(source)`
+- `finding_codes()`
+- `default_config_json()`
+- `version()`
+- `schema_version()`
+- `asset_cache_key()`
+- `cache_metadata()`
+
+## Offline caching integration
+
+Use `asset_cache_key()` or `cache_metadata().cache_key` when storing wasm assets in CacheStorage or a service worker. The key changes when either package version or schema version changes, so stale assets are safely evicted.

--- a/tooling/sanctifier-wasm/src/lib.rs
+++ b/tooling/sanctifier-wasm/src/lib.rs
@@ -30,6 +30,8 @@ const MAX_SOURCE_SIZE: usize = 10 * 1024 * 1024;
 
 /// Minimum required source code size (1 byte).
 const MIN_SOURCE_SIZE: usize = 1;
+/// Namespace prefix for browser-side wasm asset caches.
+const CACHE_NAMESPACE: &str = "sanctifier-wasm";
 
 // Improve panic messages in the browser console.
 fn set_panic_hook() {
@@ -144,6 +146,15 @@ pub struct ProgressEvent {
 pub struct ProgressiveAnalysisResult {
     pub events: Vec<ProgressEvent>,
     pub result: AnalysisResult,
+}
+
+/// Minimal metadata required by browser cache layers.
+#[derive(Serialize)]
+pub struct CacheMetadata {
+    pub package: &'static str,
+    pub version: &'static str,
+    pub schema_version: &'static str,
+    pub cache_key: String,
 }
 
 // ── Helpers to convert core types into Finding ───────────────────────────────
@@ -326,6 +337,10 @@ fn build_progress_events(total_findings: usize) -> Vec<ProgressEvent> {
         .collect()
 }
 
+fn build_cache_key() -> String {
+    format!("{}:{}:{}", CACHE_NAMESPACE, env!("CARGO_PKG_VERSION"), SCHEMA_VERSION)
+}
+
 // ── Public WASM API ───────────────────────────────────────────────────────────
 
 /// Analyse Soroban contract source code with default configuration.
@@ -448,4 +463,25 @@ pub fn schema_version() -> String {
 #[wasm_bindgen]
 pub fn default_config_json() -> String {
     serde_json::to_string_pretty(&SanctifyConfig::default()).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Return a deterministic cache key for wasm module assets.
+///
+/// Frontend loaders can use this value to bust stale service-worker and
+/// CacheStorage entries whenever the package or schema version changes.
+#[wasm_bindgen]
+pub fn asset_cache_key() -> String {
+    build_cache_key()
+}
+
+/// Return cache metadata for offline-first consumers.
+#[wasm_bindgen]
+pub fn cache_metadata() -> JsValue {
+    let metadata = CacheMetadata {
+        package: "sanctifier-wasm",
+        version: env!("CARGO_PKG_VERSION"),
+        schema_version: SCHEMA_VERSION,
+        cache_key: build_cache_key(),
+    };
+    serde_wasm_bindgen::to_value(&metadata).unwrap_or(JsValue::NULL)
 }


### PR DESCRIPTION
## Summary
- add canonical finding-code normalization plus strict S### validation/search filtering in dashboard
- add client-side contract upload validation for extension/size with clearer user-facing errors
- refactor filtering and upload checks into dedicated frontend lib modules for clearer state boundaries
- add wasm cache metadata exports (asset_cache_key, cache_metadata) and documentation for offline asset caching

## Notes
- no tests were added in this PR per request
- wasm crate compiles successfully with: cargo check -p sanctifier-wasm
- frontend lint could not run in this environment because eslint is not installed in local dependencies

Closes #562
Closes #572
Closes #560
Closes #556
