### PR TITLE
docs(action): document debug logging mode (#639)

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -152,6 +152,14 @@
 - Scheduled validation
 - Artifact management
 
+### Sanctifier Scan GitHub Action
+
+**Location:** `action.yml`
+
+- Composite action for running `sanctifier analyze` in CI
+- Support matrix: `docs/github-action-support-matrix.md` (includes debug logging mode)
+- Threat model notes: `docs/github-action-threat-model.md`
+
 ---
 
 ## 📚 Documentation Map by Use Case

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ jobs:
           min-severity: high
           upload-sarif: "true"
           sarif-output: sanctifier-results.sarif
+          debug: "false"
 ```
 
 When `format: sarif` and `upload-sarif: "true"`, the action uploads the SARIF
@@ -422,6 +423,7 @@ See also:
 
 - `docs/github-action-support-matrix.md`
 - `docs/github-action-threat-model.md`
+- Debug logging mode: set `with: debug: "true"` to print extra `[sanctifier-action][debug] ...` lines (safe-by-default).
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: Path for generated SARIF report
     required: false
     default: sanctifier-results.sarif
+  debug:
+    description: Enable verbose debug logging for the action steps (safe-by-default; no secrets)
+    required: false
+    default: "false"
 
 outputs:
   findings-count:
@@ -51,6 +55,7 @@ runs:
           --format "${{ inputs.format }}" \
           --upload-sarif "${{ inputs.upload-sarif }}" \
           --sarif-output "${{ inputs.sarif-output }}" \
+          --debug "${{ inputs.debug }}" \
           --output "$RUNNER_TEMP/sanctifier_action_inputs"
         cat "$RUNNER_TEMP/sanctifier_action_inputs" >> "$GITHUB_ENV"
 
@@ -63,6 +68,9 @@ runs:
           --output "$RUNNER_TEMP/sanctifier_cli_version"
 
         version="$(cat "$RUNNER_TEMP/sanctifier_cli_version" || true)"
+        if [ "${SANCTIFIER_ACTION_DEBUG:-false}" = "true" ]; then
+          echo "[sanctifier-action][debug] action_ref=${{ github.action_ref }} requested_version=${{ inputs.version }} resolved_version=${version:-latest}"
+        fi
         if [ -n "$version" ]; then
           echo "Installing sanctifier-cli==$version"
           cargo install sanctifier-cli --locked --version "$version"
@@ -74,6 +82,9 @@ runs:
     - name: Analyze project
       shell: bash
       run: |
+        if [ "${SANCTIFIER_ACTION_DEBUG:-false}" = "true" ]; then
+          echo "[sanctifier-action][debug] scan path=$SANCTIFIER_ACTION_PATH format=$SANCTIFIER_ACTION_FORMAT min_severity=$SANCTIFIER_ACTION_MIN_SEVERITY"
+        fi
         if [ "$SANCTIFIER_ACTION_FORMAT" = "sarif" ]; then
           mkdir -p "$(dirname "$SANCTIFIER_ACTION_SARIF_OUTPUT")"
           sanctifier analyze "$SANCTIFIER_ACTION_PATH" \

--- a/docs/github-action-support-matrix.md
+++ b/docs/github-action-support-matrix.md
@@ -45,6 +45,7 @@ The composite action validates its inputs before installing or running the CLI:
 - `min-severity` must be one of `critical`, `high`, `medium`, `low`, or `info`.
 - `upload-sarif` accepts boolean-like values and is normalized to `true` or `false`.
 - `sarif-output` must be a relative output path and cannot include path traversal segments.
+- `debug` accepts boolean-like values and is normalized to `true` or `false`.
 
 Action helper logic lives in `scripts/action_inputs.py`, `scripts/action_summary.py`, and `scripts/resolve_action_version.py`.
 Unit fixtures live under `tests/action/fixtures/`, and CI runs them with:
@@ -52,3 +53,16 @@ Unit fixtures live under `tests/action/fixtures/`, and CI runs them with:
 ```bash
 python -m unittest discover -s tests/action -p "test_*.py"
 ```
+
+## Debug logging mode
+
+The composite action supports a safe-by-default debug logging mode:
+
+- Set `with: debug: "true"` to print extra `[sanctifier-action][debug] ...` lines.
+- Debug logs include normalized inputs, resolved CLI version, and scan parameters.
+- Debug logs must **not** print secrets or dump the full environment.
+
+### Contributor notes
+
+- Keep debug output stable and parseable (`[sanctifier-action][debug]` prefix).
+- Prefer adding new debug details rather than changing existing fields in-place.

--- a/scripts/action_inputs.py
+++ b/scripts/action_inputs.py
@@ -21,6 +21,7 @@ class ActionInputs:
     format: str
     upload_sarif: str
     sarif_output: str
+    debug: str
 
 
 def _normalise_bool(value: str, *, name: str) -> str:
@@ -60,6 +61,7 @@ def validate_inputs(
     format: str,
     upload_sarif: str,
     sarif_output: str,
+    debug: str,
 ) -> ActionInputs:
     fmt = (format or "").strip().lower()
     if fmt not in _ALLOWED_FORMATS:
@@ -77,6 +79,7 @@ def validate_inputs(
         format=fmt,
         upload_sarif=_normalise_bool(upload_sarif, name="upload-sarif"),
         sarif_output=_validate_path(sarif_output, name="sarif-output", allow_missing=True),
+        debug=_normalise_bool(debug, name="debug"),
     )
 
 
@@ -89,6 +92,7 @@ def write_env_file(inputs: ActionInputs, output: Path) -> None:
                 f"SANCTIFIER_ACTION_FORMAT={inputs.format}",
                 f"SANCTIFIER_ACTION_UPLOAD_SARIF={inputs.upload_sarif}",
                 f"SANCTIFIER_ACTION_SARIF_OUTPUT={inputs.sarif_output}",
+                f"SANCTIFIER_ACTION_DEBUG={inputs.debug}",
                 "",
             ]
         ),
@@ -103,6 +107,7 @@ def main() -> int:
     parser.add_argument("--format", default=os.environ.get("INPUT_FORMAT", "sarif"))
     parser.add_argument("--upload-sarif", default=os.environ.get("INPUT_UPLOAD_SARIF", "true"))
     parser.add_argument("--sarif-output", default=os.environ.get("INPUT_SARIF_OUTPUT", "sanctifier-results.sarif"))
+    parser.add_argument("--debug", default=os.environ.get("INPUT_DEBUG", "false"))
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
@@ -113,10 +118,20 @@ def main() -> int:
             format=args.format,
             upload_sarif=args.upload_sarif,
             sarif_output=args.sarif_output,
+            debug=args.debug,
         )
     except ValueError as exc:
         print(f"::error title=Invalid Input::Sanctifier action input error: {exc}", file=sys.stderr)
         return 2
+
+    if inputs.debug == "true":
+        print(
+            "[sanctifier-action][debug] "
+            f"path={inputs.path!r} format={inputs.format!r} "
+            f"min_severity={inputs.min_severity!r} upload_sarif={inputs.upload_sarif!r} "
+            f"sarif_output={inputs.sarif_output!r}",
+            file=sys.stderr,
+        )
 
     write_env_file(inputs, Path(args.output))
     return 0

--- a/tests/action/test_action_inputs.py
+++ b/tests/action/test_action_inputs.py
@@ -15,6 +15,7 @@ class ActionInputTests(unittest.TestCase):
             format="SARIF",
             upload_sarif="yes",
             sarif_output="reports/results.sarif",
+            debug="TRUE",
         )
 
         self.assertEqual(got.path, ".")
@@ -22,6 +23,7 @@ class ActionInputTests(unittest.TestCase):
         self.assertEqual(got.format, "sarif")
         self.assertEqual(got.upload_sarif, "true")
         self.assertEqual(got.sarif_output, "reports/results.sarif")
+        self.assertEqual(got.debug, "true")
 
     def test_rejects_unknown_format(self) -> None:
         from scripts.action_inputs import validate_inputs
@@ -33,6 +35,7 @@ class ActionInputTests(unittest.TestCase):
                 format="xml",
                 upload_sarif="true",
                 sarif_output="out.sarif",
+                debug="false",
             )
 
     def test_rejects_path_traversal(self) -> None:
@@ -45,6 +48,7 @@ class ActionInputTests(unittest.TestCase):
                 format="sarif",
                 upload_sarif="true",
                 sarif_output="out.sarif",
+                debug="false",
             )
 
     def test_rejects_missing_scan_path(self) -> None:
@@ -57,6 +61,7 @@ class ActionInputTests(unittest.TestCase):
                 format="sarif",
                 upload_sarif="true",
                 sarif_output="out.sarif",
+                debug="false",
             )
 
 


### PR DESCRIPTION
Closes #639

## Summary
Documents and implements a safe-by-default debug logging mode for the composite GitHub Action (`action.yml`) via a new `debug` input.

## Changes
- Add `with: debug: "true|false"` input to `action.yml`.
- Export `SANCTIFIER_ACTION_DEBUG` and print stable `[sanctifier-action][debug] ...` lines when enabled.
- Update docs and documentation index to describe behavior and contributor expectations.

## Testing
- `python -m unittest discover -s tests/action -p "test_*.py"`
