### PR TITLE
test(data): add vulndb back-compat checks (#655)

### DIFF
--- a/tests/vulnerability_db/test_db_version_bump.py
+++ b/tests/vulnerability_db/test_db_version_bump.py
@@ -10,6 +10,40 @@ DATABASES = [
     "tooling/sanctifier-cli/data/vulnerability-db.json",
 ]
 
+def resolve_base_ref() -> str:
+    """
+    Resolve the git ref we diff against for version-bump checks.
+
+    In GitHub Actions PRs, `GITHUB_BASE_REF` is usually a branch name like "main"
+    (not "origin/main"), and actions/checkout may not create a local branch.
+    """
+    base_ref = (os.environ.get("GITHUB_BASE_REF") or "").strip()
+    candidates: list[str] = []
+    if base_ref:
+        candidates.extend(
+            [
+                base_ref,
+                f"origin/{base_ref}",
+                f"refs/remotes/origin/{base_ref}",
+                f"refs/heads/{base_ref}",
+            ]
+        )
+    candidates.extend(["origin/main", "refs/remotes/origin/main", "main", "refs/heads/main"])
+
+    for candidate in candidates:
+        try:
+            subprocess.check_call(
+                ["git", "rev-parse", "--verify", candidate],
+                cwd=ROOT,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return candidate
+        except subprocess.CalledProcessError:
+            continue
+
+    return ""
+
 def get_git_diff_files(base_ref: str) -> list[str]:
     try:
         output = subprocess.check_output(
@@ -39,20 +73,9 @@ def parse_version(v: str) -> tuple[int, ...]:
 
 class DBVersioningTests(unittest.TestCase):
     def test_db_version_bumped_if_modified(self) -> None:
-        base_ref = os.environ.get("GITHUB_BASE_REF")
+        base_ref = resolve_base_ref()
         if not base_ref:
-            # Not in a PR environment, fallback to origin/main if available
-            base_ref = "origin/main"
-
-        try:
-            subprocess.check_call(
-                ["git", "rev-parse", "--verify", base_ref],
-                cwd=ROOT,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL
-            )
-        except subprocess.CalledProcessError:
-            self.skipTest(f"Base ref {base_ref} not found, skipping version bump check")
+            self.skipTest("No suitable base ref found; skipping version bump check")
 
         changed_files = get_git_diff_files(base_ref)
 

--- a/tests/vulnerability_db/test_vulnerability_db_data.py
+++ b/tests/vulnerability_db/test_vulnerability_db_data.py
@@ -1,5 +1,7 @@
 import json
+import re
 import pathlib
+import datetime
 import unittest
 
 
@@ -20,6 +22,33 @@ class VulnerabilityDatabaseDataTests(unittest.TestCase):
             schema["required"],
             ["version", "last_updated", "description", "vulnerabilities"],
         )
+
+    def test_schema_item_required_fields_remain_backwards_compatible(self) -> None:
+        schema_path = ROOT / "schemas" / "vulnerability-db.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        vuln_items = schema["properties"]["vulnerabilities"]["items"]
+        self.assertEqual(vuln_items["type"], "object")
+        self.assertEqual(vuln_items["additionalProperties"], False)
+        self.assertEqual(
+            vuln_items["required"],
+            ["id", "name", "description", "severity", "category", "pattern", "recommendation"],
+        )
+        self.assertNotIn("references", vuln_items["required"])
+
+    def test_databases_have_semver_version_and_iso_dates(self) -> None:
+        semver = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+        iso_date = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+
+        for db_path in DATABASES:
+            with self.subTest(database=str(db_path.relative_to(ROOT))):
+                payload = json.loads(db_path.read_text(encoding="utf-8"))
+                version = payload.get("version", "")
+                last_updated = payload.get("last_updated", "")
+
+                self.assertRegex(version, semver)
+                self.assertRegex(last_updated, iso_date)
+                datetime.date.fromisoformat(last_updated)
 
     def test_database_entries_have_unique_ids_names_and_signatures(self) -> None:
         for db_path in DATABASES:


### PR DESCRIPTION
Closes #655

## Summary
Adds targeted backwards-compatibility tests for `data/` + `schemas/` (vulnerability DB), and makes the existing version-bump test reliably find the PR base ref in GitHub Actions.

## Changes
- Resolve `GITHUB_BASE_REF` into a verifiable git ref (supports `main`, `origin/main`, and other common checkout layouts).
- Add “schema must remain backwards compatible” assertions (no new required fields for vulnerability entries).
- Validate DB `version` is semver and `last_updated` is ISO `YYYY-MM-DD`.

## Testing
- `python -m unittest discover -s tests/vulnerability_db -p "test_*.py"`
