### PR TITLE
perf(data): add data/schema budgets + benchmarks (#662)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'contracts/**'
       - 'tooling/**'
+      - 'data/**'
+      - 'schemas/**'
+      - 'benchmarks/**'
+      - 'tests/vulnerability_db/**'
   workflow_dispatch:
 
 jobs:
@@ -15,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Data/schemas JSON performance snapshot
+        run: |
+          python benchmarks/data_schemas_perf.py --output benchmarks/data_schemas_perf.json
+          cat benchmarks/data_schemas_perf.json
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -276,6 +276,7 @@ See: [QUICK_START.md - Verification](QUICK_START.md#-check-results-1-min)
 - Threat Model Notes: [docs/github-action-threat-model.md](docs/github-action-threat-model.md)
 - Action unit test fixtures: [tests/action/fixtures](tests/action/fixtures)
 - Vulnerability DB format and validation: [docs/vulnerability-database-format.md](docs/vulnerability-database-format.md)
+- Data + schemas performance budgets/benchmarks: [docs/data-schemas-performance.md](docs/data-schemas-performance.md)
 
 **Production Setup**
 

--- a/benchmarks/data_schemas_perf.py
+++ b/benchmarks/data_schemas_perf.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class JsonPerfMetrics:
+    path: str
+    bytes: int
+    read_ms: float
+    parse_ms: float
+    vulnerabilities: int | None = None
+    max_pattern_len: int | None = None
+    total_pattern_len: int | None = None
+
+
+def load_json_metrics(path: Path) -> JsonPerfMetrics:
+    start_read = time.perf_counter()
+    raw = path.read_text(encoding="utf-8")
+    end_read = time.perf_counter()
+
+    start_parse = time.perf_counter()
+    payload = json.loads(raw)
+    end_parse = time.perf_counter()
+
+    vulnerabilities = None
+    max_pattern_len = None
+    total_pattern_len = None
+    if isinstance(payload, dict) and isinstance(payload.get("vulnerabilities"), list):
+        vulns = payload.get("vulnerabilities") or []
+        vulnerabilities = len(vulns)
+        patterns = [str(v.get("pattern", "")) for v in vulns if isinstance(v, dict)]
+        if patterns:
+            max_pattern_len = max(len(p) for p in patterns)
+            total_pattern_len = sum(len(p) for p in patterns)
+
+    return JsonPerfMetrics(
+        path=str(path.relative_to(ROOT)).replace("\\", "/"),
+        bytes=path.stat().st_size,
+        read_ms=(end_read - start_read) * 1000.0,
+        parse_ms=(end_parse - start_parse) * 1000.0,
+        vulnerabilities=vulnerabilities,
+        max_pattern_len=max_pattern_len,
+        total_pattern_len=total_pattern_len,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="", help="Optional JSON output file path")
+    args = parser.parse_args()
+
+    targets = [
+        ROOT / "data" / "vulnerability-db.json",
+        ROOT / "tooling" / "sanctifier-cli" / "data" / "vulnerability-db.json",
+        ROOT / "schemas" / "vulnerability-db.json",
+    ]
+
+    report = {
+        "generated_at_epoch_ms": int(time.time() * 1000),
+        "metrics": [asdict(load_json_metrics(p)) for p in targets if p.exists()],
+    }
+
+    out = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        Path(args.output).write_text(out + "\n", encoding="utf-8")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/docs/data-schemas-performance.md
+++ b/docs/data-schemas-performance.md
@@ -1,0 +1,44 @@
+# Data + Schemas Performance Benchmarks & Budgets
+
+This repository treats `data/` and `schemas/` as *production inputs*:
+they ship in the repo, are loaded by tooling, and should remain fast to parse and validate.
+
+This document describes:
+
+- performance budgets enforced in CI
+- a lightweight benchmark script for measuring JSON load/parse cost
+
+## Budgets (enforced in CI)
+
+Budgets are enforced by `tests/vulnerability_db/test_perf_budgets.py` and run in CI via:
+
+```bash
+python -m unittest discover -s tests/vulnerability_db -p "test_*.py"
+```
+
+Current budgets:
+
+- Vulnerability DB JSON size: `<= 5 MiB` per file
+- Vulnerability count: `<= 2000` entries per file
+- Max regex pattern length: `<= 5000` chars per entry
+- Total regex pattern length: `<= 500,000` chars per file
+- Schema JSON size: `<= 512 KiB`
+
+These budgets are intentionally conservative to avoid CI timeouts and keep local tooling responsive.
+
+## Benchmarks (nightly + PR-visible)
+
+The benchmark script measures JSON read/parse time and basic shape metrics:
+
+```bash
+python benchmarks/data_schemas_perf.py
+```
+
+To write a JSON report file:
+
+```bash
+python benchmarks/data_schemas_perf.py --output benchmarks/data_schemas_perf.json
+```
+
+The `Performance Benchmarks` workflow runs this script and records output for tracking.
+

--- a/docs/vulnerability-database-format.md
+++ b/docs/vulnerability-database-format.md
@@ -12,6 +12,8 @@ JSON Schema enforces the document shape, while the CLI loader adds semantic chec
 
 Validation failures include the duplicate or overlapping entry indexes so contributors can fix data issues quickly.
 
+See also: performance budgets and benchmark tooling in [docs/data-schemas-performance.md](data-schemas-performance.md).
+
 ```json
 {
   "version": "1.0.0",

--- a/tests/vulnerability_db/test_perf_budgets.py
+++ b/tests/vulnerability_db/test_perf_budgets.py
@@ -1,0 +1,57 @@
+import json
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DATABASES = [
+    ROOT / "data" / "vulnerability-db.json",
+    ROOT / "tooling" / "sanctifier-cli" / "data" / "vulnerability-db.json",
+]
+
+
+MAX_DB_BYTES = 5 * 1024 * 1024
+MAX_VULNERABILITIES = 2000
+MAX_PATTERN_LEN = 5000
+MAX_TOTAL_PATTERN_LEN = 500_000
+MAX_SCHEMA_BYTES = 512 * 1024
+
+
+class VulnerabilityDatabasePerformanceBudgetsTests(unittest.TestCase):
+    def test_vulnerability_db_size_and_shape_stay_within_budgets(self) -> None:
+        for db_path in DATABASES:
+            with self.subTest(database=str(db_path.relative_to(ROOT))):
+                self.assertTrue(db_path.exists(), f"missing {db_path}")
+                self.assertLessEqual(
+                    db_path.stat().st_size,
+                    MAX_DB_BYTES,
+                    f"{db_path} exceeds size budget ({MAX_DB_BYTES} bytes)",
+                )
+
+                payload = json.loads(db_path.read_text(encoding="utf-8"))
+                vulns = payload.get("vulnerabilities") or []
+                self.assertIsInstance(vulns, list)
+                self.assertLessEqual(
+                    len(vulns),
+                    MAX_VULNERABILITIES,
+                    f"{db_path} exceeds vulnerability count budget ({MAX_VULNERABILITIES})",
+                )
+
+                patterns = [v.get("pattern", "") for v in vulns if isinstance(v, dict)]
+                if patterns:
+                    self.assertLessEqual(max(len(p) for p in patterns), MAX_PATTERN_LEN)
+                    self.assertLessEqual(sum(len(p) for p in patterns), MAX_TOTAL_PATTERN_LEN)
+
+    def test_schema_file_size_stays_within_budget(self) -> None:
+        schema_path = ROOT / "schemas" / "vulnerability-db.json"
+        self.assertTrue(schema_path.exists(), "schemas/vulnerability-db.json missing")
+        self.assertLessEqual(
+            schema_path.stat().st_size,
+            MAX_SCHEMA_BYTES,
+            f"{schema_path} exceeds size budget ({MAX_SCHEMA_BYTES} bytes)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Closes #662

## Summary
Add performance budgets + a lightweight benchmark snapshot for `data/` and `schemas/`, and link the docs from the documentation index.

## Testing
- python -m unittest discover -s tests/vulnerability_db -p "test_*.py"
