### PR TITLE
feat: wasm module boundaries, npm publishing, TS bindings, contracts validation, frontend telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,13 +378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bridge-contract"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,13 +2005,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "oracle-contract"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
 
 [[package]]
 name = "p256"
@@ -3656,13 +3642,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsafe-prng-example"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
 
 [[package]]
 name = "untrusted"

--- a/contracts/runtime-guard-wrapper/src/lib.rs
+++ b/contracts/runtime-guard-wrapper/src/lib.rs
@@ -17,6 +17,51 @@ const CONTRACT_VERSION_KEY: &str = "version";
 /// changes and provide a migration path in `docs/contract-versioning.md`.
 pub const CONTRACT_VERSION: u32 = 1;
 
+// ── Semantic error codes ───────────────────────────────────────────────────────
+//
+// These constants replace raw numeric literals throughout the contract so that
+// a failing test or on-chain event can be matched to a specific guard stage
+// without consulting source code.
+
+/// Pre-execution guard: wrapped contract address has not been set via `init`.
+pub const ERR_WRAPPED_CONTRACT_NOT_SET: u32 = 1;
+
+/// Pre-execution guard: instance storage is missing the wrapped contract key —
+/// indicates storage was cleared or the contract was not properly initialised.
+pub const ERR_STORAGE_INTEGRITY_FAILED: u32 = 2;
+
+/// Execution monitoring: the requested function name is not registered in the
+/// allowed function dispatch table.
+pub const ERR_UNKNOWN_FUNCTION: u32 = 3;
+
+/// Execution monitoring: the argument vector length does not match the expected
+/// arity for the requested function.
+pub const ERR_ARGUMENT_COUNT_MISMATCH: u32 = 4;
+
+// ── Error message helpers ──────────────────────────────────────────────────────
+
+/// Human-readable error descriptions keyed to each semantic error code.
+///
+/// These are intentionally kept in `no_std` (no heap allocations beyond the
+/// string literal itself) so they can be embedded in event data or returned
+/// to callers via the host SDK without requiring `std::string::String`.
+pub mod error_messages {
+    pub const WRAPPED_CONTRACT_NOT_SET: &str =
+        "Guard wrapper has not been initialised: call `init` with a wrapped contract address first";
+
+    pub const STORAGE_INTEGRITY_FAILED: &str =
+        "Instance storage integrity check failed: wrapped contract address key is missing — \
+         the contract may have been deployed without calling `init`";
+
+    pub const UNKNOWN_FUNCTION: &str =
+        "Requested function name is not registered in the guard dispatch table — \
+         only `ping`, `echo`, and `sum` are currently supported";
+
+    pub const ARGUMENT_COUNT_MISMATCH: &str =
+        "Argument count does not match the expected arity for the requested function — \
+         check the function signature in the dispatch table";
+}
+
 mod event_fixtures {
     use soroban_sdk::{Env, Symbol};
 
@@ -148,11 +193,24 @@ impl RuntimeGuardWrapper {
     }
 
     pub fn execute_guarded(env: Env, function_name: Symbol, args: Vec<Val>) -> Result<Val, Error> {
+        Self::validate_function_name(&env, &function_name)?;
         Self::pre_execution_guards(env.clone())?;
         let result = Self::execute_with_monitoring(env.clone(), &function_name, &args)?;
         Self::post_execution_guards(env.clone())?;
         Self::log_execution(env.clone(), &function_name, &result);
         Ok(result)
+    }
+
+    /// Validate that the function name is non-empty and within the allowed
+    /// Symbol length (Soroban Symbols are capped at 32 characters).
+    fn validate_function_name(env: &Env, function_name: &Symbol) -> Result<(), Error> {
+        // A valid function name Symbol must be non-zero when converted to a Val
+        // payload — this catches default/zero Symbol values.
+        let val: Val = function_name.clone().into_val(env);
+        if val.get_payload() == 0 {
+            return Err(Error::from_contract_error(ERR_UNKNOWN_FUNCTION));
+        }
+        Ok(())
     }
 
     fn pre_execution_guards(env: Env) -> Result<(), Error> {
@@ -166,7 +224,7 @@ impl RuntimeGuardWrapper {
                 event_fixtures::EVENT_PRE_EXEC_GUARD,
                 event_fixtures::STATUS_WRAPPED_NOT_SET,
             );
-            return Err(Error::from_contract_error(1));
+            return Err(Error::from_contract_error(ERR_WRAPPED_CONTRACT_NOT_SET));
         }
 
         Self::validate_storage_integrity(env)?;
@@ -188,7 +246,7 @@ impl RuntimeGuardWrapper {
         let wrapped_addr: Option<Address> =
             instance_storage.get(&Symbol::new(&env, WRAPPED_CONTRACT_ADDRESS));
         if wrapped_addr.is_none() {
-            return Err(Error::from_contract_error(2));
+            return Err(Error::from_contract_error(ERR_STORAGE_INTEGRITY_FAILED));
         }
         Ok(())
     }
@@ -214,13 +272,13 @@ impl RuntimeGuardWrapper {
             Some(count) => count,
             None => {
                 Self::record_guard_failure(env.clone(), Symbol::new(&env, "missing_function"));
-                return Err(Error::from_contract_error(3));
+                return Err(Error::from_contract_error(ERR_UNKNOWN_FUNCTION));
             }
         };
 
         if args.len() != expected_arg_count {
             Self::record_guard_failure(env.clone(), Symbol::new(&env, "arg_mismatch"));
-            return Err(Error::from_contract_error(4));
+            return Err(Error::from_contract_error(ERR_ARGUMENT_COUNT_MISMATCH));
         }
 
         let start_tick = env.ledger().timestamp();
@@ -280,13 +338,13 @@ impl RuntimeGuardWrapper {
         }
         if *function_name == sum {
             let left = u32::try_from_val(&env, &args.get(0).unwrap_or(Val::VOID.into()))
-                .map_err(|_| Error::from_contract_error(4))?;
+                .map_err(|_| Error::from_contract_error(ERR_ARGUMENT_COUNT_MISMATCH))?;
             let right = u32::try_from_val(&env, &args.get(1).unwrap_or(Val::VOID.into()))
-                .map_err(|_| Error::from_contract_error(4))?;
+                .map_err(|_| Error::from_contract_error(ERR_ARGUMENT_COUNT_MISMATCH))?;
             return Ok(left.saturating_add(right).into_val(&env));
         }
 
-        Err(Error::from_contract_error(3))
+        Err(Error::from_contract_error(ERR_UNKNOWN_FUNCTION))
     }
 
     fn log_execution(env: Env, function_name: &Symbol, _result: &Val) {

--- a/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_echo_pass_through.1.json
+++ b/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_echo_pass_through.1.json
@@ -1,0 +1,506 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "call_log"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "call_log"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "symbol": "echo"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "exec_metrics"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "exec_metrics"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "u32": 2799898034
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "guard_failures"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "guard_failures"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "invariants_checked"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "invariants_checked"
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "guard_config"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "wrapped_contract_addr"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "wrapper_initialized"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "echo"
+                },
+                {
+                  "vec": [
+                    {
+                      "u32": 42
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "u32": 1
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_multiple_calls_accumulate_stats.1.json
+++ b/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_multiple_calls_accumulate_stats.1.json
@@ -1,0 +1,1022 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "call_log"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "call_log"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "symbol": "ping"
+                    },
+                    {
+                      "symbol": "ping"
+                    },
+                    {
+                      "symbol": "ping"
+                    },
+                    {
+                      "symbol": "ping"
+                    },
+                    {
+                      "symbol": "ping"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "exec_metrics"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "exec_metrics"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "u32": 112235954
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "u32": 112235954
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "u32": 112235954
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "u32": 112235954
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "u32": 112235954
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "guard_failures"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "guard_failures"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "invariants_checked"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "invariants_checked"
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 5
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "guard_config"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "wrapped_contract_addr"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "wrapper_initialized"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "ping"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "symbol": "pong"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "ping"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "symbol": "pong"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "ping"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "symbol": "pong"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "ping"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "symbol": "pong"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "ping"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "symbol": "pong"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "u32": 5
+                },
+                {
+                  "u32": 5
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_ping_round_trip.1.json
+++ b/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_ping_round_trip.1.json
@@ -1,0 +1,502 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "call_log"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "call_log"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "symbol": "ping"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "exec_metrics"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "exec_metrics"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "u32": 112235954
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "guard_failures"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "guard_failures"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "invariants_checked"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "invariants_checked"
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "guard_config"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "wrapped_contract_addr"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "wrapper_initialized"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "ping"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "symbol": "pong"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "u32": 1
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_sum_two_u32_args.1.json
+++ b/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_sum_two_u32_args.1.json
@@ -1,0 +1,509 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "call_log"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "call_log"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "symbol": "sum"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "exec_metrics"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "exec_metrics"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "u32": 1850183602
+                        },
+                        {
+                          "bool": true
+                        },
+                        {
+                          "u64": 0
+                        },
+                        {
+                          "u64": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "guard_failures"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "guard_failures"
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "symbol": "invariants_checked"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "symbol": "invariants_checked"
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "guard_config"
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            },
+                            {
+                              "bool": true
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "wrapped_contract_addr"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "wrapper_initialized"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "sum"
+                },
+                {
+                  "vec": [
+                    {
+                      "u32": 10
+                    },
+                    {
+                      "u32": 20
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "post_exec_guard"
+                },
+                {
+                  "symbol": "passed"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "execution_logged"
+                },
+                {
+                  "symbol": "success"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "u32": 30
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_stats"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "u32": 1
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_uninitialised_contract_returns_error.1.json
+++ b/contracts/runtime-guard-wrapper/test_snapshots/guard_wrapper_sample_uninitialised_contract_returns_error.1.json
@@ -1,0 +1,228 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "ping"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "guard_wrapper"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "pre_exec_guard"
+                },
+                {
+                  "symbol": "wrapped_contract_not_set"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "execute_guarded"
+              }
+            ],
+            "data": {
+              "error": {
+                "contract": 1
+              }
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 1
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating Ok(ScErrorType::Contract) frame-exit to Err"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 1
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "execute_guarded"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "ping"
+                    },
+                    {
+                      "vec": []
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/runtime-guard-wrapper/tests/integration_tests.rs
+++ b/contracts/runtime-guard-wrapper/tests/integration_tests.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 #![allow(unexpected_cfgs)]
 
-use runtime_guard_wrapper::RuntimeGuardWrapper;
+use runtime_guard_wrapper::{
+    RuntimeGuardWrapper, ERR_ARGUMENT_COUNT_MISMATCH, ERR_UNKNOWN_FUNCTION,
+    ERR_WRAPPED_CONTRACT_NOT_SET,
+};
 use soroban_sdk::{
     contract, contractimpl, testutils::Address as _, vec, Address, Env, IntoVal, Symbol, Val, Vec,
 };
@@ -44,6 +47,9 @@ fn setup(env: &Env) -> (RuntimeGuardWrapperHarnessClient<'_>, Address) {
     (client, wrapped)
 }
 
+// ── Error code assertions ──────────────────────────────────────────────────────
+
+/// Unknown function returns ERR_UNKNOWN_FUNCTION (code 3).
 #[test]
 fn execute_guarded_rejects_missing_function_name() {
     let env = Env::default();
@@ -51,19 +57,27 @@ fn execute_guarded_rejects_missing_function_name() {
     let result = client.try_execute_guarded(&Symbol::new(&env, "missing"), &vec![&env]);
 
     assert!(result.is_err());
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(ERR_UNKNOWN_FUNCTION));
     assert_eq!(client.get_stats(), (0, 0, 0));
 }
 
+/// Wrong arity returns ERR_ARGUMENT_COUNT_MISMATCH (code 4).
 #[test]
 fn execute_guarded_rejects_argument_count_mismatch() {
     let env = Env::default();
     let (client, _) = setup(&env);
+    // `ping` expects 0 args; pass 1.
     let args = vec![&env, 7u32.into_val(&env)];
     let result = client.try_execute_guarded(&Symbol::new(&env, "ping"), &args);
 
     assert!(result.is_err());
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(ERR_ARGUMENT_COUNT_MISMATCH));
     assert_eq!(client.get_stats(), (0, 0, 0));
 }
+
+// ── Idempotency ────────────────────────────────────────────────────────────────
 
 #[test]
 fn init_called_twice_is_idempotent() {
@@ -76,6 +90,8 @@ fn init_called_twice_is_idempotent() {
     assert_eq!(client.get_wrapped_contract(), wrapped);
     assert_eq!(client.get_stats(), (0, 0, 0));
 }
+
+// ── Storage budget ─────────────────────────────────────────────────────────────
 
 #[test]
 fn health_check_fails_after_storage_budget_is_exhausted() {
@@ -90,6 +106,8 @@ fn health_check_fails_after_storage_budget_is_exhausted() {
 
     assert!(!client.health_check());
 }
+
+// ── Stats tracking ─────────────────────────────────────────────────────────────
 
 #[test]
 fn get_stats_tracks_successes_and_failures() {
@@ -127,4 +145,92 @@ fn execute_guarded_tracks_wrapped_call_result_errors() {
 
     assert!(result.is_err());
     assert_eq!(client.get_stats(), (0, 0, 0));
+}
+
+// ── Guard wrapper samples ──────────────────────────────────────────────────────
+//
+// The tests below demonstrate the complete guard lifecycle for each supported
+// function.  They serve as living examples that contributors can copy when
+// registering new wrapped functions.
+
+/// Sample: `ping` — zero-argument round-trip through all three guard stages.
+#[test]
+fn guard_wrapper_sample_ping_round_trip() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    // pre-guard + execute + post-guard must all succeed for a valid call.
+    let result = client.execute_guarded(&Symbol::new(&env, "ping"), &vec![&env]);
+    let _ = result; // returns "pong" Symbol
+
+    // invariants_checked incremented by post-execution guard.
+    let (invariants_checked, call_log_len, failures) = client.get_stats();
+    assert_eq!(invariants_checked, 1, "post-guard must increment invariants_checked");
+    assert_eq!(call_log_len, 1, "call must be logged");
+    assert_eq!(failures, 0, "no failures expected");
+}
+
+/// Sample: `echo` — single-argument pass-through.
+#[test]
+fn guard_wrapper_sample_echo_pass_through() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let arg_val: Val = 42u32.into_val(&env);
+    let _ = client.execute_guarded(&Symbol::new(&env, "echo"), &vec![&env, arg_val]);
+
+    let (invariants_checked, call_log_len, failures) = client.get_stats();
+    assert_eq!(invariants_checked, 1);
+    assert_eq!(call_log_len, 1);
+    assert_eq!(failures, 0);
+}
+
+/// Sample: `sum` — two-argument arithmetic with correct types.
+#[test]
+fn guard_wrapper_sample_sum_two_u32_args() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    let result = client.execute_guarded(
+        &Symbol::new(&env, "sum"),
+        &vec![&env, 10u32.into_val(&env), 20u32.into_val(&env)],
+    );
+    let _ = result; // expected: 30u32 as Val
+
+    let (invariants_checked, call_log_len, failures) = client.get_stats();
+    assert_eq!(invariants_checked, 1);
+    assert_eq!(call_log_len, 1);
+    assert_eq!(failures, 0);
+}
+
+/// Sample: error path — confirms ERR_WRAPPED_CONTRACT_NOT_SET is returned when
+/// the contract is accessed without `init`.
+#[test]
+fn guard_wrapper_sample_uninitialised_contract_returns_error() {
+    let env = Env::default();
+    // Register the harness contract but do NOT call init.
+    let contract_id = env.register_contract(None, RuntimeGuardWrapperHarness);
+    let client = RuntimeGuardWrapperHarnessClient::new(&env, &contract_id);
+
+    let result = client.try_execute_guarded(&Symbol::new(&env, "ping"), &vec![&env]);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(ERR_WRAPPED_CONTRACT_NOT_SET));
+}
+
+/// Sample: sequential calls accumulate stats correctly.
+#[test]
+fn guard_wrapper_sample_multiple_calls_accumulate_stats() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    for _ in 0..5 {
+        let _ = client.execute_guarded(&Symbol::new(&env, "ping"), &vec![&env]);
+    }
+
+    let (invariants_checked, call_log_len, failures) = client.get_stats();
+    assert_eq!(invariants_checked, 5);
+    assert_eq!(call_log_len, 5);
+    assert_eq!(failures, 0);
 }

--- a/tooling/sanctifier-wasm/pkg/package.json
+++ b/tooling/sanctifier-wasm/pkg/package.json
@@ -1,1 +1,42 @@
-﻿{"name": "@sanctifier/wasm", "version": "0.1.0", "main": "index.js"}
+{
+  "name": "@sanctifier/wasm",
+  "version": "0.2.0",
+  "description": "WebAssembly bindings for the Sanctifier Soroban smart-contract static-analysis engine",
+  "main": "sanctifier_wasm.js",
+  "types": "sanctifier_wasm.d.ts",
+  "exports": {
+    ".": {
+      "import": "./sanctifier_wasm.js",
+      "types": "./sanctifier_wasm.d.ts"
+    }
+  },
+  "files": [
+    "sanctifier_wasm_bg.wasm",
+    "sanctifier_wasm_bg.wasm.d.ts",
+    "sanctifier_wasm.js",
+    "sanctifier_wasm.d.ts"
+  ],
+  "keywords": [
+    "soroban",
+    "stellar",
+    "smart-contract",
+    "static-analysis",
+    "wasm",
+    "security"
+  ],
+  "author": "HyperSafeD",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HyperSafeD/Sanctifier"
+  },
+  "homepage": "https://github.com/HyperSafeD/Sanctifier/tree/main/tooling/sanctifier-wasm",
+  "bugs": {
+    "url": "https://github.com/HyperSafeD/Sanctifier/issues"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/tooling/sanctifier-wasm/scripts/sync-pkg-version.js
+++ b/tooling/sanctifier-wasm/scripts/sync-pkg-version.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Synchronise pkg/package.json version with the version in Cargo.toml.
+//
+// Run after `wasm-pack build` in CI to ensure the published npm package
+// always carries the same semver as the Rust crate.
+//
+// Usage: node scripts/sync-pkg-version.js
+
+const fs = require("fs");
+const path = require("path");
+
+const cargoPath = path.resolve(__dirname, "..", "Cargo.toml");
+const pkgPath = path.resolve(__dirname, "..", "pkg", "package.json");
+
+const cargo = fs.readFileSync(cargoPath, "utf8");
+const match = cargo.match(/^version\s*=\s*"([^"]+)"/m);
+if (!match) {
+  console.error("ERROR: Could not find version in Cargo.toml");
+  process.exit(1);
+}
+
+const cargoVersion = match[1];
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+
+if (pkg.version === cargoVersion) {
+  console.log(`pkg/package.json already at ${cargoVersion} — nothing to do.`);
+  process.exit(0);
+}
+
+console.log(`Updating pkg/package.json: ${pkg.version} → ${cargoVersion}`);
+pkg.version = cargoVersion;
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+console.log("Done.");

--- a/tooling/sanctifier-wasm/src/analysis.rs
+++ b/tooling/sanctifier-wasm/src/analysis.rs
@@ -1,0 +1,197 @@
+//! Analysis orchestration: runs all passes and builds output structures.
+//!
+//! This module owns the logic for driving `sanctifier-core`, collecting
+//! findings from every pass, assembling the final `AnalysisResult`, and
+//! constructing progress events and cache keys.  It does not perform any
+//! input validation (see [`crate::validation`]) or JS serialisation (see the
+//! top-level WASM API in `lib.rs`).
+
+use sanctifier_core::{finding_codes, Analyzer, SanctifyConfig};
+
+use crate::constants::{CACHE_NAMESPACE, SCHEMA_VERSION};
+use crate::converters;
+use crate::types::{
+    AnalysisResult, Finding, ProgressEvent, ProgressiveAnalysisResult, Summary,
+};
+
+// ── Progress phase table ───────────────────────────────────────────────────────
+
+const PROGRESS_PHASES: [(&str, u8); 5] = [
+    ("Validating source input", 10),
+    ("Parsing and indexing contract", 30),
+    ("Running security passes", 60),
+    ("Aggregating findings", 85),
+    ("Finalizing schema output", 100),
+];
+
+// ── Internal helpers ───────────────────────────────────────────────────────────
+
+fn run_analysis(analyzer: &Analyzer, source: &str) -> AnalysisResult {
+    let auth_gaps = analyzer.scan_auth_gaps(source);
+    let panic_issues = analyzer.scan_panics(source);
+    let arithmetic_issues = analyzer.scan_arithmetic_overflow(source);
+    let size_warnings = analyzer.analyze_ledger_size(source);
+    let unsafe_patterns = analyzer.analyze_unsafe_patterns(source);
+    let storage_collisions = analyzer.scan_storage_collisions(source);
+    let event_issues = analyzer.scan_events(source);
+    let unhandled_results = analyzer.scan_unhandled_results(source);
+    let upgrade_report = analyzer.analyze_upgrade_patterns(source);
+    let sep41_report = analyzer.verify_sep41_interface(source);
+
+    let mut findings: Vec<Finding> = Vec::new();
+
+    for g in &auth_gaps {
+        findings.push(converters::auth_gap(g));
+    }
+    for p in &panic_issues {
+        findings.push(converters::panic_issue(p));
+    }
+    for a in &arithmetic_issues {
+        findings.push(converters::arithmetic(a));
+    }
+    for w in &size_warnings {
+        findings.push(converters::size_warning(w));
+    }
+    for p in &unsafe_patterns {
+        findings.push(converters::unsafe_pattern(p));
+    }
+    for c in &storage_collisions {
+        findings.push(converters::storage_collision(c));
+    }
+    for e in &event_issues {
+        findings.push(converters::event_issue(e));
+    }
+    for r in &unhandled_results {
+        findings.push(converters::unhandled_result(r));
+    }
+    for f in &upgrade_report.findings {
+        findings.push(Finding {
+            code: finding_codes::UPGRADE_RISK,
+            category: "upgrades",
+            message: f.message.clone(),
+            location: Some(f.location.clone()),
+        });
+    }
+    for issue in &sep41_report.issues {
+        findings.push(Finding {
+            code: finding_codes::SEP41_INTERFACE_DEVIATION,
+            category: "token_interface",
+            message: issue.message.clone(),
+            location: Some(issue.location.clone()),
+        });
+    }
+
+    let summary = Summary {
+        total: findings.len(),
+        auth_gaps: auth_gaps.len(),
+        panic_issues: panic_issues.len(),
+        arithmetic_issues: arithmetic_issues.len(),
+        size_warnings: size_warnings.len(),
+        unsafe_patterns: unsafe_patterns.len(),
+        storage_collisions: storage_collisions.len(),
+        event_issues: event_issues.len(),
+        unhandled_results: unhandled_results.len(),
+        upgrade_risks: upgrade_report.findings.len(),
+        sep41_issues: sep41_report.issues.len(),
+        has_critical: false,
+        has_high: !auth_gaps.is_empty() || !upgrade_report.findings.is_empty(),
+    };
+
+    AnalysisResult {
+        findings,
+        summary,
+        schema_version: SCHEMA_VERSION,
+    }
+}
+
+fn build_progress_events(total_findings: usize) -> Vec<ProgressEvent> {
+    PROGRESS_PHASES
+        .iter()
+        .enumerate()
+        .map(|(idx, (phase, percent))| ProgressEvent {
+            phase,
+            percent: *percent,
+            findings_so_far: ((idx + 1) * total_findings) / PROGRESS_PHASES.len(),
+        })
+        .collect()
+}
+
+// ── Public API (called from lib.rs) ───────────────────────────────────────────
+
+/// Run all analysis passes with `SanctifyConfig::default()`.
+pub fn run_analysis_default(source: &str) -> AnalysisResult {
+    let analyzer = Analyzer::new(SanctifyConfig::default());
+    run_analysis(&analyzer, source)
+}
+
+/// Run all analysis passes, deserialising config from JSON (falls back to
+/// `SanctifyConfig::default()` if parsing fails).
+pub fn run_analysis_with_config(config_json: &str, source: &str) -> AnalysisResult {
+    let config: SanctifyConfig = serde_json::from_str(config_json).unwrap_or_default();
+    let analyzer = Analyzer::new(config);
+    run_analysis(&analyzer, source)
+}
+
+/// Run all passes and bundle the result with deterministic progress events.
+pub fn run_analysis_with_progress(source: &str) -> ProgressiveAnalysisResult {
+    let analyzer = Analyzer::new(SanctifyConfig::default());
+    let result = run_analysis(&analyzer, source);
+    let events = build_progress_events(result.summary.total);
+    ProgressiveAnalysisResult { events, result }
+}
+
+/// Return a deterministic cache-bust key (`namespace:pkg_version:schema_version`).
+pub fn build_cache_key() -> String {
+    format!(
+        "{}:{}:{}",
+        CACHE_NAMESPACE,
+        env!("CARGO_PKG_VERSION"),
+        SCHEMA_VERSION
+    )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{CACHE_NAMESPACE, SCHEMA_VERSION};
+
+    #[test]
+    fn cache_key_contains_namespace_and_schema_version() {
+        let key = build_cache_key();
+        assert!(key.contains(CACHE_NAMESPACE));
+        assert!(key.contains(SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn cache_key_has_three_colon_delimited_segments() {
+        let key = build_cache_key();
+        assert_eq!(key.splitn(3, ':').count(), 3);
+    }
+
+    #[test]
+    fn progress_events_match_phase_count() {
+        let events = build_progress_events(10);
+        assert_eq!(events.len(), PROGRESS_PHASES.len());
+    }
+
+    #[test]
+    fn progress_events_end_at_100_percent() {
+        let events = build_progress_events(5);
+        assert_eq!(events.last().unwrap().percent, 100);
+    }
+
+    #[test]
+    fn run_analysis_default_produces_schema_version() {
+        let result = run_analysis_default("fn foo() {}");
+        assert_eq!(result.schema_version, SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn run_analysis_with_invalid_config_falls_back_to_defaults() {
+        // Invalid JSON → falls back to default, should not panic.
+        let result = run_analysis_with_config("{invalid}", "fn foo() {}");
+        assert_eq!(result.schema_version, SCHEMA_VERSION);
+    }
+}

--- a/tooling/sanctifier-wasm/src/constants.rs
+++ b/tooling/sanctifier-wasm/src/constants.rs
@@ -1,0 +1,37 @@
+//! Compile-time constants for the WASM package.
+//!
+//! All tuneable limits and namespace strings live here so they can be
+//! referenced by both the implementation modules and the test suite without
+//! coupling either to internal details of the other.
+
+/// Analysis output schema version (independent of tool version).
+///
+/// Increment only when the JSON output format changes in a breaking way.
+/// See `docs/wasm-versioning-alignment.md` for the full versioning policy.
+pub const SCHEMA_VERSION: &str = "1.0.0";
+
+/// Maximum allowed source code size (10 MB).
+pub const MAX_SOURCE_SIZE: usize = 10 * 1024 * 1024;
+
+/// Minimum required source code size (1 byte).
+pub const MIN_SOURCE_SIZE: usize = 1;
+
+/// Conservative per-invocation memory budget (32 MB).
+///
+/// WASM32 has a 4 GB virtual address space but the default linear memory
+/// grows in 64 KB pages.  Capping working-set estimation to 32 MB prevents
+/// runaway allocations from stalling the browser tab.
+pub const MEMORY_BUDGET_BYTES: usize = 32 * 1024 * 1024;
+
+/// Conservative overhead multiplier for memory budget estimation.
+///
+/// The analyser expands source into several internal representations (tokens,
+/// AST nodes, finding lists).  A factor of 8 covers the worst-case observed
+/// peak without live heap profiling.
+pub const MEMORY_OVERHEAD_FACTOR: usize = 8;
+
+/// Maximum allowed configuration JSON size (1 MB).
+pub const MAX_CONFIG_SIZE: usize = 1024 * 1024;
+
+/// Namespace prefix for browser-side wasm asset caches.
+pub const CACHE_NAMESPACE: &str = "sanctifier-wasm";

--- a/tooling/sanctifier-wasm/src/converters.rs
+++ b/tooling/sanctifier-wasm/src/converters.rs
@@ -1,0 +1,91 @@
+//! Core-type → [`Finding`](crate::types::Finding) conversion helpers.
+//!
+//! Each function takes a reference to a `sanctifier-core` issue type and
+//! returns a normalised [`Finding`] suitable for JS consumers.  Keeping these
+//! here rather than inlining them into the analysis module makes it easy to
+//! audit the mapping between internal codes and output messages in one place.
+
+use sanctifier_core::{
+    finding_codes, ArithmeticIssue, AuthGapIssue, EventIssue, PanicIssue, SizeWarning,
+    StorageCollisionIssue, UnhandledResultIssue, UnsafePattern,
+};
+
+use crate::types::Finding;
+
+pub fn auth_gap(issue: &AuthGapIssue) -> Finding {
+    Finding {
+        code: finding_codes::AUTH_GAP,
+        category: "authentication",
+        message: format!("Missing authentication guard in `{}`", issue.function_name),
+        location: Some(issue.function_name.clone()),
+    }
+}
+
+pub fn panic_issue(p: &PanicIssue) -> Finding {
+    Finding {
+        code: finding_codes::PANIC_USAGE,
+        category: "panic_handling",
+        message: format!("`{}` usage in `{}`", p.issue_type, p.function_name),
+        location: Some(p.location.clone()),
+    }
+}
+
+pub fn arithmetic(a: &ArithmeticIssue) -> Finding {
+    Finding {
+        code: finding_codes::ARITHMETIC_OVERFLOW,
+        category: "arithmetic",
+        message: format!(
+            "Unchecked `{}` in `{}` — {}",
+            a.operation, a.function_name, a.suggestion
+        ),
+        location: Some(a.location.clone()),
+    }
+}
+
+pub fn size_warning(w: &SizeWarning) -> Finding {
+    Finding {
+        code: finding_codes::LEDGER_SIZE_RISK,
+        category: "storage_limits",
+        message: format!(
+            "`{}` estimated size {}B approaches/exceeds ledger limit {}B",
+            w.struct_name, w.estimated_size, w.limit
+        ),
+        location: None,
+    }
+}
+
+pub fn unsafe_pattern(p: &UnsafePattern) -> Finding {
+    Finding {
+        code: finding_codes::UNSAFE_PATTERN,
+        category: "unsafe_patterns",
+        message: format!("{:?} at line {}: {}", p.pattern_type, p.line, p.snippet),
+        location: Some(format!("line:{}", p.line)),
+    }
+}
+
+pub fn storage_collision(c: &StorageCollisionIssue) -> Finding {
+    Finding {
+        code: finding_codes::STORAGE_COLLISION,
+        category: "storage_keys",
+        message: c.message.clone(),
+        location: Some(c.location.clone()),
+    }
+}
+
+pub fn event_issue(e: &EventIssue) -> Finding {
+    Finding {
+        code: finding_codes::EVENT_INCONSISTENCY,
+        category: "events",
+        message: e.message.clone(),
+        location: Some(e.location.clone()),
+    }
+}
+
+pub fn unhandled_result(r: &UnhandledResultIssue) -> Finding {
+    Finding {
+        code: finding_codes::UNHANDLED_RESULT,
+        category: "logic",
+        message: r.message.clone(),
+        location: Some(r.location.clone()),
+    }
+}

--- a/tooling/sanctifier-wasm/src/lib.rs
+++ b/tooling/sanctifier-wasm/src/lib.rs
@@ -3,6 +3,17 @@
 //! Compiled with `wasm-pack build --target web` this crate produces the
 //! `@sanctifier/wasm` npm package consumed by the frontend dashboard.
 //!
+//! # Module layout
+//!
+//! | Module        | Responsibility                                         |
+//! |---------------|--------------------------------------------------------|
+//! | `constants`   | Compile-time limits, namespace strings, version pins  |
+//! | `validation`  | Input guard functions (source size, memory budget, config) |
+//! | `types`       | Serialisable output structs returned to JS consumers  |
+//! | `converters`  | Core-type → [`types::Finding`] conversion helpers     |
+//! | `analysis`    | Orchestration of analysis passes, progress, cache key |
+//! | *(top-level)* | `#[wasm_bindgen]` public API surface                  |
+//!
 //! # Exported functions
 //!
 //! * [`analyze`] — run all analysis passes with default config.
@@ -12,372 +23,38 @@
 //! * [`schema_version`] — return the analysis output schema version.
 //! * [`finding_codes`] — return the finding code catalogue.
 //! * [`default_config_json`] — return default config JSON for easy customization.
+//! * [`asset_cache_key`] — return a deterministic browser cache-bust key.
+//! * [`cache_metadata`] — return full cache metadata for offline-first consumers.
 
-use sanctifier_core::{
-    finding_codes, Analyzer, ArithmeticIssue, AuthGapIssue, EventIssue, PanicIssue, SanctifyConfig,
-    SizeWarning, StorageCollisionIssue, UnhandledResultIssue, UnsafePattern,
-};
-use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-// ── Constants ──────────────────────────────────────────────────────────────────
+// ── Module declarations ────────────────────────────────────────────────────────
 
-/// Analysis output schema version (independent of tool version).
-const SCHEMA_VERSION: &str = "1.0.0";
+pub mod constants;
+pub mod validation;
+pub mod types;
+mod converters;
+mod analysis;
 
-/// Maximum allowed source code size (10 MB).
-const MAX_SOURCE_SIZE: usize = 10 * 1024 * 1024;
+// Re-export the public API types so consumers can import them directly.
+pub use types::{
+    AnalysisResult, CacheMetadata, ErrorResponse, Finding, ProgressEvent,
+    ProgressiveAnalysisResult, Summary,
+};
 
-/// Minimum required source code size (1 byte).
-const MIN_SOURCE_SIZE: usize = 1;
+// ── Internal wiring ────────────────────────────────────────────────────────────
 
-/// Conservative per-invocation memory budget (32 MB).
-///
-/// WASM32 has a 4 GB virtual address space but the default linear memory
-/// grows in 64 KB pages.  Capping working-set estimation to 32 MB prevents
-/// runaway allocations from stalling the browser tab.  The heuristic
-/// (`MEMORY_OVERHEAD_FACTOR × source_len`) is deliberately pessimistic so
-/// the check fires before an actual OOM rather than after.
-const MEMORY_BUDGET_BYTES: usize = 32 * 1024 * 1024;
-
-/// Conservative multiplier: the analyser expands source into several internal
-/// representations (tokens, AST nodes, finding lists).  A factor of 8 covers
-/// the worst-case observed peak without live heap profiling.
-const MEMORY_OVERHEAD_FACTOR: usize = 8;
-
-/// Namespace prefix for browser-side wasm asset caches.
-const CACHE_NAMESPACE: &str = "sanctifier-wasm";
-
-// Improve panic messages in the browser console.
 fn set_panic_hook() {
     console_error_panic_hook::set_once();
 }
 
-// ── Input validation ───────────────────────────────────────────────────────────
-
-/// Validate source code input.
-///
-/// # Errors
-/// Returns a descriptive error message if validation fails.
-fn validate_source(source: &str) -> Result<(), String> {
-    let len = source.len();
-
-    if len < MIN_SOURCE_SIZE {
-        return Err("Source code cannot be empty".to_string());
-    }
-
-    if len > MAX_SOURCE_SIZE {
-        return Err(format!(
-            "Source code exceeds maximum size of {} bytes (got {} bytes)",
-            MAX_SOURCE_SIZE, len
-        ));
-    }
-
-    Ok(())
-}
-
-/// Estimate worst-case heap usage for the given source length and verify it
-/// fits within `MEMORY_BUDGET_BYTES`.
-///
-/// # Errors
-/// Returns an `MEMORY_BUDGET_EXCEEDED` error string when the estimated working
-/// set would exceed the budget.  This is a pre-flight check — it fires before
-/// any allocation so the WASM linear memory is never exhausted silently.
-fn check_memory_budget(source_len: usize) -> Result<(), String> {
-    let estimated = source_len.saturating_mul(MEMORY_OVERHEAD_FACTOR);
-    if estimated > MEMORY_BUDGET_BYTES {
-        return Err(format!(
-            "Estimated working set {} bytes exceeds memory budget of {} bytes. \
-             Split the contract into smaller files.",
-            estimated, MEMORY_BUDGET_BYTES
-        ));
-    }
-    Ok(())
-}
-
-/// Validate configuration JSON.
-///
-/// # Errors
-/// Returns a descriptive error message if validation fails.
-fn validate_config_json(config_json: &str) -> Result<(), String> {
-    if config_json.trim().is_empty() {
-        return Ok(());
-    }
-
-    if config_json.len() > 1024 * 1024 {
-        return Err("Configuration JSON exceeds maximum size of 1 MB".to_string());
-    }
-
-    Ok(())
-}
-
-// ── Output types ──────────────────────────────────────────────────────────────
-
-/// Error response for validation or processing failures.
-#[derive(Serialize)]
-pub struct ErrorResponse {
-    /// Error code (e.g., "INVALID_INPUT", "PARSE_ERROR").
-    pub error_code: String,
-    /// Human-readable error message.
-    pub message: String,
-    /// Schema version for consistency.
-    pub schema_version: &'static str,
-}
-
-/// A single finding emitted by any analysis pass, normalised for JS consumers.
-#[derive(Serialize)]
-pub struct Finding {
-    /// Canonical code (`S000`–`S012`).
-    pub code: &'static str,
-    /// Broad category string (matches the finding-code catalogue).
-    pub category: &'static str,
-    /// Human-readable description of the issue.
-    pub message: String,
-    /// Source location string when available (e.g. `"function_name:line"`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub location: Option<String>,
-}
-
-/// Top-level result returned by [`analyze`] and [`analyze_with_config`].
-#[derive(Serialize)]
-pub struct AnalysisResult {
-    /// Flat list of all findings across every analysis pass.
-    pub findings: Vec<Finding>,
-    /// Pre-computed counts so JS consumers don't have to iterate.
-    pub summary: Summary,
-    /// Schema version for versioning alignment.
-    pub schema_version: &'static str,
-}
-
-/// Aggregate counts included in every [`AnalysisResult`].
-#[derive(Serialize)]
-pub struct Summary {
-    pub total: usize,
-    pub auth_gaps: usize,
-    pub panic_issues: usize,
-    pub arithmetic_issues: usize,
-    pub size_warnings: usize,
-    pub unsafe_patterns: usize,
-    pub storage_collisions: usize,
-    pub event_issues: usize,
-    pub unhandled_results: usize,
-    pub upgrade_risks: usize,
-    pub sep41_issues: usize,
-    pub has_critical: bool,
-    pub has_high: bool,
-}
-
-/// Progress event emitted by [`analyze_with_progress`].
-#[derive(Serialize)]
-pub struct ProgressEvent {
-    pub phase: &'static str,
-    pub percent: u8,
-    pub findings_so_far: usize,
-}
-
-/// Progressive response shape for browsers rendering partial progress.
-#[derive(Serialize)]
-pub struct ProgressiveAnalysisResult {
-    pub events: Vec<ProgressEvent>,
-    pub result: AnalysisResult,
-}
-
-/// Minimal metadata required by browser cache layers.
-#[derive(Serialize)]
-pub struct CacheMetadata {
-    pub package: &'static str,
-    pub version: &'static str,
-    pub schema_version: &'static str,
-    pub cache_key: String,
-}
-
-// ── Helpers to convert core types into Finding ───────────────────────────────
-
-fn auth_gap_finding(issue: &AuthGapIssue) -> Finding {
-    Finding {
-        code: finding_codes::AUTH_GAP,
-        category: "authentication",
-        message: format!("Missing authentication guard in `{}`", issue.function_name),
-        location: Some(issue.function_name.clone()),
-    }
-}
-
-fn panic_finding(p: &PanicIssue) -> Finding {
-    Finding {
-        code: finding_codes::PANIC_USAGE,
-        category: "panic_handling",
-        message: format!("`{}` usage in `{}`", p.issue_type, p.function_name),
-        location: Some(p.location.clone()),
-    }
-}
-
-fn arithmetic_finding(a: &ArithmeticIssue) -> Finding {
-    Finding {
-        code: finding_codes::ARITHMETIC_OVERFLOW,
-        category: "arithmetic",
-        message: format!(
-            "Unchecked `{}` in `{}` — {}",
-            a.operation, a.function_name, a.suggestion
-        ),
-        location: Some(a.location.clone()),
-    }
-}
-
-fn size_finding(w: &SizeWarning) -> Finding {
-    Finding {
-        code: finding_codes::LEDGER_SIZE_RISK,
-        category: "storage_limits",
-        message: format!(
-            "`{}` estimated size {}B approaches/exceeds ledger limit {}B",
-            w.struct_name, w.estimated_size, w.limit
-        ),
-        location: None,
-    }
-}
-
-fn unsafe_finding(p: &UnsafePattern) -> Finding {
-    Finding {
-        code: finding_codes::UNSAFE_PATTERN,
-        category: "unsafe_patterns",
-        message: format!("{:?} at line {}: {}", p.pattern_type, p.line, p.snippet),
-        location: Some(format!("line:{}", p.line)),
-    }
-}
-
-fn collision_finding(c: &StorageCollisionIssue) -> Finding {
-    Finding {
-        code: finding_codes::STORAGE_COLLISION,
-        category: "storage_keys",
-        message: c.message.clone(),
-        location: Some(c.location.clone()),
-    }
-}
-
-fn event_finding(e: &EventIssue) -> Finding {
-    Finding {
-        code: finding_codes::EVENT_INCONSISTENCY,
-        category: "events",
-        message: e.message.clone(),
-        location: Some(e.location.clone()),
-    }
-}
-
-fn unhandled_finding(r: &UnhandledResultIssue) -> Finding {
-    Finding {
-        code: finding_codes::UNHANDLED_RESULT,
-        category: "logic",
-        message: r.message.clone(),
-        location: Some(r.location.clone()),
-    }
-}
-
-// ── Core analysis logic ───────────────────────────────────────────────────────
-
-fn run_analysis(analyzer: &Analyzer, source: &str) -> AnalysisResult {
-    let auth_gaps = analyzer.scan_auth_gaps(source);
-    let panic_issues = analyzer.scan_panics(source);
-    let arithmetic_issues = analyzer.scan_arithmetic_overflow(source);
-    let size_warnings = analyzer.analyze_ledger_size(source);
-    let unsafe_patterns = analyzer.analyze_unsafe_patterns(source);
-    let storage_collisions = analyzer.scan_storage_collisions(source);
-    let event_issues = analyzer.scan_events(source);
-    let unhandled_results = analyzer.scan_unhandled_results(source);
-    let upgrade_report = analyzer.analyze_upgrade_patterns(source);
-    let sep41_report = analyzer.verify_sep41_interface(source);
-
-    let mut findings: Vec<Finding> = Vec::new();
-
-    for g in &auth_gaps {
-        findings.push(auth_gap_finding(g));
-    }
-    for p in &panic_issues {
-        findings.push(panic_finding(p));
-    }
-    for a in &arithmetic_issues {
-        findings.push(arithmetic_finding(a));
-    }
-    for w in &size_warnings {
-        findings.push(size_finding(w));
-    }
-    for p in &unsafe_patterns {
-        findings.push(unsafe_finding(p));
-    }
-    for c in &storage_collisions {
-        findings.push(collision_finding(c));
-    }
-    for e in &event_issues {
-        findings.push(event_finding(e));
-    }
-    for r in &unhandled_results {
-        findings.push(unhandled_finding(r));
-    }
-    for f in &upgrade_report.findings {
-        findings.push(Finding {
-            code: finding_codes::UPGRADE_RISK,
-            category: "upgrades",
-            message: f.message.clone(),
-            location: Some(f.location.clone()),
-        });
-    }
-    for issue in &sep41_report.issues {
-        findings.push(Finding {
-            code: finding_codes::SEP41_INTERFACE_DEVIATION,
-            category: "token_interface",
-            message: issue.message.clone(),
-            location: Some(issue.location.clone()),
-        });
-    }
-
-    let summary = Summary {
-        total: findings.len(),
-        auth_gaps: auth_gaps.len(),
-        panic_issues: panic_issues.len(),
-        arithmetic_issues: arithmetic_issues.len(),
-        size_warnings: size_warnings.len(),
-        unsafe_patterns: unsafe_patterns.len(),
-        storage_collisions: storage_collisions.len(),
-        event_issues: event_issues.len(),
-        unhandled_results: unhandled_results.len(),
-        upgrade_risks: upgrade_report.findings.len(),
-        sep41_issues: sep41_report.issues.len(),
-        has_critical: false, // wasm passes don't produce critical-severity findings
-        has_high: !auth_gaps.is_empty() || !upgrade_report.findings.is_empty(),
+fn make_error(error_code: &str, message: String) -> JsValue {
+    let error = ErrorResponse {
+        error_code: error_code.to_string(),
+        message,
+        schema_version: constants::SCHEMA_VERSION,
     };
-
-    AnalysisResult {
-        findings,
-        summary,
-        schema_version: SCHEMA_VERSION,
-    }
-}
-
-const PROGRESS_PHASES: [(&str, u8); 5] = [
-    ("Validating source input", 10),
-    ("Parsing and indexing contract", 30),
-    ("Running security passes", 60),
-    ("Aggregating findings", 85),
-    ("Finalizing schema output", 100),
-];
-
-fn build_progress_events(total_findings: usize) -> Vec<ProgressEvent> {
-    PROGRESS_PHASES
-        .iter()
-        .enumerate()
-        .map(|(idx, (phase, percent))| ProgressEvent {
-            phase,
-            percent: *percent,
-            findings_so_far: ((idx + 1) * total_findings) / PROGRESS_PHASES.len(),
-        })
-        .collect()
-}
-
-fn build_cache_key() -> String {
-    format!(
-        "{}:{}:{}",
-        CACHE_NAMESPACE,
-        env!("CARGO_PKG_VERSION"),
-        SCHEMA_VERSION
-    )
+    serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL)
 }
 
 // ── Public WASM API ───────────────────────────────────────────────────────────
@@ -393,32 +70,22 @@ fn build_cache_key() -> String {
 /// }
 /// ```
 ///
-/// # Errors
-/// Returns an error object if source code validation fails.
+/// On validation failure the return value is shaped as [`ErrorResponse`]:
+/// ```json
+/// { "error_code": "INVALID_INPUT", "message": "...", "schema_version": "1.0.0" }
+/// ```
 #[wasm_bindgen]
 pub fn analyze(source: &str) -> JsValue {
     set_panic_hook();
 
-    if let Err(err) = validate_source(source) {
-        let error = ErrorResponse {
-            error_code: "INVALID_INPUT".to_string(),
-            message: err,
-            schema_version: SCHEMA_VERSION,
-        };
-        return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
+    if let Err(msg) = validation::validate_source(source) {
+        return make_error("INVALID_INPUT", msg);
+    }
+    if let Err(msg) = validation::check_memory_budget(source.len()) {
+        return make_error("MEMORY_BUDGET_EXCEEDED", msg);
     }
 
-    if let Err(err) = check_memory_budget(source.len()) {
-        let error = ErrorResponse {
-            error_code: "MEMORY_BUDGET_EXCEEDED".to_string(),
-            message: err,
-            schema_version: SCHEMA_VERSION,
-        };
-        return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
-    }
-
-    let analyzer = Analyzer::new(SanctifyConfig::default());
-    let result = run_analysis(&analyzer, source);
+    let result = analysis::run_analysis_default(source);
     serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
 }
 
@@ -427,68 +94,39 @@ pub fn analyze(source: &str) -> JsValue {
 /// Falls back to `SanctifyConfig::default()` if `config_json` cannot be parsed.
 ///
 /// # Errors
-/// Returns an error object if input validation fails.
+/// Returns an [`ErrorResponse`] object if input validation fails.
 #[wasm_bindgen]
 pub fn analyze_with_config(config_json: &str, source: &str) -> JsValue {
     set_panic_hook();
 
-    if let Err(err) = validate_config_json(config_json) {
-        let error = ErrorResponse {
-            error_code: "INVALID_CONFIG".to_string(),
-            message: err,
-            schema_version: SCHEMA_VERSION,
-        };
-        return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
+    if let Err(msg) = validation::validate_config_json(config_json) {
+        return make_error("INVALID_CONFIG", msg);
+    }
+    if let Err(msg) = validation::validate_source(source) {
+        return make_error("INVALID_INPUT", msg);
+    }
+    if let Err(msg) = validation::check_memory_budget(source.len()) {
+        return make_error("MEMORY_BUDGET_EXCEEDED", msg);
     }
 
-    if let Err(err) = validate_source(source) {
-        let error = ErrorResponse {
-            error_code: "INVALID_INPUT".to_string(),
-            message: err,
-            schema_version: SCHEMA_VERSION,
-        };
-        return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
-    }
-
-    if let Err(err) = check_memory_budget(source.len()) {
-        let error = ErrorResponse {
-            error_code: "MEMORY_BUDGET_EXCEEDED".to_string(),
-            message: err,
-            schema_version: SCHEMA_VERSION,
-        };
-        return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
-    }
-
-    let config: SanctifyConfig = serde_json::from_str(config_json).unwrap_or_default();
-    let analyzer = Analyzer::new(config);
-    let result = run_analysis(&analyzer, source);
+    let result = analysis::run_analysis_with_config(config_json, source);
     serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
 }
 
 /// Analyse with deterministic progress snapshots for streaming-like UX.
 ///
-/// This returns both progress events and the final [`AnalysisResult`], allowing
-/// frontend clients to show partial progress while keeping output deterministic.
+/// Returns a [`ProgressiveAnalysisResult`] containing both progress events and
+/// the final [`AnalysisResult`], allowing frontend clients to render partial
+/// progress while output remains deterministic and cacheable.
 #[wasm_bindgen]
 pub fn analyze_with_progress(source: &str) -> JsValue {
     set_panic_hook();
 
-    if let Err(err) = validate_source(source) {
-        let error = ErrorResponse {
-            error_code: "INVALID_INPUT".to_string(),
-            message: err,
-            schema_version: SCHEMA_VERSION,
-        };
-        return serde_wasm_bindgen::to_value(&error).unwrap_or(JsValue::NULL);
+    if let Err(msg) = validation::validate_source(source) {
+        return make_error("INVALID_INPUT", msg);
     }
 
-    let analyzer = Analyzer::new(SanctifyConfig::default());
-    let result = run_analysis(&analyzer, source);
-    let progressive = ProgressiveAnalysisResult {
-        events: build_progress_events(result.summary.total),
-        result,
-    };
-
+    let progressive = analysis::run_analysis_with_progress(source);
     serde_wasm_bindgen::to_value(&progressive).unwrap_or(JsValue::NULL)
 }
 
@@ -509,26 +147,27 @@ pub fn version() -> String {
 
 /// Return the analysis output schema version (independent of tool version).
 ///
-/// This version is used for JSON output compatibility and should be incremented
-/// when the output format changes in a breaking way.
+/// Increment this only when the JSON output format changes in a breaking way.
+/// See `docs/wasm-versioning-alignment.md` for the versioning policy.
 #[wasm_bindgen]
 pub fn schema_version() -> String {
-    SCHEMA_VERSION.to_string()
+    constants::SCHEMA_VERSION.to_string()
 }
 
 /// Return default config JSON for easy copy/edit in browser tooling.
 #[wasm_bindgen]
 pub fn default_config_json() -> String {
-    serde_json::to_string_pretty(&SanctifyConfig::default()).unwrap_or_else(|_| "{}".to_string())
+    serde_json::to_string_pretty(&sanctifier_core::SanctifyConfig::default())
+        .unwrap_or_else(|_| "{}".to_string())
 }
 
 /// Return a deterministic cache key for wasm module assets.
 ///
-/// Frontend loaders can use this value to bust stale service-worker and
-/// CacheStorage entries whenever the package or schema version changes.
+/// Frontend loaders use this to bust stale service-worker and CacheStorage
+/// entries whenever the package or schema version changes.
 #[wasm_bindgen]
 pub fn asset_cache_key() -> String {
-    build_cache_key()
+    analysis::build_cache_key()
 }
 
 /// Return cache metadata for offline-first consumers.
@@ -537,17 +176,19 @@ pub fn cache_metadata() -> JsValue {
     let metadata = CacheMetadata {
         package: "sanctifier-wasm",
         version: env!("CARGO_PKG_VERSION"),
-        schema_version: SCHEMA_VERSION,
-        cache_key: build_cache_key(),
+        schema_version: constants::SCHEMA_VERSION,
+        cache_key: analysis::build_cache_key(),
     };
     serde_wasm_bindgen::to_value(&metadata).unwrap_or(JsValue::NULL)
 }
 
-// ── Native unit tests (compile for host, not wasm32) ─────────────────────────
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::{check_memory_budget, validate_source};
+    use crate::constants::{MAX_SOURCE_SIZE, MEMORY_BUDGET_BYTES, MEMORY_OVERHEAD_FACTOR};
 
     // ── validate_source ───────────────────────────────────────────────────────
 
@@ -577,14 +218,11 @@ mod tests {
 
     #[test]
     fn memory_budget_accepts_small_source() {
-        // 1 KB source → 8 KB estimated — well within 32 MB budget.
         assert!(check_memory_budget(1024).is_ok());
     }
 
     #[test]
     fn memory_budget_accepts_source_at_exact_limit() {
-        // MEMORY_BUDGET_BYTES / MEMORY_OVERHEAD_FACTOR is the largest source
-        // that still passes the budget check.
         let max_ok = MEMORY_BUDGET_BYTES / MEMORY_OVERHEAD_FACTOR;
         assert!(check_memory_budget(max_ok).is_ok());
     }
@@ -606,17 +244,44 @@ mod tests {
 
     #[test]
     fn memory_budget_saturating_mul_does_not_overflow() {
-        // usize::MAX would overflow a plain multiply — saturating_mul must handle it.
         let result = check_memory_budget(usize::MAX);
-        assert!(result.is_err()); // saturates above budget, correctly rejected
+        assert!(result.is_err());
     }
 
     // ── build_cache_key ───────────────────────────────────────────────────────
 
     #[test]
     fn cache_key_contains_namespace_and_versions() {
-        let key = build_cache_key();
-        assert!(key.contains(CACHE_NAMESPACE));
-        assert!(key.contains(SCHEMA_VERSION));
+        let key = analysis::build_cache_key();
+        assert!(key.contains(constants::CACHE_NAMESPACE));
+        assert!(key.contains(constants::SCHEMA_VERSION));
+    }
+
+    // ── Module boundary: public re-exports are accessible ────────────────────
+
+    #[test]
+    fn types_module_re_exports_are_accessible() {
+        // Ensures the public module boundary is stable; adding a new type here
+        // will cause a compile error if the module layout changes unexpectedly.
+        let _ = ErrorResponse {
+            error_code: "TEST".to_string(),
+            message: "test".to_string(),
+            schema_version: constants::SCHEMA_VERSION,
+        };
+        let _ = Summary {
+            total: 0,
+            auth_gaps: 0,
+            panic_issues: 0,
+            arithmetic_issues: 0,
+            size_warnings: 0,
+            unsafe_patterns: 0,
+            storage_collisions: 0,
+            event_issues: 0,
+            unhandled_results: 0,
+            upgrade_risks: 0,
+            sep41_issues: 0,
+            has_critical: false,
+            has_high: false,
+        };
     }
 }

--- a/tooling/sanctifier-wasm/src/types.rs
+++ b/tooling/sanctifier-wasm/src/types.rs
@@ -1,0 +1,101 @@
+//! Serialisable output structs returned to JS consumers.
+//!
+//! All types implement [`serde::Serialize`] so they can be converted to
+//! `JsValue` via `serde-wasm-bindgen`.  They are intentionally decoupled from
+//! the `sanctifier-core` types so the WASM public API surface can evolve
+//! independently of internal analyser structures.
+
+use serde::Serialize;
+
+/// Error response for validation or processing failures.
+///
+/// ```json
+/// { "error_code": "INVALID_INPUT", "message": "...", "schema_version": "1.0.0" }
+/// ```
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    /// Machine-readable code (e.g. `"INVALID_INPUT"`, `"PARSE_ERROR"`).
+    pub error_code: String,
+    /// Human-readable description forwarded to the JS caller.
+    pub message: String,
+    /// Schema version for response envelope consistency.
+    pub schema_version: &'static str,
+}
+
+/// A single finding emitted by any analysis pass, normalised for JS consumers.
+#[derive(Serialize)]
+pub struct Finding {
+    /// Canonical code (`S000`–`S012`).
+    pub code: &'static str,
+    /// Broad category string (matches the finding-code catalogue).
+    pub category: &'static str,
+    /// Human-readable description of the issue.
+    pub message: String,
+    /// Source location string when available (e.g. `"function_name:line"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+}
+
+/// Top-level result returned by [`analyze`](crate::analyze) and
+/// [`analyze_with_config`](crate::analyze_with_config).
+#[derive(Serialize)]
+pub struct AnalysisResult {
+    /// Flat list of all findings across every analysis pass.
+    pub findings: Vec<Finding>,
+    /// Pre-computed counts so JS consumers don't have to iterate.
+    pub summary: Summary,
+    /// Schema version for versioning alignment.
+    pub schema_version: &'static str,
+}
+
+/// Aggregate counts included in every [`AnalysisResult`].
+#[derive(Serialize)]
+pub struct Summary {
+    pub total: usize,
+    pub auth_gaps: usize,
+    pub panic_issues: usize,
+    pub arithmetic_issues: usize,
+    pub size_warnings: usize,
+    pub unsafe_patterns: usize,
+    pub storage_collisions: usize,
+    pub event_issues: usize,
+    pub unhandled_results: usize,
+    pub upgrade_risks: usize,
+    pub sep41_issues: usize,
+    pub has_critical: bool,
+    pub has_high: bool,
+}
+
+/// Progress event emitted by
+/// [`analyze_with_progress`](crate::analyze_with_progress).
+#[derive(Serialize)]
+pub struct ProgressEvent {
+    /// Phase label shown in the UI (e.g. `"Running security passes"`).
+    pub phase: &'static str,
+    /// Completion percentage `[0, 100]`.
+    pub percent: u8,
+    /// Running finding count at this phase boundary.
+    pub findings_so_far: usize,
+}
+
+/// Progressive response for browsers rendering partial progress.
+#[derive(Serialize)]
+pub struct ProgressiveAnalysisResult {
+    /// Ordered sequence of phase checkpoints emitted before the final result.
+    pub events: Vec<ProgressEvent>,
+    /// Full analysis result available once all phases complete.
+    pub result: AnalysisResult,
+}
+
+/// Minimal metadata required by browser cache layers.
+#[derive(Serialize)]
+pub struct CacheMetadata {
+    /// npm package name (`"sanctifier-wasm"`).
+    pub package: &'static str,
+    /// Crate semver version.
+    pub version: &'static str,
+    /// Analysis output schema version.
+    pub schema_version: &'static str,
+    /// Deterministic cache-bust key derived from package + schema versions.
+    pub cache_key: String,
+}

--- a/tooling/sanctifier-wasm/src/validation.rs
+++ b/tooling/sanctifier-wasm/src/validation.rs
@@ -1,0 +1,152 @@
+//! Input guard functions for the WASM public API.
+//!
+//! Each function returns `Ok(())` on success or `Err(String)` with a
+//! human-readable message that is forwarded directly to JS callers via
+//! [`ErrorResponse`](crate::types::ErrorResponse).
+
+use crate::constants::{
+    MAX_CONFIG_SIZE, MAX_SOURCE_SIZE, MEMORY_BUDGET_BYTES, MEMORY_OVERHEAD_FACTOR, MIN_SOURCE_SIZE,
+};
+
+/// Validate source code input against size limits.
+///
+/// # Errors
+/// - `"Source code cannot be empty"` — when `source` is zero bytes.
+/// - `"Source code exceeds maximum size of N bytes (got M bytes)"` — when
+///   `source.len() > MAX_SOURCE_SIZE`.
+pub fn validate_source(source: &str) -> Result<(), String> {
+    let len = source.len();
+
+    if len < MIN_SOURCE_SIZE {
+        return Err("Source code cannot be empty".to_string());
+    }
+
+    if len > MAX_SOURCE_SIZE {
+        return Err(format!(
+            "Source code exceeds maximum size of {} bytes (got {} bytes)",
+            MAX_SOURCE_SIZE, len
+        ));
+    }
+
+    Ok(())
+}
+
+/// Estimate worst-case heap usage and verify it fits within `MEMORY_BUDGET_BYTES`.
+///
+/// This is a pre-flight check — it fires *before* any allocation so the WASM
+/// linear memory is never exhausted silently.
+///
+/// # Errors
+/// Returns a `"MEMORY_BUDGET_EXCEEDED"` message when the estimated working set
+/// (`source_len × MEMORY_OVERHEAD_FACTOR`) exceeds `MEMORY_BUDGET_BYTES`.
+pub fn check_memory_budget(source_len: usize) -> Result<(), String> {
+    let estimated = source_len.saturating_mul(MEMORY_OVERHEAD_FACTOR);
+    if estimated > MEMORY_BUDGET_BYTES {
+        return Err(format!(
+            "Estimated working set {} bytes exceeds memory budget of {} bytes. \
+             Split the contract into smaller files.",
+            estimated, MEMORY_BUDGET_BYTES
+        ));
+    }
+    Ok(())
+}
+
+/// Validate configuration JSON against size limits.
+///
+/// An empty or whitespace-only string is accepted (caller falls back to defaults).
+///
+/// # Errors
+/// - `"Configuration JSON exceeds maximum size of 1 MB"` — when
+///   `config_json.len() > MAX_CONFIG_SIZE`.
+pub fn validate_config_json(config_json: &str) -> Result<(), String> {
+    if config_json.trim().is_empty() {
+        return Ok(());
+    }
+
+    if config_json.len() > MAX_CONFIG_SIZE {
+        return Err(format!(
+            "Configuration JSON exceeds maximum size of {} bytes",
+            MAX_CONFIG_SIZE
+        ));
+    }
+
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{MAX_SOURCE_SIZE, MEMORY_BUDGET_BYTES, MEMORY_OVERHEAD_FACTOR};
+
+    #[test]
+    fn validate_source_empty_returns_err() {
+        assert!(validate_source("").is_err());
+    }
+
+    #[test]
+    fn validate_source_single_byte_ok() {
+        assert!(validate_source("x").is_ok());
+    }
+
+    #[test]
+    fn validate_source_at_max_size_ok() {
+        assert!(validate_source(&"x".repeat(MAX_SOURCE_SIZE)).is_ok());
+    }
+
+    #[test]
+    fn validate_source_one_over_max_err() {
+        let result = validate_source(&"x".repeat(MAX_SOURCE_SIZE + 1));
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("exceeds maximum size"));
+    }
+
+    #[test]
+    fn memory_budget_small_source_ok() {
+        assert!(check_memory_budget(1024).is_ok());
+    }
+
+    #[test]
+    fn memory_budget_exact_limit_ok() {
+        let max_ok = MEMORY_BUDGET_BYTES / MEMORY_OVERHEAD_FACTOR;
+        assert!(check_memory_budget(max_ok).is_ok());
+    }
+
+    #[test]
+    fn memory_budget_one_over_limit_err() {
+        let just_over = MEMORY_BUDGET_BYTES / MEMORY_OVERHEAD_FACTOR + 1;
+        let result = check_memory_budget(just_over);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("memory budget"));
+    }
+
+    #[test]
+    fn memory_budget_usize_max_does_not_overflow() {
+        assert!(check_memory_budget(usize::MAX).is_err());
+    }
+
+    #[test]
+    fn validate_config_empty_string_ok() {
+        assert!(validate_config_json("").is_ok());
+    }
+
+    #[test]
+    fn validate_config_whitespace_only_ok() {
+        assert!(validate_config_json("   ").is_ok());
+    }
+
+    #[test]
+    fn validate_config_oversized_err() {
+        let big = "x".repeat(MAX_CONFIG_SIZE + 1);
+        let result = validate_config_json(&big);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("exceeds maximum size"));
+    }
+
+    #[test]
+    fn validate_config_at_max_size_ok() {
+        assert!(validate_config_json(&"x".repeat(MAX_CONFIG_SIZE)).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses four hardening work items across `tooling/sanctifier-wasm`, `contracts/runtime-guard-wrapper`, and `frontend`.

---

### #550 — tooling/sanctifier-wasm: Refactor for clearer module boundaries (package publishing strategy)

- Split the flat `lib.rs` into five explicit Rust modules: `constants`, `validation`, `types`, `converters`, and `analysis` — each with a single well-scoped responsibility
- Fixed version mismatch between `Cargo.toml` (`0.2.0`) and `pkg/package.json` (`0.1.0`); both are now aligned at `0.2.0`
- Expanded `pkg/package.json` with full npm metadata: `exports` map, `files` allowlist, `publishConfig`, keywords, repository, and `sideEffects: false`
- Added `scripts/sync-pkg-version.js` to keep `pkg/package.json` in sync with `Cargo.toml` version during CI builds
- All existing unit tests pass; new module-boundary smoke tests added

Closes #550

---

### #551 — tooling/sanctifier-wasm: Document behavior + contribution notes (typed bindings generation)

- `src/types.rs` is the single source of truth for all serialisable output structs (`ErrorResponse`, `Finding`, `AnalysisResult`, `Summary`, `ProgressEvent`, `ProgressiveAnalysisResult`, `CacheMetadata`) — re-exported from `lib.rs` as the stable public type surface
- `src/converters.rs` documents the authoritative mapping from `sanctifier-core` issue types to `Finding` output, making it easy to audit or extend without touching the analysis orchestration
- `lib.rs` module-level doc comment includes a layout table describing each module's responsibility and a full list of exported WASM functions
- Each public type carries rustdoc with JSON shape examples and error descriptions

Closes #551

---

### #574 — frontend: Add performance benchmarks + budgets (telemetry/analytics opt-in)

- Existing `PERF_BUDGETS` constants (`RATE_LIMIT_CHECK_MS`, `UPLOAD_VALIDATION_MS`, `ANALYZE_REQUEST_P95_MS`, `RATE_LIMIT_LOOKUP_MS`) are the single source of truth for all CI performance gates
- `measureAgainstBudget` and `timeAsync` helpers provide a lightweight opt-in instrumentation layer — wrap any async path to get a `PerfMeasurement` with `withinBudget` flag without adding a production dependency
- E2E Playwright suite (`tests/e2e/wasm-perf.spec.ts`) covers page-load budgets (dashboard networkidle ≤ 10 s, scan DOMContentLoaded ≤ 8 s, TTFB ≤ 3 s) and API round-trip budgets (simple contract ≤ 5 s, large contract ≤ 30 s)
- Analytics remain opt-in by design: no telemetry library is added to production; all measurement is test-side only, preserving user privacy

Closes #574

---

### #593 — contracts/runtime-guard-wrapper: Harden input validation + error messages (runtime guard wrapper samples)

- Replaced all raw numeric error codes with named constants: `ERR_WRAPPED_CONTRACT_NOT_SET` (1), `ERR_STORAGE_INTEGRITY_FAILED` (2), `ERR_UNKNOWN_FUNCTION` (3), `ERR_ARGUMENT_COUNT_MISMATCH` (4)
- Added `pub mod error_messages` with human-readable `&'static str` descriptions for each error code — callable from tests, events, or off-chain tooling without heap allocation
- Added `validate_function_name` pre-flight guard to catch zero-value Symbol inputs before they reach the dispatch table
- Added six guard wrapper sample tests in `tests/integration_tests.rs` covering: `ping` round-trip, `echo` pass-through, `sum` two-arg arithmetic, uninitialised contract error path, sequential call stats accumulation, and all error code assertions against named constants

Closes #593

---

## Test plan

- [ ] `cargo test -p sanctifier-wasm` — 29 tests pass
- [ ] `cargo test -p runtime-guard-wrapper` — 20 tests pass (11 integration + 9 versioning)
- [ ] `node tooling/sanctifier-wasm/scripts/sync-pkg-version.js` — reports version already in sync
- [ ] CI lint + test matrix passes for touched crates