### PR TITLE
Add docs/specs community policy fixtures and tests

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -23,6 +23,11 @@
 - **[COMPLETION_REPORT.md](COMPLETION_REPORT.md)** - What was delivered
 - **[IMPLEMENTATION_SUMMARY.md](IMPLEMENTATION_SUMMARY.md)** - What's included
 
+### Contributor & Community Policies
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contribution workflow and PR process
+- **[Code of Conduct](.github/CODE_OF_CONDUCT.md)** - Community behavior expectations
+
 ---
 
 ## 📚 Comprehensive Guides

--- a/tests/action/fixtures/community-doc-links.json
+++ b/tests/action/fixtures/community-doc-links.json
@@ -1,0 +1,15 @@
+{
+  "contributing_file": "CONTRIBUTING.md",
+  "documentation_index_file": "DOCUMENTATION_INDEX.md",
+  "required_contributing_links": [
+    ".github/CODE_OF_CONDUCT.md",
+    ".github/ISSUE_TEMPLATE/bug_report.yml",
+    ".github/ISSUE_TEMPLATE/feature_request.yml",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    ".github/SECURITY.md"
+  ],
+  "required_index_links": [
+    "CONTRIBUTING.md",
+    ".github/CODE_OF_CONDUCT.md"
+  ]
+}

--- a/tests/action/test_community_docs.py
+++ b/tests/action/test_community_docs.py
@@ -1,0 +1,42 @@
+import json
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "tests" / "action" / "fixtures" / "community-doc-links.json"
+MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def markdown_links(path: pathlib.Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    return {match.group(1).strip() for match in MARKDOWN_LINK.finditer(text)}
+
+
+class CommunityDocsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.contributing_path = ROOT / self.fixture["contributing_file"]
+        self.index_path = ROOT / self.fixture["documentation_index_file"]
+
+    def test_contributing_contains_required_community_links(self) -> None:
+        links = markdown_links(self.contributing_path)
+        for target in self.fixture["required_contributing_links"]:
+            with self.subTest(link=target):
+                self.assertIn(target, links)
+
+    def test_required_community_link_targets_exist(self) -> None:
+        for target in self.fixture["required_contributing_links"]:
+            with self.subTest(path=target):
+                self.assertTrue((ROOT / target).exists())
+
+    def test_documentation_index_points_to_community_docs(self) -> None:
+        links = markdown_links(self.index_path)
+        for target in self.fixture["required_index_links"]:
+            with self.subTest(link=target):
+                self.assertIn(target, links)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #675
Closes #677
Closes #686
Closes #688

## Changes
- Added docs/specs fixture coverage for community policy links:
  - `tests/action/fixtures/community-doc-links.json`
- Added new unit tests:
  - `tests/action/test_community_docs.py`
  - Validates `CONTRIBUTING.md` includes required community-health links.
  - Validates linked files exist.
  - Validates `DOCUMENTATION_INDEX.md` references contributor/community policy docs.
- Updated `DOCUMENTATION_INDEX.md` with a dedicated contributor/community policy section linking:
  - `CONTRIBUTING.md`
  - `.github/CODE_OF_CONDUCT.md`

## Testing
- Ran: `python3 -m unittest discover -s tests/action -p 'test_*.py'`
- Result: all tests passed.
