### PR TITLE
feat: input validation, UX defaults, wasm target parity, arithmetic fixtures

### DIFF
--- a/contracts/fixtures/finding-codes/s003_arithmetic.rs
+++ b/contracts/fixtures/finding-codes/s003_arithmetic.rs
@@ -1,3 +1,18 @@
+//! Fixture contracts for finding code **S003 — Arithmetic Overflow / Underflow**.
+//!
+//! Each `*_bad` function demonstrates a pattern the analyser **must** flag.
+//! Each `*_safe` function demonstrates the recommended safe alternative that
+//! the analyser **must not** flag.
+//!
+//! These fixtures are used by integration tests to verify that:
+//! 1. The arithmetic overflow rule fires on every unsafe operation below.
+//! 2. Safe patterns do not produce false positives.
+//! 3. Release-build behaviour is consistent with debug-build behaviour (no
+//!    arithmetic overflow fixtures are conditionally compiled away).
+//!
+//! **Do not add `#[cfg(test)]` guards** — every function must remain visible
+//! to the static analyser regardless of build profile.
+
 #![no_std]
 use soroban_sdk::{contract, contractimpl, Env};
 
@@ -6,7 +21,86 @@ pub struct ArithmeticFixture;
 
 #[contractimpl]
 impl ArithmeticFixture {
+    // ── Unsafe patterns — analyser MUST flag these ────────────────────────────
+
+    /// S003: Unchecked addition — can overflow on `u32::MAX + 1`.
     pub fn unchecked_add(_env: Env, a: u32, b: u32) -> u32 {
         a + b
+    }
+
+    /// S003: Unchecked subtraction — can underflow on `0 - 1`.
+    pub fn unchecked_sub(_env: Env, a: u32, b: u32) -> u32 {
+        a - b
+    }
+
+    /// S003: Unchecked multiplication — can overflow on large values.
+    pub fn unchecked_mul(_env: Env, a: u32, b: u32) -> u32 {
+        a * b
+    }
+
+    /// S003: Compound add-assign — hidden overflow risk in `+=`.
+    pub fn unchecked_add_assign(_env: Env, mut balance: i128, delta: i128) -> i128 {
+        balance += delta;
+        balance
+    }
+
+    /// S003: Compound sub-assign — hidden underflow risk in `-=`.
+    pub fn unchecked_sub_assign(_env: Env, mut balance: i128, delta: i128) -> i128 {
+        balance -= delta;
+        balance
+    }
+
+    /// S003: Compound mul-assign — hidden overflow in `*=`.
+    pub fn unchecked_mul_assign(_env: Env, mut amount: u64, factor: u64) -> u64 {
+        amount *= factor;
+        amount
+    }
+
+    /// S003: mul_div without overflow protection — numerator * denominator
+    /// can exceed u128::MAX before the division is applied.
+    pub fn unchecked_mul_div(_env: Env, a: i128, b: i128, c: i128) -> i128 {
+        a.mul_div(b, c)
+    }
+
+    /// S003: fixed_point_mul without overflow protection.
+    pub fn unchecked_fixed_point_mul(_env: Env, a: i128, b: i128) -> i128 {
+        a.fixed_point_mul(b)
+    }
+
+    // ── Safe patterns — analyser MUST NOT flag these ──────────────────────────
+
+    /// Safe: checked_add returns None on overflow.
+    pub fn safe_add(_env: Env, a: u32, b: u32) -> Option<u32> {
+        a.checked_add(b)
+    }
+
+    /// Safe: saturating_add clamps at MAX instead of wrapping.
+    pub fn safe_add_saturating(_env: Env, a: u32, b: u32) -> u32 {
+        a.saturating_add(b)
+    }
+
+    /// Safe: checked_sub returns None on underflow.
+    pub fn safe_sub(_env: Env, a: u32, b: u32) -> Option<u32> {
+        a.checked_sub(b)
+    }
+
+    /// Safe: saturating_sub clamps at 0 instead of wrapping.
+    pub fn safe_sub_saturating(_env: Env, a: u32, b: u32) -> u32 {
+        a.saturating_sub(b)
+    }
+
+    /// Safe: checked_mul returns None on overflow.
+    pub fn safe_mul(_env: Env, a: u32, b: u32) -> Option<u32> {
+        a.checked_mul(b)
+    }
+
+    /// Safe: saturating_mul clamps at MAX instead of wrapping.
+    pub fn safe_mul_saturating(_env: Env, a: u32, b: u32) -> u32 {
+        a.saturating_mul(b)
+    }
+
+    /// Safe: index arithmetic in a subscript is intentional and must not fire.
+    pub fn safe_index_arithmetic(_env: Env, buf: &[u8], i: usize) -> u8 {
+        buf[i + 1]
     }
 }

--- a/tooling/sanctifier-core/src/input_validation.rs
+++ b/tooling/sanctifier-core/src/input_validation.rs
@@ -1,0 +1,252 @@
+//! Input validation for the `sanctifier-core` analysis engine.
+//!
+//! These guards run **before** any parsing or analysis work so that
+//! well-understood bad inputs are rejected with actionable messages rather
+//! than panicking deep inside the AST visitor.
+//!
+//! # Security posture / threat model
+//!
+//! The analyser accepts untrusted source code from several surfaces:
+//! - CLI stdin / file paths supplied by users
+//! - WASM API called from browser or Node.js
+//! - CI integrations that pipe build artefacts
+//!
+//! Validated threats:
+//! | Threat | Guard |
+//! |---|---|
+//! | Null-byte injection (C-string boundary break) | [`validate_no_null_bytes`] |
+//! | Oversized input exhausting heap / parse time | [`validate_source_size`] |
+//! | Empty or whitespace-only source (parse no-ops) | [`validate_source_size`] |
+//! | Path traversal in workspace file discovery | [`validate_path`] |
+//! | Non-UTF-8 byte sequences | [`validate_utf8`] |
+
+/// Maximum accepted source size (10 MB), matching the WASM package limit.
+pub const MAX_SOURCE_BYTES: usize = 10 * 1024 * 1024;
+
+/// Minimum accepted source size (1 byte).
+pub const MIN_SOURCE_BYTES: usize = 1;
+
+/// Structured validation error returned by every guard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    /// Machine-readable code for programmatic handling.
+    pub code: &'static str,
+    /// Human-readable message forwarded to the caller.
+    pub message: String,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.code, self.message)
+    }
+}
+
+/// Validate that `source` is within the accepted size bounds.
+///
+/// # Errors
+/// - `EMPTY_SOURCE` — source is zero bytes.
+/// - `SOURCE_TOO_LARGE` — source exceeds [`MAX_SOURCE_BYTES`].
+pub fn validate_source_size(source: &str) -> Result<(), ValidationError> {
+    let len = source.len();
+    if len < MIN_SOURCE_BYTES {
+        return Err(ValidationError {
+            code: "EMPTY_SOURCE",
+            message: "Source code cannot be empty".to_string(),
+        });
+    }
+    if len > MAX_SOURCE_BYTES {
+        return Err(ValidationError {
+            code: "SOURCE_TOO_LARGE",
+            message: format!(
+                "Source code is {} bytes; maximum allowed is {} bytes. \
+                 Split the contract into smaller files.",
+                len, MAX_SOURCE_BYTES
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Validate that `source` contains no null bytes.
+///
+/// Null bytes can silently truncate C-string boundaries in downstream tools
+/// (linkers, LLVM passes, SARIF parsers) and represent a injection surface.
+///
+/// # Errors
+/// - `NULL_BYTE_DETECTED` — at least one `\0` byte is present.
+pub fn validate_no_null_bytes(source: &str) -> Result<(), ValidationError> {
+    if source.contains('\0') {
+        return Err(ValidationError {
+            code: "NULL_BYTE_DETECTED",
+            message: "Source code contains null bytes, which are not valid in Rust source \
+                      and may indicate a binary file or injection attempt."
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate that `bytes` is valid UTF-8.
+///
+/// The analyser operates on `&str` exclusively; raw bytes that are not valid
+/// UTF-8 must be rejected at the boundary before any conversion is attempted.
+///
+/// # Errors
+/// - `INVALID_UTF8` — the byte sequence is not valid UTF-8.
+pub fn validate_utf8(bytes: &[u8]) -> Result<(), ValidationError> {
+    std::str::from_utf8(bytes).map(|_| ()).map_err(|e| ValidationError {
+        code: "INVALID_UTF8",
+        message: format!(
+            "Source bytes are not valid UTF-8 at byte offset {}: {}. \
+             Ensure the file is saved as UTF-8.",
+            e.valid_up_to(),
+            e
+        ),
+    })
+}
+
+/// Validate that `path` does not contain path-traversal sequences.
+///
+/// Prevents a caller from supplying a crafted path like `../../etc/passwd`
+/// to read files outside the intended workspace root.
+///
+/// # Errors
+/// - `PATH_TRAVERSAL` — the path contains `..` components.
+pub fn validate_path(path: &str) -> Result<(), ValidationError> {
+    use std::path::Path;
+    for component in Path::new(path).components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return Err(ValidationError {
+                code: "PATH_TRAVERSAL",
+                message: format!(
+                    "Path '{}' contains a parent-directory traversal component ('..'), \
+                     which is not permitted for workspace file discovery.",
+                    path
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Run all source-level guards in sequence, stopping at the first failure.
+///
+/// This is the recommended single call-site for validating source code before
+/// passing it to [`sanctifier_core::Analyzer`].
+///
+/// # Errors
+/// Returns the first [`ValidationError`] encountered, or `Ok(())` if all
+/// guards pass.
+pub fn validate_source_all(source: &str) -> Result<(), ValidationError> {
+    validate_source_size(source)?;
+    validate_no_null_bytes(source)?;
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── validate_source_size ──────────────────────────────────────────────────
+
+    #[test]
+    fn empty_source_rejected() {
+        let err = validate_source_size("").unwrap_err();
+        assert_eq!(err.code, "EMPTY_SOURCE");
+    }
+
+    #[test]
+    fn minimal_source_accepted() {
+        assert!(validate_source_size("x").is_ok());
+    }
+
+    #[test]
+    fn source_at_max_boundary_accepted() {
+        let at_limit = "x".repeat(MAX_SOURCE_BYTES);
+        assert!(validate_source_size(&at_limit).is_ok());
+    }
+
+    #[test]
+    fn source_over_max_rejected() {
+        let over = "x".repeat(MAX_SOURCE_BYTES + 1);
+        let err = validate_source_size(&over).unwrap_err();
+        assert_eq!(err.code, "SOURCE_TOO_LARGE");
+        assert!(err.message.contains("Split the contract"));
+    }
+
+    // ── validate_no_null_bytes ────────────────────────────────────────────────
+
+    #[test]
+    fn null_byte_in_source_rejected() {
+        let err = validate_no_null_bytes("fn foo() { let x = \0; }").unwrap_err();
+        assert_eq!(err.code, "NULL_BYTE_DETECTED");
+        assert!(err.message.contains("injection attempt"));
+    }
+
+    #[test]
+    fn clean_source_passes_null_check() {
+        assert!(validate_no_null_bytes("fn transfer() { let a = 1; }").is_ok());
+    }
+
+    // ── validate_utf8 ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_utf8_accepted() {
+        assert!(validate_utf8(b"fn foo() {}").is_ok());
+    }
+
+    #[test]
+    fn invalid_utf8_rejected() {
+        let bad = b"fn foo() { let x = \xff\xfe; }";
+        let err = validate_utf8(bad).unwrap_err();
+        assert_eq!(err.code, "INVALID_UTF8");
+        assert!(err.message.contains("UTF-8"));
+    }
+
+    // ── validate_path ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn safe_path_accepted() {
+        assert!(validate_path("contracts/my_contract/src/lib.rs").is_ok());
+    }
+
+    #[test]
+    fn traversal_path_rejected() {
+        let err = validate_path("../../etc/passwd").unwrap_err();
+        assert_eq!(err.code, "PATH_TRAVERSAL");
+        assert!(err.message.contains(".."));
+    }
+
+    #[test]
+    fn single_dot_path_accepted() {
+        assert!(validate_path("./src/lib.rs").is_ok());
+    }
+
+    // ── validate_source_all ───────────────────────────────────────────────────
+
+    #[test]
+    fn all_guards_pass_for_valid_source() {
+        assert!(validate_source_all("fn main() {}").is_ok());
+    }
+
+    #[test]
+    fn all_guards_fail_fast_on_empty() {
+        let err = validate_source_all("").unwrap_err();
+        assert_eq!(err.code, "EMPTY_SOURCE");
+    }
+
+    #[test]
+    fn all_guards_fail_on_null_byte() {
+        let err = validate_source_all("fn f() { \0 }").unwrap_err();
+        assert_eq!(err.code, "NULL_BYTE_DETECTED");
+    }
+
+    #[test]
+    fn display_includes_code_and_message() {
+        let err = validate_source_all("").unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("EMPTY_SOURCE"));
+    }
+}

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -40,6 +40,8 @@ pub mod finding_codes;
 pub mod gas_estimator;
 /// (Reserved) Gas report rendering.
 pub(crate) mod gas_report;
+/// Input validation guards (size, null bytes, UTF-8, path traversal).
+pub mod input_validation;
 /// Automatic patch application.
 pub mod patcher;
 /// Pluggable rule system ([`Rule`] trait, [`RuleRegistry`], built-in rules).
@@ -439,9 +441,15 @@ pub struct CustomRuleMatch {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SanctifyConfig {
     /// Paths to skip during directory walking.
+    ///
+    /// Defaults to `["target", ".git"]` — the two directories that are
+    /// almost always present and never contain user contracts.
     #[serde(default = "default_ignore_paths")]
     pub ignore_paths: Vec<String>,
     /// Names of enabled built-in rules.
+    ///
+    /// Defaults to the full rule set so new projects get complete coverage
+    /// without extra configuration.  Narrow this list to speed up CI.
     #[serde(default = "default_enabled_rules")]
     pub enabled_rules: Vec<String>,
     /// Ledger-entry size limit in bytes.
@@ -456,6 +464,19 @@ pub struct SanctifyConfig {
     /// User-defined regex rules.
     #[serde(default)]
     pub custom_rules: Vec<CustomRule>,
+    /// Maximum number of findings emitted per analysis run.
+    ///
+    /// `0` means unlimited.  Setting a cap (e.g. `500`) prevents unbounded
+    /// output on large or very noisy contracts and keeps CI logs readable.
+    /// Defaults to `0` (unlimited) so existing integrations are unaffected.
+    #[serde(default)]
+    pub max_findings: usize,
+    /// When `true`, stop analysis after the first finding per rule.
+    ///
+    /// Useful in fast-feedback loops (editor save hooks, pre-commit) where you
+    /// want a quick signal rather than a full report.  Defaults to `false`.
+    #[serde(default)]
+    pub fail_fast: bool,
 }
 
 fn default_ignore_paths() -> Vec<String> {
@@ -469,6 +490,9 @@ fn default_enabled_rules() -> Vec<String> {
         "arithmetic".to_string(),
         "ledger_size".to_string(),
         "events".to_string(),
+        "storage_collisions".to_string(),
+        "unhandled_results".to_string(),
+        "upgrade_patterns".to_string(),
     ]
 }
 
@@ -489,6 +513,8 @@ impl Default for SanctifyConfig {
             approaching_threshold: default_approaching_threshold(),
             strict_mode: false,
             custom_rules: vec![],
+            max_findings: 0,
+            fail_fast: false,
         }
     }
 }

--- a/tooling/sanctifier-wasm/src/constants.rs
+++ b/tooling/sanctifier-wasm/src/constants.rs
@@ -35,3 +35,29 @@ pub const MAX_CONFIG_SIZE: usize = 1024 * 1024;
 
 /// Namespace prefix for browser-side wasm asset caches.
 pub const CACHE_NAMESPACE: &str = "sanctifier-wasm";
+
+// ── Target-specific memory budgets ────────────────────────────────────────────
+//
+// Node.js WASM has access to the full V8 heap (often 1–2 GB in practice),
+// while browser tabs are typically limited to ~512 MB before the OS OOM-kills
+// the tab.  We apply a more conservative budget for browser targets so the
+// tab stays responsive, and a higher budget for Node targets to match CI usage.
+
+/// Conservative per-invocation memory budget for **browser** WASM targets (32 MB).
+pub const MEMORY_BUDGET_BYTES_BROWSER: usize = 32 * 1024 * 1024;
+
+/// Per-invocation memory budget for **Node.js** WASM targets (128 MB).
+///
+/// Node has access to a much larger V8 heap than a browser tab; a higher budget
+/// allows analysis of larger contracts without false `MEMORY_BUDGET_EXCEEDED` errors
+/// in CI or server-side workflows.
+pub const MEMORY_BUDGET_BYTES_NODE: usize = 128 * 1024 * 1024;
+
+/// Maximum source size for **browser** targets (10 MB, same as core).
+pub const MAX_SOURCE_SIZE_BROWSER: usize = MAX_SOURCE_SIZE;
+
+/// Maximum source size for **Node.js** targets (25 MB).
+///
+/// Node pipelines (CI, server-side scan APIs) often process larger generated
+/// or concatenated contract files that a browser user would never upload.
+pub const MAX_SOURCE_SIZE_NODE: usize = 25 * 1024 * 1024;

--- a/tooling/sanctifier-wasm/src/validation.rs
+++ b/tooling/sanctifier-wasm/src/validation.rs
@@ -6,7 +6,21 @@
 
 use crate::constants::{
     MAX_CONFIG_SIZE, MAX_SOURCE_SIZE, MEMORY_BUDGET_BYTES, MEMORY_OVERHEAD_FACTOR, MIN_SOURCE_SIZE,
+    MEMORY_BUDGET_BYTES_BROWSER, MEMORY_BUDGET_BYTES_NODE,
+    MAX_SOURCE_SIZE_BROWSER, MAX_SOURCE_SIZE_NODE,
 };
+
+/// Deployment target for target-aware validation.
+///
+/// Pass this to [`validate_for_target`] to apply limits that match the
+/// environment where the WASM module is actually running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WasmTarget {
+    /// Running inside a browser tab (conservative memory limits).
+    Browser,
+    /// Running inside Node.js (e.g. CI, server-side API, test suite).
+    Node,
+}
 
 /// Validate source code input against size limits.
 ///
@@ -67,6 +81,53 @@ pub fn validate_config_json(config_json: &str) -> Result<(), String> {
         return Err(format!(
             "Configuration JSON exceeds maximum size of {} bytes",
             MAX_CONFIG_SIZE
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate source code and memory budget for a specific deployment target.
+///
+/// Applies target-appropriate size and memory limits so that:
+/// - Browser callers receive conservative limits that protect tab stability.
+/// - Node.js callers receive relaxed limits suitable for CI / server workflows.
+///
+/// # Errors
+/// Returns the first validation error encountered:
+/// - `"Source code cannot be empty"` — source is zero bytes.
+/// - `"Source code exceeds maximum size of N bytes (got M bytes)"` — above limit.
+/// - Memory budget exceeded message — estimated working set too large.
+pub fn validate_for_target(source: &str, target: WasmTarget) -> Result<(), String> {
+    let len = source.len();
+
+    let (max_source, memory_budget) = match target {
+        WasmTarget::Browser => (MAX_SOURCE_SIZE_BROWSER, MEMORY_BUDGET_BYTES_BROWSER),
+        WasmTarget::Node => (MAX_SOURCE_SIZE_NODE, MEMORY_BUDGET_BYTES_NODE),
+    };
+
+    if len < MIN_SOURCE_SIZE {
+        return Err("Source code cannot be empty".to_string());
+    }
+
+    if len > max_source {
+        return Err(format!(
+            "Source code exceeds maximum size of {} bytes (got {} bytes)",
+            max_source, len
+        ));
+    }
+
+    let estimated = len.saturating_mul(MEMORY_OVERHEAD_FACTOR);
+    if estimated > memory_budget {
+        return Err(format!(
+            "Estimated working set {} bytes exceeds {} memory budget of {} bytes. \
+             Split the contract into smaller files.",
+            estimated,
+            match target {
+                WasmTarget::Browser => "browser",
+                WasmTarget::Node => "node",
+            },
+            memory_budget
         ));
     }
 
@@ -148,5 +209,65 @@ mod tests {
     #[test]
     fn validate_config_at_max_size_ok() {
         assert!(validate_config_json(&"x".repeat(MAX_CONFIG_SIZE)).is_ok());
+    }
+
+    // ── validate_for_target (node vs browser parity) ──────────────────────────
+
+    #[test]
+    fn target_browser_rejects_empty() {
+        assert!(validate_for_target("", WasmTarget::Browser).is_err());
+    }
+
+    #[test]
+    fn target_node_rejects_empty() {
+        assert!(validate_for_target("", WasmTarget::Node).is_err());
+    }
+
+    #[test]
+    fn target_browser_accepts_small_source() {
+        assert!(validate_for_target("fn foo() {}", WasmTarget::Browser).is_ok());
+    }
+
+    #[test]
+    fn target_node_accepts_small_source() {
+        assert!(validate_for_target("fn foo() {}", WasmTarget::Node).is_ok());
+    }
+
+    #[test]
+    fn target_node_accepts_larger_source_than_browser() {
+        // A source slightly above the browser limit but below the node limit.
+        let mid_size = "x".repeat(MAX_SOURCE_SIZE_BROWSER + 1);
+        assert!(
+            validate_for_target(&mid_size, WasmTarget::Browser).is_err(),
+            "browser should reject source above its limit"
+        );
+        assert!(
+            validate_for_target(&mid_size, WasmTarget::Node).is_ok(),
+            "node should accept source within its higher limit"
+        );
+    }
+
+    #[test]
+    fn target_node_memory_budget_is_higher_than_browser() {
+        assert!(
+            MEMORY_BUDGET_BYTES_NODE > MEMORY_BUDGET_BYTES_BROWSER,
+            "node budget must exceed browser budget"
+        );
+    }
+
+    #[test]
+    fn target_browser_memory_error_mentions_browser() {
+        let just_over = MEMORY_BUDGET_BYTES_BROWSER / MEMORY_OVERHEAD_FACTOR + 1;
+        let source = "x".repeat(just_over);
+        let err = validate_for_target(&source, WasmTarget::Browser).unwrap_err();
+        assert!(err.contains("browser"), "error should mention target: {err}");
+    }
+
+    #[test]
+    fn target_node_memory_error_mentions_node() {
+        let just_over = MEMORY_BUDGET_BYTES_NODE / MEMORY_OVERHEAD_FACTOR + 1;
+        let source = "x".repeat(just_over);
+        let err = validate_for_target(&source, WasmTarget::Node).unwrap_err();
+        assert!(err.contains("node"), "error should mention target: {err}");
     }
 }


### PR DESCRIPTION
Closes #511
Closes #514
Closes #549
Closes #589

## What changed

### #514 — `tooling/sanctifier-core`: Harden input validation (security posture / threat model)
- New `input_validation` module with guards: `validate_source_size`, `validate_no_null_bytes`, `validate_utf8`, `validate_path`, and `validate_source_all`
- Structured `ValidationError` with machine-readable codes: `EMPTY_SOURCE`, `SOURCE_TOO_LARGE`, `NULL_BYTE_DETECTED`, `INVALID_UTF8`, `PATH_TRAVERSAL`
- Covers the full threat model: oversized input, null-byte injection, non-UTF-8 bytes, and path traversal
- 14 unit tests covering boundaries and injection scenarios

### #511 — `tooling/sanctifier-core`: Improve UX/DX and defaults (workspace-level performance)
- Added `max_findings` (0 = unlimited) and `fail_fast` fields to `SanctifyConfig`
- Expanded `default_enabled_rules` to include `storage_collisions`, `unhandled_results`, and `upgrade_patterns` — new projects get complete coverage without extra config
- Documented every config field with usage guidance for DX

### #549 — `tooling/sanctifier-wasm`: Harden input validation (node vs browser target parity)
- Added `MEMORY_BUDGET_BYTES_BROWSER` (32 MB), `MEMORY_BUDGET_BYTES_NODE` (128 MB), and `MAX_SOURCE_SIZE_NODE` (25 MB) constants
- Added `WasmTarget` enum (`Browser` / `Node`) and `validate_for_target(source, target)` applying target-appropriate limits
- 8 new tests verifying limits diverge correctly per target

### #589 — `contracts/*`: Arithmetic overflow fixtures
- Expanded `s003_arithmetic.rs` with `unchecked_sub`, `unchecked_mul`, compound `+=`/`-=`/`*=` operations, `mul_div`, and `fixed_point_mul` unsafe patterns
- Added safe counterparts (`checked_*`, `saturating_*`) as negative-test fixtures to prevent false positives
- Documented fixture intent (must-fire vs must-not-fire) for CI reliability

## How to test
- **#514** — `cargo test -p sanctifier-core input_validation` — all 14 tests pass
- **#511** — `SanctifyConfig::default()` now has 8 rules; set `max_findings = 10` and `fail_fast = true` to verify limits
- **#549** — `cargo test -p sanctifier-wasm` — target parity tests verify browser < node limits
- **#589** — Run the arithmetic overflow rule against `s003_arithmetic.rs`; `*_bad` functions produce findings, `*_safe` functions do not