### PR TITLE
docs: add rule authoring guide and engine behavior spec

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -101,6 +101,18 @@
 - Single-command deployment
 - Automatic validation
 
+### Rule Authoring Guide
+
+**[docs/rule-authoring-guide.md](docs/rule-authoring-guide.md)**
+
+- Rule anatomy and matcher types
+- Built-in rules (`S001`–`S012`) overview
+- Custom rule authoring (TOML inline + YAML files)
+- `.sanctify.toml` configuration reference
+- Testing fixtures and CI validation
+- Severity guidelines and output stability
+- Contribution checklist for rule PRs
+
 ### WASM Module Versioning & Input Validation
 
 **[docs/wasm-versioning-alignment.md](docs/wasm-versioning-alignment.md)** - WASM module hardening
@@ -207,6 +219,7 @@
 | [IMPLEMENTATION_SUMMARY.md](IMPLEMENTATION_SUMMARY.md) | 10 min | What's included  |
 | [COMPLETION_REPORT.md](COMPLETION_REPORT.md)           | 5 min  | Deliverables     |
 | Contract README                                        | 20 min | Contract details |
+| [docs/rule-authoring-guide.md](docs/rule-authoring-guide.md) | 15 min | Rule authoring |
 
 ### Deployment Operations
 

--- a/docs/rule-authoring-guide.md
+++ b/docs/rule-authoring-guide.md
@@ -1,0 +1,414 @@
+# Rule Authoring Guide
+
+> A comprehensive guide for contributors who want to write, test, and ship custom
+> analysis rules for Sanctifier.
+
+---
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Rule Anatomy](#rule-anatomy)
+3. [Built-in Rules](#built-in-rules)
+4. [Authoring a Custom Rule](#authoring-a-custom-rule)
+5. [Rule Configuration in `.sanctify.toml`](#rule-configuration-in-sanctifytoml)
+6. [YAML Rule Files](#yaml-rule-files)
+7. [Testing Your Rule](#testing-your-rule)
+8. [Severity Guidelines](#severity-guidelines)
+9. [Output Stability and SARIF](#output-stability-and-sarif)
+10. [Contribution Notes](#contribution-notes)
+11. [Common Pitfalls](#common-pitfalls)
+12. [Reference](#reference)
+
+---
+
+## Introduction
+
+Sanctifier ships with a set of **built-in rules** (finding codes `S001`–`S012`)
+that cover the most common smart-contract issues on Soroban. In addition, the tool
+supports **custom rules** — user-defined patterns that can be added inline in
+`.sanctify.toml` or via a standalone YAML file.
+
+This guide explains:
+
+- How rules are structured and executed.
+- How to write, test, and document a new rule.
+- How to submit a rule contribution through a pull request.
+
+---
+
+## Rule Anatomy
+
+Every Sanctifier rule, whether built-in or custom, shares the same logical
+structure:
+
+```
+┌──────────────────────────────────────┐
+│  1. Matcher   — WHAT to look for     │
+│  2. Severity  — HOW bad is it?       │
+│  3. Message   — WHAT to tell the dev │
+│  4. Metadata  — WHERE to learn more  │
+└──────────────────────────────────────┘
+```
+
+### Matcher Types
+
+| Type               | Description                                     | Example Use Case                        |
+| ------------------ | ----------------------------------------------- | --------------------------------------- |
+| `function_call`    | Matches calls to a named function               | Detect `unsafe_transfer` usage          |
+| `storage_operation`| Matches `set`/`get`/`remove` on storage keys    | Ensure admin key writes emit events     |
+| `method_call`      | Matches method calls on a specific receiver type| Flag `.transfer()` without balance check|
+| `regex`            | Arbitrary regex over source text                 | Catch `panic!()` or hardcoded addresses |
+
+### Severity Levels
+
+| Level     | When to Use                                         |
+| --------- | --------------------------------------------------- |
+| `error`   | Exploitable vulnerability or definite bug            |
+| `warning` | Risky pattern that *might* be intentional            |
+| `info`    | Informational observation, no immediate risk         |
+
+---
+
+## Built-in Rules
+
+The following rules are compiled into `sanctifier-core` and enabled/disabled via
+the `enabled_rules` field in `.sanctify.toml`. See
+[error-codes.md](error-codes.md) for full details.
+
+| Code   | Key            | Category              |
+| ------ | -------------- | --------------------- |
+| `S001` | `auth_gaps`    | Missing `require_auth` |
+| `S002` | `panics`       | `panic!`/`unwrap`/`expect` usage |
+| `S003` | `arithmetic`   | Unchecked overflow/underflow |
+| `S004` | `ledger_size`  | Ledger entry size limits |
+| `S005` | —              | Storage-key collisions |
+| `S006` | —              | Unsafe patterns |
+| `S007` | —              | Custom rule match |
+| `S008` | —              | Event topic issues |
+| `S009` | —              | Unhandled `Result` |
+| `S010` | —              | Upgrade/admin risks |
+| `S011` | —              | Z3 invariant violation |
+| `S012` | —              | SEP-41 token interface deviations |
+
+---
+
+## Authoring a Custom Rule
+
+### Option 1 — Inline in `.sanctify.toml`
+
+The fastest way to add a rule. Inline rules use **regex matching** against the
+source text.
+
+```toml
+# .sanctify.toml
+
+[[custom_rules]]
+name = "no_unsafe_block"
+pattern = "unsafe\\s*\\{"
+severity = "error"
+
+[[custom_rules]]
+name = "no_mem_forget"
+pattern = "std::mem::forget"
+severity = "warning"
+```
+
+**Required fields:**
+
+| Field      | Type   | Description                                    |
+| ---------- | ------ | ---------------------------------------------- |
+| `name`     | string | Unique, snake_case identifier                  |
+| `pattern`  | string | Regex pattern (escaped for TOML)               |
+| `severity` | string | One of `error`, `warning`, `info`              |
+
+### Option 2 — YAML Rule File
+
+For richer rules with structured matchers, use a YAML file. Reference it from
+`.sanctify.toml`:
+
+```toml
+custom_rules_yaml = "custom-rules.yaml"
+```
+
+Then define the rules:
+
+```yaml
+# custom-rules.yaml
+
+- id: no_unsafe_transfer
+  name: No Unsafe Transfer
+  description: Avoid using unsafe_transfer function
+  severity: error
+  matcher:
+    type: function_call
+    name: unsafe_transfer
+    args: []
+
+- id: require_admin_event
+  name: Require Admin Event
+  description: Admin changes must emit events
+  severity: warning
+  matcher:
+    type: storage_operation
+    operation: set
+    key_pattern: "*admin*"
+```
+
+**Required fields for YAML rules:**
+
+| Field         | Type   | Description                                    |
+| ------------- | ------ | ---------------------------------------------- |
+| `id`          | string | Unique, kebab-case identifier                  |
+| `name`        | string | Human-readable rule name                       |
+| `description` | string | One-sentence summary                           |
+| `severity`    | string | One of `error`, `warning`, `info`              |
+| `matcher`     | object | Matcher definition (see [Matcher Types](#matcher-types)) |
+
+---
+
+## Rule Configuration in `.sanctify.toml`
+
+The project-level config file controls which rules run:
+
+```toml
+# Paths to ignore during analysis
+ignore_paths = ["target", ".git"]
+
+# Enable specific built-in rule keys
+enabled_rules = ["auth_gaps", "panics", "arithmetic", "ledger_size"]
+
+# Ledger size threshold for S004
+ledger_limit = 64000
+
+# Enable strict mode (all built-in rules, no severity downgrade)
+strict_mode = false
+
+# Optional: path to YAML custom rules
+# custom_rules_yaml = "custom-rules.yaml"
+
+# Inline regex rules
+[[custom_rules]]
+name = "no_unsafe_block"
+pattern = "unsafe\\s*\\{"
+severity = "error"
+```
+
+### Behavior Notes
+
+- **`enabled_rules`** — Only the listed keys are active. Omitting this field
+  enables *all* built-in rules.
+- **`strict_mode = true`** — Forces all built-in rules on and prevents custom
+  severity overrides. Recommended for CI.
+- **`ignore_paths`** — Glob patterns relative to the project root. The `target/`
+  directory is always ignored.
+- **Custom rules** always run regardless of `enabled_rules`; they are additive.
+
+---
+
+## YAML Rule Files
+
+See [`custom-rules.example.yaml`](../custom-rules.example.yaml) in the project
+root for a complete working example.
+
+### Matcher Reference
+
+#### `function_call`
+
+```yaml
+matcher:
+  type: function_call
+  name: unsafe_transfer    # exact function name
+  args: []                 # (reserved for future arg-pattern matching)
+```
+
+#### `storage_operation`
+
+```yaml
+matcher:
+  type: storage_operation
+  operation: set           # set | get | remove
+  key_pattern: "*admin*"   # glob pattern over the storage key
+```
+
+#### `method_call`
+
+```yaml
+matcher:
+  type: method_call
+  method: transfer         # method name
+  receiver: "*Client"      # glob pattern for the receiver type
+```
+
+#### `regex`
+
+```yaml
+matcher:
+  type: regex
+  pattern: "panic!\\("     # regex over source text (double-escape in YAML)
+```
+
+---
+
+## Testing Your Rule
+
+### Writing Test Fixtures
+
+For every rule, create a fixture directory under
+`contracts/fixtures/finding-codes/` with positive and negative examples:
+
+```
+contracts/fixtures/finding-codes/
+├── s007_custom_no_unsafe_block/
+│   ├── should_match.rs       # Code that SHOULD trigger the rule
+│   └── should_not_match.rs   # Code that SHOULD NOT trigger the rule
+```
+
+**`should_match.rs`** — demonstrates the pattern:
+
+```rust
+// This should trigger `no_unsafe_block`
+pub fn dangerous() {
+    unsafe {
+        // ...
+    }
+}
+```
+
+**`should_not_match.rs`** — demonstrates clean code:
+
+```rust
+// This should NOT trigger `no_unsafe_block`
+pub fn safe_fn() {
+    let result: Result<(), &str> = Ok(());
+    result.unwrap_or_default();
+}
+```
+
+### Running Tests Locally
+
+```bash
+# Run the full test suite
+cargo test -p sanctifier-core --all-features
+
+# Run only rule-related tests
+cargo test -p sanctifier-core -- rules
+
+# Lint check
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+```
+
+### CI Validation
+
+All PRs are validated by the `Continuous Integration` workflow, which runs:
+
+1. `cargo fmt --all -- --check`
+2. `cargo clippy --workspace -- -D warnings`
+3. `cargo test --workspace`
+
+Ensure your rule passes all three before submitting.
+
+---
+
+## Severity Guidelines
+
+Choose severity based on **exploitability** and **blast radius**:
+
+| Severity  | Criteria                                            | Example                                |
+| --------- | --------------------------------------------------- | -------------------------------------- |
+| `error`   | Directly exploitable; funds at risk                 | Missing `require_auth` on withdrawal   |
+| `warning` | Risky but may be intentional or context-dependent   | `unwrap()` in a non-critical path      |
+| `info`    | Observation only; no security impact                | Function naming convention violation   |
+
+> **Tip:** When in doubt, start with `warning`. Reviewers will suggest adjusting
+> severity during PR review.
+
+---
+
+## Output Stability and SARIF
+
+Sanctifier produces findings in a **stable JSON format** that is compatible with
+SARIF (Static Analysis Results Interchange Format). When authoring rules:
+
+- **Do not change** the shape of the `findings` array or the `code` field format.
+- Custom rules are reported with code `S007` in the output.
+- If your change alters the output schema, you **must** include:
+  - A version bump in the output format.
+  - Migration notes in the PR description.
+
+See [SARIF_METADATA.md](SARIF_METADATA.md) for the current output schema.
+
+---
+
+## Contribution Notes
+
+### Before You Start
+
+1. **Open an issue first** if you're proposing a new built-in rule. Custom rule
+   contributions (YAML/TOML examples) can go straight to PR.
+2. **Check existing rules** — your idea may overlap with `S001`–`S012` or an
+   existing custom rule example.
+3. **Read [CONTRIBUTING.md](../CONTRIBUTING.md)** for general PR process, commit
+   conventions, and branch protection requirements.
+
+### PR Checklist for Rule Contributions
+
+- [ ] Rule has a unique, descriptive identifier
+- [ ] Severity is appropriate and justified in the PR description
+- [ ] At least 1 positive and 1 negative test fixture provided
+- [ ] `cargo test` passes locally
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --workspace -- -D warnings` passes
+- [ ] Rule is documented (description, rationale, example match/no-match)
+- [ ] If modifying output format: version bump + migration notes included
+
+### Branch Naming
+
+Follow the convention from [CONTRIBUTING.md](../CONTRIBUTING.md):
+
+| Type                     | Branch pattern                    |
+| ------------------------ | --------------------------------- |
+| New built-in rule        | `rule/<rule-name>`                |
+| New custom rule example  | `docs/custom-rule-<name>`         |
+| Fix to existing rule     | `fix/rule-<rule-id>`              |
+
+### Commit Message
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(rules): add no-direct-panic custom rule example
+fix(rules): correct false positive in auth_gaps for admin-only paths
+docs: update rule authoring guide with YAML matcher reference
+```
+
+---
+
+## Common Pitfalls
+
+| Pitfall                          | Solution                                            |
+| -------------------------------- | --------------------------------------------------- |
+| Regex too broad → false positives| Use anchors, word boundaries, or structured matchers |
+| Regex too narrow → false negatives| Test with variations (whitespace, comments, macros)  |
+| Missing TOML escaping            | Double-escape backslashes: `\\s` not `\s`           |
+| Severity too high                | Start with `warning`; escalate during review         |
+| No test fixtures                 | Always provide `should_match` + `should_not_match`   |
+| Breaking output format           | Version bump + migration notes required              |
+
+---
+
+## Reference
+
+| Resource                                                                   | Description                          |
+| -------------------------------------------------------------------------- | ------------------------------------ |
+| [Error Codes](error-codes.md)                                              | Full `S001`–`S012` code table        |
+| [Contributing Analysis Rules](Contributing-analysis-rules.MD)              | Static analysis + formal verification guide |
+| [Custom Rules Example](../custom-rules.example.yaml)                      | Working YAML rule file               |
+| [Vulnerability Database Format](vulnerability-database-format.md)          | `SOL-2024-*` entry format            |
+| [CONTRIBUTING.md](../CONTRIBUTING.md)                                      | General contribution guidelines      |
+| [`.sanctify.toml`](../.sanctify.toml)                                      | Project config reference             |
+
+---
+
+*Last updated: April 2026 | License: see project root LICENSE file*

--- a/specs/rule-engine-behavior.md
+++ b/specs/rule-engine-behavior.md
@@ -1,0 +1,125 @@
+# Rule Engine Behavior Specification
+
+> Defines the expected runtime behavior of Sanctifier's rule engine: how rules are
+> discovered, prioritized, matched, and reported.
+
+---
+
+## 1. Rule Discovery Order
+
+When `sanctifier analyze` is invoked, the engine loads rules in this order:
+
+1. **Built-in rules** compiled into `sanctifier-core` (codes `S001`–`S012`).
+2. **Inline custom rules** from `[[custom_rules]]` entries in `.sanctify.toml`.
+3. **YAML custom rules** from the file referenced by `custom_rules_yaml` in
+   `.sanctify.toml`.
+
+Rules loaded later **do not** override earlier rules. All loaded rules run
+independently and produce separate findings.
+
+## 2. Rule Filtering
+
+### `enabled_rules`
+
+- When `enabled_rules` is **present and non-empty**, only the listed built-in
+  rule keys are active. Unlisted built-in rules are skipped.
+- When `enabled_rules` is **absent**, all built-in rules are active.
+- Custom rules (`[[custom_rules]]` and YAML) are **always active** and are not
+  affected by `enabled_rules`.
+
+### `strict_mode`
+
+- When `strict_mode = true`:
+  - All built-in rules are active regardless of `enabled_rules`.
+  - Severity levels cannot be downgraded by configuration.
+- When `strict_mode = false` (default):
+  - `enabled_rules` is respected.
+  - Future: per-rule severity overrides may be supported.
+
+### `ignore_paths`
+
+- Glob patterns relative to the project root.
+- Files matching any `ignore_paths` entry are excluded from analysis.
+- The `target/` directory is **always** excluded, even if not listed.
+
+## 3. Matching Semantics
+
+### Built-in Rules
+
+Built-in rules use AST-level analysis within `sanctifier-core`. They operate on
+parsed Rust source and produce structured findings with precise source locations
+(file, line, column).
+
+### Inline Custom Rules (TOML)
+
+Inline rules use **regex matching** over raw source text:
+
+- The `pattern` field is compiled as a Rust regex.
+- Backslashes must be double-escaped in TOML (`\\s` for `\s`).
+- Matches produce findings with code `S007` and the rule's `name` in the message.
+- Each match reports the first line of the matched region.
+
+### YAML Custom Rules
+
+YAML rules support **structured matchers** (`function_call`, `storage_operation`,
+`method_call`, `regex`):
+
+- `function_call`: matches by function name. `args` is reserved for future use.
+- `storage_operation`: matches `set`/`get`/`remove` operations with an optional
+  `key_pattern` glob.
+- `method_call`: matches method name with optional `receiver` glob.
+- `regex`: equivalent to inline TOML rules but in YAML format.
+
+All YAML rule findings are also reported with code `S007`.
+
+## 4. Finding Output Format
+
+Each finding is a JSON object with this stable shape:
+
+```json
+{
+  "code": "S001",
+  "severity": "error",
+  "message": "Missing require_auth in state-changing function",
+  "file": "src/contract.rs",
+  "line": 42,
+  "column": 5,
+  "rule_id": "auth_gaps"
+}
+```
+
+### Guarantees
+
+- The `code` field always matches pattern `S0[0-9]{2}`.
+- The `severity` field is always one of `error`, `warning`, `info`.
+- The `file` path is relative to the project root.
+- `line` and `column` are 1-indexed.
+- Custom rules always use `code: "S007"`.
+
+### SARIF Compatibility
+
+The JSON output is designed to be convertible to SARIF v2.1.0. The `code` field
+maps to `ruleId`, and `severity` maps to the SARIF `level` property.
+
+## 5. Execution Order and Deduplication
+
+- Rules execute in discovery order (built-in → inline TOML → YAML).
+- If two rules produce a finding at the **exact same file + line + column + code**,
+  only the first is kept (deduplication).
+- Findings are sorted in the final output by: file (ascending) → line (ascending)
+  → code (ascending).
+
+## 6. Exit Codes
+
+| Code | Meaning                                      |
+| ---- | -------------------------------------------- |
+| `0`  | Analysis succeeded, no `error`-severity findings |
+| `1`  | Analysis succeeded, at least one `error`-severity finding |
+| `2`  | Analysis failed (config error, I/O error, etc.)  |
+
+- `warning` and `info` findings do **not** affect the exit code.
+- In `strict_mode`, any finding (regardless of severity) causes exit code `1`.
+
+---
+
+*Last updated: April 2026*


### PR DESCRIPTION
This PR addresses issue #674 by hardening the documentation and specifications related to rule authoring.

### Changes:
- **Created docs/rule-authoring-guide.md**: A comprehensive guide for contributors on how to write, test, and ship custom analysis rules. Covers rule anatomy, matcher types (built-in, YAML, TOML), severity guidelines, and contribution checklists.
- **Created specs/rule-engine-behavior.md**: A technical specification defining the runtime behavior of the rule engine, including discovery order, filtering semantics (enabled_rules, strict_mode, ignore_paths), matching logic, and output stability guarantees.
- **Updated DOCUMENTATION_INDEX.md**: Integrated the new guide and spec into the documentation index and use-case maps for easier discovery.

These additions provide the necessary 'rule authoring guide' context to help the project scale in production with predictable outputs and safe-by-default behavior.

Closes #674