### PR TITLE
feat/fix: SARIF snapshots, coverage gate 80%, Tailwind dark mode, mobile sidebar

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,3 +56,89 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release -p sanctifier-cli
+
+  coverage:
+    name: Coverage Gate (≥ 80% per crate)
+    runs-on: ubuntu-latest
+    # Only enforce on push/PR to main to avoid gating dependabot bumps
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cov-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-cov-
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Collect coverage — sanctifier-core
+        run: |
+          cargo llvm-cov --lcov --output-path lcov-core.info \
+            -p sanctifier-core \
+            --ignore-filename-regex '(_tests\.rs|/tests/|/benches/)'
+
+      - name: Collect coverage — sanctifier-cli
+        run: |
+          cargo llvm-cov --lcov --output-path lcov-cli.info \
+            -p sanctifier-cli \
+            --ignore-filename-regex '(_tests\.rs|/tests/|/benches/)'
+
+      - name: Upload coverage to Codecov (sanctifier-core)
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov-core.info
+          flags: sanctifier-core
+          fail_ci_if_error: true
+
+      - name: Upload coverage to Codecov (sanctifier-cli)
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov-cli.info
+          flags: sanctifier-cli
+          fail_ci_if_error: true
+
+  sarif-snapshots:
+    name: SARIF Snapshot Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-snapshots-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-snapshots-
+
+      - name: Install cargo-insta
+        run: cargo install cargo-insta --locked
+
+      - name: Generate missing snapshots
+        env:
+          INSTA_UPDATE: new
+        run: cargo test --test sarif_snapshots -p sanctifier-core
+
+      - name: Verify snapshots are committed and unchanged
+        run: cargo insta review --no-input --check

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,58 @@
+coverage:
+  # Fail the CI check when coverage drops below the thresholds below.
+  status:
+    project:
+      default:
+        # Overall project target.
+        target: 80%
+        threshold: 2%   # allow up to 2 percentage-point drop before failing
+
+    patch:
+      default:
+        # Every PR must cover at least 80% of the lines it changes.
+        target: 80%
+        threshold: 2%
+
+  # Per-crate coverage flags.
+  # Each flag maps to a Codecov flag uploaded in CI (--flags argument to the
+  # Codecov upload step).  Override the global threshold per crate here.
+  flags:
+    sanctifier-core:
+      paths:
+        - tooling/sanctifier-core/src/
+      target: 80%
+      threshold: 2%
+
+    sanctifier-cli:
+      paths:
+        - tooling/sanctifier-cli/src/
+      target: 80%
+      threshold: 2%
+
+    sanctifier-wasm:
+      paths:
+        - tooling/sanctifier-wasm/src/
+      target: 80%
+      threshold: 2%
+
+# Ignore auto-generated or test-only files.
+ignore:
+  - "**/*_tests.rs"
+  - "**/tests/**"
+  - "**/benches/**"
+  - "**/benchmarks/**"
+  - "contracts/**"       # example contracts are not production code
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true  # only comment when coverage changes
+
+# How to run coverage locally:
+#
+#   cargo install cargo-llvm-cov
+#   cargo llvm-cov --lcov --output-path lcov.info \
+#       -p sanctifier-core -p sanctifier-cli
+#
+# The CI uploads the resulting lcov.info to Codecov automatically.
+# See .github/workflows/rust.yml (coverage job) for the full command.

--- a/frontend/app/components/WorkspaceSidebar.tsx
+++ b/frontend/app/components/WorkspaceSidebar.tsx
@@ -1,87 +1,122 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect } from "react";
 import { useWorkspace } from "../providers/WorkspaceProvider";
 
-export function WorkspaceSidebar() {
-  const { workspace, selectedContract, selectContract } = useWorkspace();
-  const [isOpen, setIsOpen] = useState(false);
+interface WorkspaceSidebarProps {
+  /** Mobile sheet open state (ignored on md+ where the sidebar is always visible). */
+  isOpen?: boolean;
+  /** Called when the user closes the mobile sheet (backdrop click or × button). */
+  onClose?: () => void;
+}
 
-  if (!workspace || workspace.contracts.length <= 1) {
-    return null;
-  }
+function SidebarContent({ onItemClick }: { onItemClick?: () => void }) {
+  const { workspace, selectedContract, selectContract } = useWorkspace();
+
+  if (!workspace || workspace.contracts.length <= 1) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 shadow-sm">
+        <h3 className="text-sm font-semibold mb-3 theme-high-contrast:text-yellow-300">
+          Workspace Members
+        </h3>
+        <nav className="space-y-1 max-h-[calc(100vh-200px)] md:max-h-none overflow-y-auto">
+          {workspace.contracts.map((contract) => (
+            <button
+              key={contract.name}
+              onClick={() => {
+                selectContract(contract.name);
+                onItemClick?.();
+              }}
+              className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                selectedContract?.name === contract.name
+                  ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 font-medium"
+                  : "text-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 hover:text-zinc-700 dark:hover:text-zinc-300"
+              }`}
+            >
+              <div className="flex justify-between items-center">
+                <span className="truncate">{contract.name}</span>
+                {contract.total_findings > 0 && (
+                  <span className="ml-2 px-1.5 py-0.5 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 text-[10px] font-bold">
+                    {contract.total_findings}
+                  </span>
+                )}
+              </div>
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {workspace.shared_libs.length > 0 && (
+        <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 shadow-sm opacity-60">
+          <h3 className="text-sm font-semibold mb-2">Shared Libraries</h3>
+          <ul className="space-y-1 max-h-[200px] overflow-y-auto">
+            {workspace.shared_libs.map((lib) => (
+              <li key={lib} className="px-3 py-1 text-xs text-zinc-500 truncate">
+                📦 {lib}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WorkspaceSidebar({ isOpen = false, onClose }: WorkspaceSidebarProps) {
+  const { workspace } = useWorkspace();
+
+  // Lock body scroll while the mobile sheet is open.
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  if (!workspace || workspace.contracts.length <= 1) return null;
 
   return (
     <>
-      {/* Mobile toggle button */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="md:hidden fixed bottom-4 right-4 z-40 p-3 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 shadow-lg"
-        aria-label="Toggle sidebar"
-      >
-        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
-
-      {/* Mobile overlay */}
-      {isOpen && (
-        <div
-          className="md:hidden fixed inset-0 bg-black/50 z-30"
-          onClick={() => setIsOpen(false)}
-        />
-      )}
-
-      {/* Sidebar */}
-      <aside
-        className={`fixed md:relative md:w-64 md:flex-shrink-0 md:space-y-4 md:translate-x-0 transition-transform duration-300 z-30 ${
-          isOpen ? "translate-x-0" : "-translate-x-full"
-        } w-64 h-screen md:h-auto bg-white dark:bg-zinc-900 md:bg-transparent md:dark:bg-transparent space-y-4 p-4 md:p-0`}
-      >
-        <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 shadow-sm">
-          <h3 className="text-sm font-semibold mb-3 theme-high-contrast:text-yellow-300">
-            Workspace Members
-          </h3>
-          <nav className="space-y-1 max-h-[calc(100vh-200px)] md:max-h-none overflow-y-auto">
-            {workspace.contracts.map((contract) => (
-              <button
-                key={contract.name}
-                onClick={() => {
-                  selectContract(contract.name);
-                  setIsOpen(false);
-                }}
-                className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
-                  selectedContract?.name === contract.name
-                    ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 font-medium"
-                    : "text-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 hover:text-zinc-700 dark:hover:text-zinc-300"
-                }`}
-              >
-                <div className="flex justify-between items-center">
-                  <span className="truncate">{contract.name}</span>
-                  {contract.total_findings > 0 && (
-                    <span className="ml-2 px-1.5 py-0.5 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 text-[10px] font-bold">
-                      {contract.total_findings}
-                    </span>
-                  )}
-                </div>
-              </button>
-            ))}
-          </nav>
-        </div>
-
-        {workspace.shared_libs.length > 0 && (
-          <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 shadow-sm opacity-60">
-            <h3 className="text-sm font-semibold mb-2">Shared Libraries</h3>
-            <ul className="space-y-1 max-h-[200px] overflow-y-auto">
-              {workspace.shared_libs.map((lib) => (
-                <li key={lib} className="px-3 py-1 text-xs text-zinc-500 truncate">
-                  📦 {lib}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
+      {/* Desktop: permanent fixed-width sidebar */}
+      <aside className="hidden md:block w-64 flex-shrink-0">
+        <SidebarContent />
       </aside>
+
+      {/* Mobile: slide-out sheet */}
+      {isOpen && (
+        <div className="md:hidden fixed inset-0 z-40 flex">
+          {/* Backdrop */}
+          <button
+            aria-label="Close sidebar"
+            className="absolute inset-0 bg-black/50"
+            onClick={onClose}
+          />
+
+          {/* Sheet panel */}
+          <div
+            role="dialog"
+            aria-label="Workspace members"
+            className="relative z-50 w-64 max-w-[85vw] h-full bg-white dark:bg-zinc-900 border-r border-zinc-200 dark:border-zinc-800 overflow-y-auto p-4 flex flex-col gap-4 animate-in slide-in-from-left duration-300"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                Contracts
+              </span>
+              <button
+                aria-label="Close sidebar"
+                onClick={onClose}
+                className="p-1 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors text-zinc-500"
+              >
+                ✕
+              </button>
+            </div>
+
+            <SidebarContent onItemClick={onClose} />
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -45,6 +45,7 @@ export default function DashboardPage() {
   const [codeFilterInput, setCodeFilterInput] = useState("");
   const [codeFilterError, setCodeFilterError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const currentReport = selectedContract?.report;
 
@@ -184,8 +185,24 @@ export default function DashboardPage() {
           sampleJson={SAMPLE_JSON}
         />
 
+        {/* Mobile sidebar hamburger — only shown when a multi-contract workspace is loaded */}
+        <div className="md:hidden">
+          <button
+            aria-label="Open workspace sidebar"
+            onClick={() => setSidebarOpen(true)}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+              <rect y="3" width="18" height="2" rx="1" fill="currentColor" />
+              <rect y="8" width="18" height="2" rx="1" fill="currentColor" />
+              <rect y="13" width="18" height="2" rx="1" fill="currentColor" />
+            </svg>
+            Contracts
+          </button>
+        </div>
+
         <div className="flex flex-col md:flex-row gap-8">
-          <WorkspaceSidebar />
+          <WorkspaceSidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
           <div className="flex-1 space-y-8">
             {hasData && (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+/* Tailwind v4: wire the `dark:` variant to the `.dark` class on <html>.
+   Without this, `dark:` defaults to the prefers-color-scheme media query and
+   the theme toggle has no effect on utility-class-styled content. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/tooling/sanctifier-core/Cargo.toml
+++ b/tooling/sanctifier-core/Cargo.toml
@@ -32,6 +32,8 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
+insta = { version = "1.40", features = ["json", "redactions"] }
+serde_json = "1.0"
 
 [[bench]]
 name = "benchmark"

--- a/tooling/sanctifier-core/tests/sarif_snapshots.rs
+++ b/tooling/sanctifier-core/tests/sarif_snapshots.rs
@@ -1,0 +1,348 @@
+//! Snapshot tests for SARIF output of every built-in rule.
+//!
+//! Each test runs a rule against a minimal Soroban source snippet that is
+//! guaranteed to trigger at least one violation and snapshots the
+//! JSON-serialised `RuleViolation` list.  This catches silent regressions
+//! in rule messages, severity levels, or suggestion text.
+//!
+//! Run locally:
+//!   cargo test --test sarif_snapshots
+//!
+//! To regenerate snapshots after an intentional change:
+//!   INSTA_UPDATE=new cargo test --test sarif_snapshots
+//!   cargo insta review
+
+use insta::with_settings;
+use sanctifier_core::rules::{
+    arithmetic_overflow::ArithmeticOverflowRule,
+    auth_gap::AuthGapRule,
+    instance_storage_misuse::InstanceStorageMisuseRule,
+    ledger_size::LedgerSizeRule,
+    missing_state_event::MissingStateEventRule,
+    panic_detection::PanicDetectionRule,
+    reentrancy::ReentrancyRule,
+    shadow_storage::ShadowStorageRule,
+    storage_update_state_check::StorageUpdateStateCheckRule,
+    truncation_bounds::TruncationBoundsRule,
+    unchecked_external_call::UncheckedExternalCallRule,
+    unhandled_result::UnhandledResultRule,
+    unsafe_prng::UnsafePrngRule,
+    unused_variable::UnusedVariableRule,
+    variable_shadowing::VariableShadowingRule,
+    Rule, RuleViolation,
+};
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+/// Serialize violations to a JSON value, replacing the `location` field with
+/// a stable placeholder so snapshots are not fragile to span/line-number shifts
+/// that syn reports for string inputs.
+fn violations_json(violations: &[RuleViolation]) -> serde_json::Value {
+    let mut v: serde_json::Value = serde_json::to_value(violations).unwrap();
+    if let Some(arr) = v.as_array_mut() {
+        for item in arr.iter_mut() {
+            if let Some(loc) = item.get_mut("location") {
+                // Keep the function-name prefix, strip the `:line` suffix.
+                let s = loc.as_str().unwrap_or("").to_string();
+                let stable = s.split(':').next().unwrap_or(&s).to_string();
+                *loc = serde_json::Value::String(stable);
+            }
+        }
+    }
+    v
+}
+
+// ── auth_gap ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_auth_gap() {
+    let source = r#"
+        impl MyContract {
+            pub fn withdraw(env: Env, recipient: Address, amount: i128) {
+                env.storage().persistent().set(&recipient, &amount);
+            }
+        }
+    "#;
+    let rule = AuthGapRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "auth_gap must fire");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("auth_gap", violations_json(&violations));
+    });
+}
+
+// ── panic_detection ───────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_panic_detection() {
+    let source = r#"
+        impl MyContract {
+            pub fn fund(env: Env, key: i64) {
+                let _v = env.storage().persistent().get(&key).unwrap();
+            }
+        }
+    "#;
+    let rule = PanicDetectionRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "panic_detection must fire for unwrap");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("panic_detection", violations_json(&violations));
+    });
+}
+
+// ── arithmetic_overflow ───────────────────────────────────────────────────────
+
+#[test]
+fn sarif_arithmetic_overflow() {
+    let source = r#"
+        impl MyContract {
+            pub fn add(env: Env, a: i128, b: i128) -> i128 {
+                a + b
+            }
+        }
+    "#;
+    let rule = ArithmeticOverflowRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "arithmetic_overflow must fire for bare +");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("arithmetic_overflow", violations_json(&violations));
+    });
+}
+
+// ── unsafe_prng ───────────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_unsafe_prng() {
+    let source = r#"
+        impl MyContract {
+            pub fn draw_winner(env: Env, slot: i64) {
+                let n = env.prng().u64_in_range(0..100);
+                env.storage().persistent().set(&slot, &n);
+            }
+        }
+    "#;
+    let rule = UnsafePrngRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "unsafe_prng must fire");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("unsafe_prng", violations_json(&violations));
+    });
+}
+
+// ── unhandled_result ──────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_unhandled_result() {
+    let source = r#"
+        impl MyContract {
+            pub fn transfer(env: Env, token: Address, to: Address, amount: i128) {
+                token::Client::new(&env, &token).try_transfer(&env.current_contract_address(), &to, &amount);
+            }
+        }
+    "#;
+    let rule = UnhandledResultRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "unhandled_result must fire for ignored try_*");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("unhandled_result", violations_json(&violations));
+    });
+}
+
+// ── shadow_storage ────────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_shadow_storage() {
+    let source = r#"
+        impl MyContract {
+            pub fn set_user_balance(env: Env, user: Address, balance: i128) {
+                env.storage().instance().set(&user, &balance);
+            }
+            pub fn set_global_balance(env: Env, balance: i128) {
+                let user = Address::from_str("GABC");
+                env.storage().instance().set(&user, &balance);
+            }
+        }
+    "#;
+    let rule = ShadowStorageRule::new();
+    let violations = rule.check(source);
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("shadow_storage", violations_json(&violations));
+    });
+}
+
+// ── reentrancy ────────────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_reentrancy() {
+    let source = r#"
+        impl MyContract {
+            pub fn withdraw(env: Env, amount: i128, recipient: Address) {
+                env.storage().persistent().set(&symbol_short!("BAL"), &(amount - 10));
+                env.invoke_contract::<()>(&recipient, &symbol_short!("recv"), vec![&env]);
+            }
+        }
+    "#;
+    let rule = ReentrancyRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "reentrancy must fire");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("reentrancy", violations_json(&violations));
+    });
+}
+
+// ── unused_variable ───────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_unused_variable() {
+    let source = r#"
+        impl MyContract {
+            pub fn compute(env: Env, input: i128) -> i128 {
+                let result = input * 2;
+                let extra = 99i128;
+                result
+            }
+        }
+    "#;
+    let rule = UnusedVariableRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "unused_variable must fire for 'extra'");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("unused_variable", violations_json(&violations));
+    });
+}
+
+// ── truncation_bounds ─────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_truncation_bounds() {
+    let source = r#"
+        impl MyContract {
+            pub fn shrink(env: Env, big: i128) -> u32 {
+                big as u32
+            }
+        }
+    "#;
+    let rule = TruncationBoundsRule::new();
+    let violations = rule.check(source);
+    assert!(!violations.is_empty(), "truncation_bounds must fire for i128 as u32");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("truncation_bounds", violations_json(&violations));
+    });
+}
+
+// ── unchecked_external_call ───────────────────────────────────────────────────
+
+#[test]
+fn sarif_unchecked_external_call() {
+    let source = r#"
+        impl MyContract {
+            pub fn call_other(env: Env, other: Address) {
+                env.invoke_contract::<()>(&other, &symbol_short!("foo"), vec![&env]);
+            }
+        }
+    "#;
+    let rule = UncheckedExternalCallRule::new();
+    let violations = rule.check(source);
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("unchecked_external_call", violations_json(&violations));
+    });
+}
+
+// ── storage_update_state_check ────────────────────────────────────────────────
+
+#[test]
+fn sarif_storage_update_state_check() {
+    let source = r#"
+        impl MyContract {
+            pub fn bump_counter(env: Env) {
+                env.storage().instance().update(&symbol_short!("CTR"), |v: Option<u32>| -> Result<u32, ()> {
+                    Ok(v.unwrap_or(0) + 1)
+                });
+            }
+        }
+    "#;
+    let rule = StorageUpdateStateCheckRule::new();
+    let violations = rule.check(source);
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("storage_update_state_check", violations_json(&violations));
+    });
+}
+
+// ── variable_shadowing ────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_variable_shadowing() {
+    let source = r#"
+        impl MyContract {
+            pub fn compute(env: Env, x: i128) -> i128 {
+                let x = x * 2;
+                let x = x + 1;
+                x
+            }
+        }
+    "#;
+    let rule = VariableShadowingRule::new();
+    let violations = rule.check(source);
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("variable_shadowing", violations_json(&violations));
+    });
+}
+
+// ── missing_state_event ───────────────────────────────────────────────────────
+
+#[test]
+fn sarif_missing_state_event() {
+    let source = r#"
+        impl MyContract {
+            pub fn update_config(env: Env, new_fee: u32) {
+                env.storage().instance().set(&symbol_short!("FEE"), &new_fee);
+            }
+        }
+    "#;
+    let rule = MissingStateEventRule::new();
+    let violations = rule.check(source);
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("missing_state_event", violations_json(&violations));
+    });
+}
+
+// ── instance_storage_misuse ───────────────────────────────────────────────────
+
+#[test]
+fn sarif_instance_storage_misuse() {
+    let source = r#"
+        impl MyContract {
+            pub fn set_balance(env: Env, user: Address, amount: i128) {
+                env.storage().instance().set(&user, &amount);
+            }
+        }
+    "#;
+    let rule = InstanceStorageMisuseRule::new();
+    let violations = rule.check(source);
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("instance_storage_misuse", violations_json(&violations));
+    });
+}
+
+// ── ledger_size (no-violation baseline) ──────────────────────────────────────
+
+#[test]
+fn sarif_ledger_size_clean() {
+    let source = r#"
+        #[contracttype]
+        pub struct SmallEntry {
+            pub value: u32,
+        }
+
+        impl MyContract {
+            pub fn store(env: Env, v: u32) {
+                env.storage().persistent().set(&symbol_short!("V"), &v);
+            }
+        }
+    "#;
+    let rule = LedgerSizeRule::new();
+    let violations = rule.check(source);
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!("ledger_size_clean", violations_json(&violations));
+    });
+}


### PR DESCRIPTION
Fixes #840
Fixes #842
Fixes #851
Fixes #859

## What changed

### #840 — SARIF snapshot tests

Added `tooling/sanctifier-core/tests/sarif_snapshots.rs` — one `insta` snapshot test per built-in rule (15 rules total: `auth_gap`, `panic_detection`, `arithmetic_overflow`, `unsafe_prng`, `unhandled_result`, `shadow_storage`, `reentrancy`, `unused_variable`, `truncation_bounds`, `unchecked_external_call`, `storage_update_state_check`, `variable_shadowing`, `missing_state_event`, `instance_storage_misuse`, `ledger_size`). Each test runs the rule against a minimal triggering source snippet, serialises the `Vec<RuleViolation>` as JSON, and calls `insta::assert_json_snapshot!`. A `violations_json()` helper normalises the `:line` suffix from `location` so snapshots remain stable across parse-span shifts. Added `insta` and `serde_json` to `[dev-dependencies]` in `sanctifier-core/Cargo.toml`. Added a `sarif-snapshots` job to `rust.yml` that runs with `INSTA_UPDATE=new` (generates missing snapshots on first run) then `cargo insta review --no-input --check` (fails if any snapshot is new or changed).

### #842 — Coverage gate ≥ 80% per crate

Created `codecov.yml` with per-crate flags (`sanctifier-core`, `sanctifier-cli`, `sanctifier-wasm`), each set to an 80% line-coverage threshold with a 2 percentage-point tolerance. Patch coverage also gated at 80%. Test/bench/contracts paths are excluded. Added a `coverage` job to `rust.yml` that uses `cargo-llvm-cov` to collect lcov data separately per crate and uploads with the matching flag via `codecov/codecov-action@v5`. The job runs on every push and PR to `main`.

To run locally:
```bash
cargo install cargo-llvm-cov
cargo llvm-cov --lcov --output-path lcov.info -p sanctifier-core -p sanctifier-cli
```

### #851 — Tailwind v4 dark mode (theme toggle only affected NavBar)

Added one line to `frontend/app/globals.css`, immediately after `@import "tailwindcss";`:

```css
@custom-variant dark (&:where(.dark, .dark *));
```

In Tailwind v4, `dark:` defaults to `prefers-color-scheme`. This declaration re-wires it to the `.dark` class that the theme toggle sets on `<html>`. Previously, every `dark:bg-zinc-900`, `dark:text-zinc-100`, etc. was dead — only the NavBar changed because its background bled through via CSS variables. After this fix, all pages (`/`, `/scan`, `/dashboard`, `/playground`, `/terminal`) flip palettes correctly.

### #859 — Dashboard sidebar mobile collapse

Refactored `WorkspaceSidebar` to support two render modes:
- **Desktop (`md+`):** unchanged — permanent `w-64 flex-shrink-0` aside (now `hidden md:block`)
- **Mobile (`<md`):** a fixed slide-out sheet with a dark backdrop overlay, a `×` close button, body-scroll lock (`overflow: hidden` on `<body>`), and a slide-in animation. Selecting a contract auto-closes the sheet.

Added `sidebarOpen` state and a hamburger button (`md:hidden`) to `dashboard/page.tsx` that opens the sheet. The findings list, summary chart, and call graph now use the full width on mobile.

## How to test

- **Snapshots**: `cargo test --test sarif_snapshots -p sanctifier-core` — should pass (or generate initial snapshots on first run); `cargo insta review --no-input --check` should then pass.
- **Coverage**: `cargo llvm-cov --lcov -p sanctifier-core` — should produce an lcov file.
- **Dark mode**: `cd frontend && npm run dev`, open any page, click the theme toggle — all page backgrounds, borders, and text should flip between light and dark palettes.
- **Mobile sidebar**: resize browser to < 768 px on `/dashboard` with a workspace loaded — the sidebar should be hidden; clicking the hamburger should open the slide-out sheet; clicking a contract or the backdrop should close it.