### PR TITLE
feat: analysis profiles, batch upload, system theme, env validation

### DIFF
--- a/docs/analysis-profiles.md
+++ b/docs/analysis-profiles.md
@@ -1,0 +1,74 @@
+# Analysis Profiles
+
+The `--profile` flag selects a named preset that controls which findings are emitted and whether a non-zero exit code is returned. It overrides `--exit-code` and `--min-severity` when set.
+
+```
+sanctifier analyze --profile ci ./contracts
+```
+
+## Profile matrix
+
+| Profile   | Rules emitted              | Fatal threshold       | Use case                            |
+|-----------|----------------------------|-----------------------|-------------------------------------|
+| `strict`  | All rules                  | Any finding           | Pre-merge gate on critical projects |
+| `lenient` | Critical + High only       | None (always exits 0) | Developer workflow, noisy codebases |
+| `audit`   | All rules                  | None (always exits 0) | Security audit reports              |
+| `ci`      | All rules                  | Critical + High       | Standard CI pipeline gate           |
+
+### strict
+
+Emits all built-in rules and exits with code `1` if at least one finding is produced, regardless of severity.
+
+```bash
+sanctifier analyze --profile strict .
+```
+
+### lenient
+
+Suppresses medium and low severity categories (storage collisions, variable shadowing, custom rules, contract-import mismatches, and vuln-db matches below High) to reduce noise during development. Always exits `0`.
+
+```bash
+sanctifier analyze --profile lenient .
+```
+
+### audit
+
+Emits every rule including informational findings. Exits `0` regardless of findings — suitable for generating full audit reports where a non-zero exit would break tooling.
+
+```bash
+sanctifier analyze --profile audit --format json . > audit-report.json
+```
+
+### ci
+
+Emits all rules so the full finding set is visible in logs, but only exits `1` when at least one **Critical** or **High** finding is present. Medium and Low findings are reported but non-fatal.
+
+```bash
+sanctifier analyze --profile ci --format json .
+```
+
+## Relationship to --exit-code / --min-severity
+
+`--profile` takes precedence. When a profile is set, `--exit-code` and `--min-severity` are ignored.
+
+To use custom thresholds without a preset, omit `--profile` and configure `--exit-code` with `--min-severity` directly:
+
+```bash
+# exit 1 on any medium-or-higher finding
+sanctifier analyze --exit-code --min-severity medium .
+```
+
+## Profile in JSON output
+
+The active profile is included in the `metadata` block of JSON reports:
+
+```json
+{
+  "metadata": {
+    "profile": "ci",
+    ...
+  }
+}
+```
+
+When no profile is set, `"profile"` is `null`.

--- a/frontend/app/api/ai/explain/route.ts
+++ b/frontend/app/api/ai/explain/route.ts
@@ -1,7 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { Finding } from "../../../types";
+import { AI_EXPLAIN_PROVIDER } from "../../../lib/env";
 
 export async function POST(req: NextRequest) {
+  if (!AI_EXPLAIN_PROVIDER && process.env.STUB_AI !== "1") {
+    return NextResponse.json(
+      { error: "AI provider not configured", set: ["AI_EXPLAIN_PROVIDER"] },
+      { status: 503 }
+    );
+  }
+
   try {
     const { finding } = (await req.json()) as { finding: Finding };
 

--- a/frontend/app/api/analyze/route.ts
+++ b/frontend/app/api/analyze/route.ts
@@ -3,8 +3,8 @@ import { spawn } from "child_process";
 import path from "path";
 import os from "os";
 import { mkdtemp, rm, writeFile } from "fs/promises";
-import { normalizeReport, transformReport } from "../../lib/transform";
-import type { Finding } from "../../types";
+import { normalizeReport } from "../../lib/transform";
+import { SANCTIFIER_BIN, RATE_LIMIT_REQUESTS_PER_MINUTE } from "../../lib/env";
 
 export const runtime = "nodejs";
 
@@ -12,8 +12,6 @@ const REPO_ROOT = path.resolve(process.cwd(), "..");
 const SUPPORTED_SOURCE_EXTENSIONS = new Set([".rs"]);
 const MAX_FILE_SIZE_BYTES = 250 * 1024;
 const EXECUTION_TIMEOUT_MS = 30000;
-const RATE_LIMIT_REQUESTS_PER_MINUTE = 10;
-const SANCTIFIER_BIN = process.env.SANCTIFIER_BIN?.trim() || "sanctifier";
 
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
 
@@ -262,6 +260,7 @@ export async function POST(request: NextRequest) {
   }
 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "sanctifier-contract-"));
+  try {
     const contentType = request.headers.get("content-type") ?? "";
 
     let sourcePayload: { fileName: string; source: string } | null = null;
@@ -312,8 +311,7 @@ export async function POST(request: NextRequest) {
     const report = parseJsonResponse(stdout);
 
     if (report) {
-      const findings: Finding[] = transformReport(normalizeReport(report));
-      return Response.json(findings);
+      return Response.json(normalizeReport(report));
     }
 
     return Response.json(

--- a/frontend/app/components/DashboardHeader.tsx
+++ b/frontend/app/components/DashboardHeader.tsx
@@ -1,41 +1,79 @@
 "use client";
 
 import Link from "next/link";
-import React from "react";
+import React, { useState } from "react";
+import type { RejectedFile } from "../lib/upload-validation";
+
+export type FileProgress = "pending" | "analyzing" | "done" | "error";
 
 interface DashboardHeaderProps {
   jsonInput: string;
   setJsonInput: (v: string) => void;
   loadReport: () => void;
   handleFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleContractUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onContractFiles: (files: File[]) => void;
   exportToPdf: () => void;
   hasData: boolean;
   isProcessing: boolean;
   uploadStatus: string | null;
   error: string | null;
   sampleJson: string;
+  batchProgress?: Record<string, FileProgress>;
+  rejectedFiles?: RejectedFile[];
 }
+
+const PROGRESS_ICON: Record<FileProgress, string> = {
+  pending:   "○",
+  analyzing: "…",
+  done:      "✓",
+  error:     "✗",
+};
 
 export function DashboardHeader({
   jsonInput,
   setJsonInput,
   loadReport,
   handleFileUpload,
-  handleContractUpload,
+  onContractFiles,
   exportToPdf,
   hasData,
   isProcessing,
   uploadStatus,
   error,
   sampleJson,
+  batchProgress,
+  rejectedFiles,
 }: DashboardHeaderProps) {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    // Only clear when leaving the zone itself, not child elements
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) onContractFiles(files);
+  };
+
+  const batchEntries = batchProgress ? Object.entries(batchProgress) : [];
+  const showBatchList = batchEntries.length > 1;
+
   return (
     <section className="rounded-xl border border-zinc-200 dark:border-zinc-800 theme-high-contrast:border-white bg-white dark:bg-zinc-900 theme-high-contrast:bg-black p-6 shadow-sm">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold theme-high-contrast:text-yellow-300">Load Analysis Report</h2>
-        <Link 
-          href="/dashboard/webhooks" 
+        <Link
+          href="/dashboard/webhooks"
           className="flex items-center gap-2 text-xs font-bold text-zinc-500 hover:text-emerald-500 transition-colors bg-zinc-50 dark:bg-zinc-950 px-3 py-1.5 rounded-lg border border-zinc-200 dark:border-zinc-800"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
@@ -58,14 +96,19 @@ export function DashboardHeader({
           />
         </label>
         <label className="flex-1 sm:flex-none text-center cursor-pointer rounded-lg border border-zinc-300 dark:border-zinc-600 theme-high-contrast:border-white px-4 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 theme-high-contrast:hover:bg-zinc-900 focus-within:outline-none focus-within:ring-2 focus-within:ring-zinc-400 focus-within:ring-offset-2">
-          {isProcessing ? "Processing..." : "Upload Contract"}
+          {isProcessing ? "Processing…" : "Upload Contract"}
           <input
             type="file"
             accept=".rs"
+            multiple
             className="hidden"
             aria-label="Contract file"
             data-testid="contract-upload-input"
-            onChange={handleContractUpload}
+            onChange={(e) => {
+              const files = Array.from(e.target.files ?? []);
+              if (files.length > 0) onContractFiles(files);
+              e.target.value = "";
+            }}
           />
         </label>
         <button
@@ -82,6 +125,24 @@ export function DashboardHeader({
           Export PDF
         </button>
       </div>
+
+      {/* Drag-and-drop batch upload zone */}
+      <div
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={`mt-3 rounded-lg border-2 border-dashed px-4 py-5 text-center text-sm transition-colors select-none ${
+          isDragging
+            ? "border-zinc-600 dark:border-zinc-300 bg-zinc-50 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200"
+            : "border-zinc-300 dark:border-zinc-700 text-zinc-400 dark:text-zinc-500"
+        }`}
+        aria-label="Drop zone for .rs contract files"
+      >
+        {isDragging
+          ? "Drop .rs files to analyze"
+          : "Drag & drop one or more .rs contract files here for batch analysis"}
+      </div>
+
       {uploadStatus && (
         <p className="mt-2 text-sm text-emerald-600 dark:text-emerald-400" role="status" aria-live="polite">
           {uploadStatus}
@@ -90,6 +151,49 @@ export function DashboardHeader({
       {error && (
         <p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>
       )}
+
+      {/* Rejected files toast */}
+      {rejectedFiles && rejectedFiles.length > 0 && (
+        <div
+          role="alert"
+          className="mt-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 px-3 py-2 text-xs text-amber-800 dark:text-amber-300"
+        >
+          <p className="font-medium mb-0.5">Skipped {rejectedFiles.length} file{rejectedFiles.length > 1 ? "s" : ""}:</p>
+          <ul className="space-y-0.5 list-disc list-inside">
+            {rejectedFiles.map(({ name, reason }) => (
+              <li key={name}>
+                <span className="font-mono">{name}</span> — {reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Per-file batch progress list */}
+      {showBatchList && (
+        <ul className="mt-3 space-y-1" aria-label="Batch analysis progress">
+          {batchEntries.map(([name, status]) => (
+            <li key={name} className="flex items-center gap-2 text-xs font-mono">
+              <span
+                className={
+                  status === "done" ? "text-emerald-600 dark:text-emerald-400"
+                  : status === "error" ? "text-red-600 dark:text-red-400"
+                  : "text-zinc-400 dark:text-zinc-500"
+                }
+              >
+                {PROGRESS_ICON[status]}
+              </span>
+              <span className="text-zinc-700 dark:text-zinc-300 truncate max-w-xs">{name}</span>
+              <span className="text-zinc-400 dark:text-zinc-500 shrink-0">
+                {status === "analyzing" && "Analyzing…"}
+                {status === "done" && "Done"}
+                {status === "error" && "Failed"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
       <textarea
         value={jsonInput}
         onChange={(e) => setJsonInput(e.target.value)}

--- a/frontend/app/components/ThemeToggle.tsx
+++ b/frontend/app/components/ThemeToggle.tsx
@@ -1,17 +1,26 @@
 "use client";
 
 import { useTheme } from "../providers/theme-provider";
+import type { Theme } from "../providers/theme-provider";
+
+const THEME_META: Record<Theme, { label: string; ariaLabel: string }> = {
+  light:  { label: "Light",  ariaLabel: "Switch to Dark mode" },
+  dark:   { label: "Dark",   ariaLabel: "Switch to System mode" },
+  system: { label: "System", ariaLabel: "Switch to Light mode" },
+};
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+  const { label, ariaLabel } = THEME_META[theme] ?? THEME_META.system;
 
   return (
     <button
       onClick={toggleTheme}
       className="rounded-lg border border-zinc-300 dark:border-zinc-600 px-3 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2"
-      aria-label="Toggle theme"
+      aria-label={ariaLabel}
+      title={ariaLabel}
     >
-      {theme === "dark" ? "Switch to Light" : "Switch to Dark"}
+      {label}
     </button>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -5,7 +5,10 @@ import dynamic from "next/dynamic";
 import type { Severity } from "../types";
 import { transformReport, extractCallGraph, normalizeReport } from "../lib/transform";
 import { normalizeFindingCodeQuery, validateFindingCodeQuery } from "../lib/finding-filters";
-import { validateContractUpload } from "../lib/upload-validation";
+import { validateContractBatch } from "../lib/upload-validation";
+import type { RejectedFile } from "../lib/upload-validation";
+import type { FileProgress } from "../components/DashboardHeader";
+import type { WorkspaceSummary } from "../types";
 import {
   createWorkspaceFromSingleReport,
   extractErrorMessage,
@@ -35,7 +38,7 @@ const CallGraph = dynamic(() => import("../components/CallGraph").then((m) => m.
 type Tab = "findings" | "callgraph";
 
 export default function DashboardPage() {
-  const { selectedContract, setWorkspace } = useWorkspace();
+  const { selectedContract, setWorkspace, updateContractReport } = useWorkspace();
   const [severityFilter, setSeverityFilter] = useState<Severity | "all">("all");
   const [error, setError] = useState<string | null>(null);
   const [jsonInput, setJsonInput] = useState("");
@@ -46,6 +49,8 @@ export default function DashboardPage() {
   const [codeFilterError, setCodeFilterError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [batchProgress, setBatchProgress] = useState<Record<string, FileProgress>>({});
+  const [rejectedFiles, setRejectedFiles] = useState<RejectedFile[]>([]);
 
   const currentReport = selectedContract?.report;
 
@@ -102,61 +107,90 @@ export default function DashboardPage() {
     e.target.value = "";
   }, [parseReport]);
 
-  const handleContractUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.currentTarget;
-    const file = input.files?.[0];
-    input.value = "";
+  const analyzeFile = useCallback(async (file: File): Promise<unknown> => {
+    const formData = new FormData();
+    formData.append("contract", file);
+    const response = await fetch("/api/analyze", { method: "POST", body: formData });
+    const rawBody = await response.text();
+    let payload: unknown = null;
+    if (rawBody) {
+      try { payload = JSON.parse(rawBody); } catch { payload = rawBody; }
+    }
+    if (!response.ok) throw new Error(extractErrorMessage(payload, "Contract analysis failed"));
+    return payload;
+  }, []);
 
-    if (!file) {
-      return;
+  const handleContractFiles = useCallback(async (files: File[]) => {
+    const { valid, rejected } = validateContractBatch(files);
+
+    if (rejected.length > 0) {
+      setRejectedFiles(rejected);
+      setTimeout(() => setRejectedFiles([]), 6000);
     }
 
-    const validationError = validateContractUpload(file);
-    if (validationError) {
-      setUploadStatus(null);
-      setError(validationError);
-      return;
-    }
+    if (valid.length === 0) return;
 
     setError(null);
-    setUploadStatus(`Analyzing ${file.name}...`);
     setIsUploadingContract(true);
 
-    try {
-      const formData = new FormData();
-      formData.append("contract", file);
-
-      const response = await fetch("/api/analyze", {
-        method: "POST",
-        body: formData,
-      });
-      const rawBody = await response.text();
-
-      let payload: unknown = null;
-      if (rawBody) {
-        try {
-          payload = JSON.parse(rawBody);
-        } catch {
-          payload = rawBody;
-        }
+    if (valid.length === 1) {
+      const file = valid[0];
+      setBatchProgress({ [file.name]: "analyzing" });
+      setUploadStatus(`Analyzing ${file.name}…`);
+      try {
+        const payload = await analyzeFile(file);
+        setJsonInput(JSON.stringify(payload, null, 2));
+        applyReport(payload);
+        setBatchProgress({ [file.name]: "done" });
+        setUploadStatus(`Analysis report ready for ${file.name}.`);
+      } catch (err) {
+        setBatchProgress({ [file.name]: "error" });
+        setUploadStatus(null);
+        setError(err instanceof Error ? err.message : "Contract analysis failed");
+      } finally {
+        setIsUploadingContract(false);
       }
-
-      if (!response.ok) {
-        throw new Error(extractErrorMessage(payload, "Contract analysis failed"));
-      }
-
-      setJsonInput(JSON.stringify(payload, null, 2));
-      applyReport(payload);
-      setUploadStatus(`Analysis report ready for ${file.name}.`);
-    } catch (uploadError) {
-      setUploadStatus(null);
-      setError(
-        uploadError instanceof Error ? uploadError.message : "Contract analysis failed"
-      );
-    } finally {
-      setIsUploadingContract(false);
+      return;
     }
-  }, [applyReport]);
+
+    // Batch: create workspace skeleton, then analyze each file
+    const initialProgress: Record<string, FileProgress> = {};
+    for (const f of valid) initialProgress[f.name] = "pending";
+    setBatchProgress(initialProgress);
+    setUploadStatus(`Analyzing ${valid.length} files…`);
+
+    const skeleton: WorkspaceSummary = {
+      workspace: "batch-upload",
+      contracts: valid.map((f) => ({ name: f.name, total_findings: 0 })),
+      shared_libs: [],
+      grand_total_findings: 0,
+    };
+    setWorkspace(skeleton);
+
+    let doneCount = 0;
+    let errorCount = 0;
+
+    await Promise.all(
+      valid.map(async (file) => {
+        setBatchProgress((prev) => ({ ...prev, [file.name]: "analyzing" }));
+        try {
+          const payload = await analyzeFile(file);
+          const report = normalizeReport(payload);
+          updateContractReport(file.name, report);
+          setBatchProgress((prev) => ({ ...prev, [file.name]: "done" }));
+          doneCount++;
+        } catch {
+          setBatchProgress((prev) => ({ ...prev, [file.name]: "error" }));
+          errorCount++;
+        }
+      })
+    );
+
+    setIsUploadingContract(false);
+    setUploadStatus(
+      `Batch complete: ${doneCount} analyzed${errorCount > 0 ? `, ${errorCount} failed` : ""}.`
+    );
+  }, [analyzeFile, applyReport, setWorkspace, updateContractReport]);
 
   const handleCodeFilterChange = useCallback((input: string) => {
     const normalized = normalizeFindingCodeQuery(input);
@@ -171,18 +205,20 @@ export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 theme-high-contrast:bg-black theme-high-contrast:text-white">
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-8">
-        <DashboardHeader 
+        <DashboardHeader
           jsonInput={jsonInput}
           setJsonInput={setJsonInput}
           loadReport={loadReport}
           handleFileUpload={handleFileUpload}
-          handleContractUpload={handleContractUpload}
+          onContractFiles={handleContractFiles}
           exportToPdf={() => exportToPdf(findings)}
           hasData={hasData}
           isProcessing={isProcessing}
           uploadStatus={uploadStatus}
           error={error}
           sampleJson={SAMPLE_JSON}
+          batchProgress={batchProgress}
+          rejectedFiles={rejectedFiles}
         />
 
         {/* Mobile sidebar hamburger — only shown when a multi-contract workspace is loaded */}

--- a/frontend/app/lib/env.ts
+++ b/frontend/app/lib/env.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+type Status = "set" | "defaulted" | "missing";
+
+type EnvEntry = {
+  key: string;
+  value: string | undefined;
+  defaultValue?: string;
+  description: string;
+};
+
+const entries: EnvEntry[] = [
+  { key: "SANCTIFIER_BIN",                  value: process.env.SANCTIFIER_BIN,                  defaultValue: "sanctifier", description: "Path to the sanctifier binary" },
+  { key: "AI_EXPLAIN_PROVIDER",             value: process.env.AI_EXPLAIN_PROVIDER,                             description: "AI provider (anthropic | openai)" },
+  { key: "ANTHROPIC_API_KEY",               value: process.env.ANTHROPIC_API_KEY,               description: "Anthropic API key (required when provider=anthropic)" },
+  { key: "OPENAI_API_KEY",                  value: process.env.OPENAI_API_KEY,                  description: "OpenAI API key (required when provider=openai)" },
+  { key: "RATE_LIMIT_REQUESTS_PER_MINUTE",  value: process.env.RATE_LIMIT_REQUESTS_PER_MINUTE,  defaultValue: "10", description: "Max analyze requests per IP per minute" },
+];
+
+function statusOf(entry: EnvEntry): Status {
+  if (entry.value?.trim()) return "set";
+  if (entry.defaultValue !== undefined) return "defaulted";
+  return "missing";
+}
+
+// Startup log table — emitted once at module load
+const rows = entries.map((e) => {
+  const status = statusOf(e);
+  const icon = status === "set" ? "✓ set" : status === "defaulted" ? "! defaulted" : "✗ missing";
+  return `  ${icon.padEnd(14)}${e.key.padEnd(36)}${e.description}`;
+});
+console.log(`\n[sanctifier] environment:\n${rows.join("\n")}\n`);
+
+export const SANCTIFIER_BIN = process.env.SANCTIFIER_BIN?.trim() || "sanctifier";
+export const AI_EXPLAIN_PROVIDER = process.env.AI_EXPLAIN_PROVIDER?.trim() || "";
+export const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || "";
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
+export const RATE_LIMIT_REQUESTS_PER_MINUTE = (() => {
+  const raw = process.env.RATE_LIMIT_REQUESTS_PER_MINUTE;
+  if (!raw) return 10;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10;
+})();

--- a/frontend/app/lib/upload-validation.ts
+++ b/frontend/app/lib/upload-validation.ts
@@ -20,3 +20,24 @@ export function validateContractUpload(file: File): string | null {
 
   return null;
 }
+
+export type RejectedFile = { name: string; reason: string };
+
+export type BatchValidationResult = {
+  valid: File[];
+  rejected: RejectedFile[];
+};
+
+export function validateContractBatch(files: File[]): BatchValidationResult {
+  const valid: File[] = [];
+  const rejected: RejectedFile[] = [];
+  for (const file of files) {
+    const error = validateContractUpload(file);
+    if (error) {
+      rejected.push({ name: file.name, reason: error });
+    } else {
+      valid.push(file);
+    }
+  }
+  return { valid, rejected };
+}

--- a/frontend/app/providers/theme-provider.tsx
+++ b/frontend/app/providers/theme-provider.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 
-type Theme = "light" | "dark";
+export type Theme = "light" | "dark" | "system";
 const STORAGE_KEY = "theme";
 
 type ThemeContextValue = {
@@ -18,46 +18,52 @@ type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-function getSystemTheme(): Theme {
-  if (typeof window === "undefined") {
-    return "light";
-  }
-
-  return window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
+function resolveSystemTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-function syncTheme(theme: Theme) {
+function applyTheme(theme: Theme) {
+  const resolved = theme === "system" ? resolveSystemTheme() : theme;
   const root = document.documentElement;
-  root.dataset.theme = theme;
-  root.classList.toggle("dark", theme === "dark");
-  root.style.colorScheme = theme;
+  root.dataset.theme = resolved;
+  root.classList.toggle("dark", resolved === "dark");
+  root.style.colorScheme = resolved;
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>("light");
 
+  // On mount: read stored preference, apply to DOM — do NOT write back to localStorage here
   useEffect(() => {
     const stored = window.localStorage.getItem(STORAGE_KEY);
-    const nextTheme = stored === "light" || stored === "dark"
-      ? stored
-      : getSystemTheme();
-    // Sync the hydrated state to the persisted theme after the bootstrap script has prevented flicker.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setThemeState(nextTheme);
-    syncTheme(nextTheme);
-    window.localStorage.setItem(STORAGE_KEY, nextTheme);
+    const next: Theme =
+      stored === "light" || stored === "dark" || stored === "system"
+        ? stored
+        : "system";
+    setThemeState(next);
+    applyTheme(next);
   }, []);
 
-  const setTheme = (nextTheme: Theme) => {
-    setThemeState(nextTheme);
-    syncTheme(nextTheme);
-    window.localStorage.setItem(STORAGE_KEY, nextTheme);
+  // When "system" is active, track OS preference changes in real time
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = (next: Theme) => {
+    setThemeState(next);
+    applyTheme(next);
+    window.localStorage.setItem(STORAGE_KEY, next);
   };
 
   const toggleTheme = () => {
-    setTheme(theme === "light" ? "dark" : "light");
+    const cycle: Theme[] = ["light", "dark", "system"];
+    const idx = cycle.indexOf(theme);
+    setTheme(cycle[(idx + 1) % cycle.length]);
   };
 
   return (

--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -51,6 +51,39 @@ impl std::str::FromStr for SeverityLevel {
     }
 }
 
+/// Built-in analysis presets. Overrides --exit-code and --min-severity when set.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AnalysisProfile {
+    /// Emit all rules; any finding triggers a non-zero exit
+    Strict,
+    /// Emit only critical and high findings; always exits 0
+    Lenient,
+    /// Emit all rules with full detail; always exits 0 (use for audit reports)
+    Audit,
+    /// Emit all rules; critical and high findings trigger a non-zero exit (recommended for CI)
+    Ci,
+}
+
+impl AnalysisProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Strict  => "strict",
+            Self::Lenient => "lenient",
+            Self::Audit   => "audit",
+            Self::Ci      => "ci",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Strict  => "all rules emitted; any finding is fatal",
+            Self::Lenient => "critical+high only; always exits 0",
+            Self::Audit   => "all rules emitted; always exits 0",
+            Self::Ci      => "all rules emitted; critical+high findings are fatal",
+        }
+    }
+}
+
 #[derive(Args, Debug, Clone)]
 pub struct AnalyzeArgs {
     /// Path to the contract directory or Cargo.toml
@@ -80,6 +113,9 @@ pub struct AnalyzeArgs {
     /// Disable incremental analysis cache
     #[arg(short = 'n', long)]
     pub no_cache: bool,
+    /// Analysis profile preset — overrides --exit-code and --min-severity when set
+    #[arg(long, value_enum)]
+    pub profile: Option<AnalysisProfile>,
 }
 
 // ── Per-file result container ────────────────────────────────────────────────
@@ -296,6 +332,15 @@ pub fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
         }
     }
 
+    // Apply profile filter: lenient suppresses medium/low-tier categories
+    if matches!(args.profile, Some(AnalysisProfile::Lenient)) {
+        collisions.clear();
+        variable_shadowing_violations.clear();
+        custom_matches.clear();
+        contractimport_issues.clear();
+        vuln_matches.retain(|v| matches!(v.severity.as_str(), "critical" | "high"));
+    }
+
     let total_findings = collisions.len()
         + size_warnings.len()
         + unsafe_patterns.len()
@@ -391,10 +436,16 @@ pub fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
         highest
     };
 
-    let should_exit_with_1 = args.exit_code
-        && highest_finding_severity
+    // Profile overrides --exit-code / --min-severity when set
+    let should_exit_with_1 = match args.profile {
+        Some(AnalysisProfile::Strict)  => total_findings > 0,
+        Some(AnalysisProfile::Lenient) => false,
+        Some(AnalysisProfile::Audit)   => false,
+        Some(AnalysisProfile::Ci)      => has_critical || has_high,
+        None => args.exit_code && highest_finding_severity
             .map(|h| h >= args.min_severity)
-            .unwrap_or(false);
+            .unwrap_or(false),
+    };
 
     let timestamp = chrono_timestamp();
     let _duration_ms = start.elapsed().as_millis() as u64;
@@ -444,6 +495,7 @@ pub fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
                 "timeout_secs": timeout_secs,
                 "cached_files": cached_counter.load(Ordering::Relaxed),
                 "total_files": total_files,
+                "profile": args.profile.map(|p| p.as_str()),
             },
             "error_codes": finding_codes::all_finding_codes(),
             "summary": {
@@ -473,6 +525,14 @@ pub fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
     }
 
     // ── Text output ──────────────────────────────────────────────────────────
+    if let Some(profile) = args.profile {
+        println!(
+            "{} Profile: {} — {}",
+            "ℹ".blue(),
+            profile.as_str().bold(),
+            profile.description()
+        );
+    }
     if !timed_out_files.is_empty() {
         println!(
             "\n{} {} file(s) timed out ({}s limit):",


### PR DESCRIPTION
Closes #816
Closes #817
Closes #818
Closes #865

## What changed

**#816 — `--profile` flag for `analyze` command**
- New `AnalysisProfile` enum: `strict` / `lenient` / `audit` / `ci`
- `--profile` overrides `--exit-code` / `--min-severity` when set
- `lenient` suppresses medium/low categories (collisions, variable shadowing, custom rules, contractimport mismatches, low-severity vuln-db matches)
- `ci`: all rules emitted, exits 1 on critical+high; `strict`: exits 1 on any finding; `audit`: always exits 0
- Active profile printed in text output and included in JSON `metadata.profile`
- `docs/analysis-profiles.md` with full 4×2 matrix table

**#817 — Drag-and-drop multi-file batch upload**
- Dashboard drop zone accepts multiple `.rs` files via drag-and-drop or file picker (`multiple` attribute)
- Each valid file is analyzed and added as a workspace member; per-file progress list shown during batch analysis
- Non-`.rs` or oversized files are rejected with an inline amber toast listing the reason per file
- `validateContractBatch()` added to `upload-validation.ts`; single-file path unchanged
- Analyze route now returns the normalized `AnalysisReport` object (fixes a pre-existing bug where the transformed `Finding[]` couldn't be stored as a workspace member)

**#818 — system theme mode**
- `Theme` type extended to `"light" | "dark" | "system"`
- `ThemeProvider` mount effect no longer overwrites `"system"` in localStorage; OS preference applied to DOM only
- `matchMedia` change listener keeps DOM in sync when `"system"` is active
- `ThemeToggle` cycles light → dark → system with descriptive aria-label
- Bootstrap script in `layout.tsx` unchanged (already correctly falls through to `prefers-color-scheme` for non-`"light"|"dark"` values)

**#865 — env var validation**
- `frontend/app/lib/env.ts` (server-only) emits a startup log table on first load: `✓ set`, `! defaulted`, `✗ missing` per variable
- AI explain route returns `503 { error, set: ["AI_EXPLAIN_PROVIDER"] }` when provider not configured and `STUB_AI!=1`
- Analyze route imports `SANCTIFIER_BIN` and `RATE_LIMIT_REQUESTS_PER_MINUTE` from `env.ts`; fixed pre-existing missing `try` block in POST handler

## How to test

- `sanctifier analyze --profile ci .` — verify all findings are emitted but only critical/high cause non-zero exit
- `sanctifier analyze --profile lenient .` — verify storage collisions and variable shadowing are suppressed
- Dashboard: drag two `.rs` files onto the drop zone; both should appear as workspace members with per-file progress indicators
- Dashboard: drag a non-`.rs` file; amber rejection toast should appear
- Toggle theme button should cycle Light → Dark → System; OS dark-mode toggle should update DOM when System is active
- Start frontend without `AI_EXPLAIN_PROVIDER` set and call `/api/ai/explain`; expect 503 response