### PR TITLE
docs: env example file and frontend setup guide

### DIFF
--- a/docs/frontend-setup.md
+++ b/docs/frontend-setup.md
@@ -1,0 +1,42 @@
+# Frontend Setup
+
+## Environment variables
+
+Copy `frontend/.env.local.example` to `frontend/.env.local` and set the values before starting the dev server.
+
+```
+cp frontend/.env.local.example frontend/.env.local
+```
+
+The validated variables and their startup status are printed to the console on first request — look for the `[sanctifier] environment:` table.
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `SANCTIFIER_BIN` | No | `sanctifier` | Path to the sanctifier binary |
+| `AI_EXPLAIN_PROVIDER` | Yes (for AI) | — | `anthropic` or `openai` |
+| `ANTHROPIC_API_KEY` | Conditional | — | Required when provider is `anthropic` |
+| `OPENAI_API_KEY` | Conditional | — | Required when provider is `openai` |
+| `RATE_LIMIT_REQUESTS_PER_MINUTE` | No | `10` | Per-IP rate limit on `/api/analyze` |
+
+To run without an AI provider, set `STUB_AI=1` — the explain endpoint will return canned responses.
+
+## Batch contract upload
+
+The dashboard accepts multiple `.rs` files at once via drag-and-drop or the **Upload Contract** file picker (hold Shift/Cmd to select multiple files).
+
+- Each valid file is analyzed independently and added as a workspace member.
+- A per-file progress list is shown while analysis is running.
+- Files that are not `.rs` or exceed the 250 KB size limit are rejected with an inline notice listing the reason for each file.
+- The existing single-file path is unchanged.
+
+## Theme preference
+
+The theme toggle cycles through three modes:
+
+| Mode | Behaviour |
+|------|-----------|
+| **Light** | Forces light theme regardless of OS setting |
+| **Dark** | Forces dark theme regardless of OS setting |
+| **System** | Follows the OS `prefers-color-scheme` setting and updates in real time |
+
+The selected mode is stored in `localStorage` under the key `"theme"`. An inline bootstrap script in `layout.tsx` applies the correct class before the first paint to prevent a flash of the wrong theme on page load.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,26 @@
+# Copy this file to .env.local and fill in your values.
+# All variables are validated at startup — see app/lib/env.ts for details.
+
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# Absolute path (or name on $PATH) to the sanctifier binary.
+# If omitted, defaults to "sanctifier" (assumed to be on PATH).
+SANCTIFIER_BIN=sanctifier
+
+# AI explanation provider. Set to "anthropic" or "openai".
+# Leave unset to disable AI explanations (the /api/ai/explain route will return 503).
+# Set STUB_AI=1 to return canned responses without a real provider (dev only).
+AI_EXPLAIN_PROVIDER=
+
+# ── Provider credentials (one required depending on AI_EXPLAIN_PROVIDER) ──────
+
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# Maximum number of /api/analyze requests per IP per minute. Defaults to 10.
+RATE_LIMIT_REQUESTS_PER_MINUTE=10
+
+# Set to "1" to return canned AI responses without a real provider (development only).
+# STUB_AI=1


### PR DESCRIPTION
Closes #817
Closes #818
Closes #865

## What changed

- `frontend/.env.local.example` — documents every validated env var (`SANCTIFIER_BIN`, `AI_EXPLAIN_PROVIDER`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `RATE_LIMIT_REQUESTS_PER_MINUTE`) with inline comments explaining defaults and when each is required
- `docs/frontend-setup.md` — setup guide covering:
  - Environment variable table referencing the startup log added in #865
  - Batch drag-and-drop upload behaviour, progress indicators, and rejection rules (#817)
  - Three-way theme cycling (Light / Dark / System) and localStorage persistence (#818)

## How to test

- Copy `frontend/.env.local.example` to `frontend/.env.local` and start the dev server — the `[sanctifier] environment:` table should appear in the console
- Read `docs/frontend-setup.md` to verify it accurately describes the batch upload and theme features