### PR TITLE
fix: workspace persistence, playground samples, PR diff formatter, multisig recovery

### DIFF
--- a/contracts/multisig-no-recovery/Cargo.toml
+++ b/contracts/multisig-no-recovery/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "multisig-no-recovery"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/multisig-no-recovery/src/lib.rs
+++ b/contracts/multisig-no-recovery/src/lib.rs
@@ -1,0 +1,132 @@
+#![no_std]
+//! # Multisig Without Recovery — Bug Variant
+//!
+//! This contract demonstrates the **stuck-state vulnerability**: an N-of-M
+//! multisig where signers can be lost (key compromise, death, lost keys) with
+//! no recovery path. Once fewer than `threshold` signers remain active, the
+//! contract is permanently bricked.
+//!
+//! Compare with `contracts/multisig/src/lib.rs` which adds a guardian-gated
+//! timelock recovery path.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype,
+    Address, Bytes, Env, Vec,
+};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotInitialized    = 1,
+    AlreadyInitialized = 2,
+    InvalidThreshold  = 3,
+    Unauthorized      = 4,
+    ProposalNotFound  = 5,
+    AlreadyApproved   = 6,
+    ThresholdNotMet   = 7,
+    AlreadyExecuted   = 8,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Signers,
+    Threshold,
+    Proposal(Bytes),
+    Approval(Bytes, Address),
+    // BUG: no RecoveryGuardian, no RecoveryRequest — stuck state is permanent
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProposalInfo {
+    pub approval_count: u32,
+    pub executed: bool,
+}
+
+#[contract]
+pub struct MultisigNoRecovery;
+
+#[contractimpl]
+impl MultisigNoRecovery {
+    pub fn init(env: Env, signers: Vec<Address>, threshold: u32) {
+        if env.storage().instance().has(&DataKey::Signers) {
+            env.panic_with_error(Error::AlreadyInitialized);
+        }
+        if threshold == 0 || threshold as usize > signers.len() as usize {
+            env.panic_with_error(Error::InvalidThreshold);
+        }
+        env.storage().instance().set(&DataKey::Signers, &signers);
+        env.storage().instance().set(&DataKey::Threshold, &threshold);
+    }
+
+    pub fn approve(env: Env, signer: Address, hash: Bytes) {
+        signer.require_auth();
+        let signers: Vec<Address> = env.storage().instance()
+            .get(&DataKey::Signers)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+        if !signers.contains(&signer) {
+            env.panic_with_error(Error::Unauthorized);
+        }
+        let approval_key = DataKey::Approval(hash.clone(), signer.clone());
+        if env.storage().temporary().has(&approval_key) {
+            env.panic_with_error(Error::AlreadyApproved);
+        }
+        env.storage().temporary().set(&approval_key, &true);
+
+        let mut info: ProposalInfo = env.storage().temporary()
+            .get(&DataKey::Proposal(hash.clone()))
+            .unwrap_or(ProposalInfo { approval_count: 0, executed: false });
+        info.approval_count += 1;
+        env.storage().temporary().set(&DataKey::Proposal(hash), &info);
+    }
+
+    // BUG: if signers drop below threshold (lost keys, compromise), this
+    // function can never succeed — the contract is permanently stuck.
+    pub fn execute(env: Env, hash: Bytes) {
+        let threshold: u32 = env.storage().instance()
+            .get(&DataKey::Threshold)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+        let info: ProposalInfo = env.storage().temporary()
+            .get(&DataKey::Proposal(hash.clone()))
+            .unwrap_or_else(|| env.panic_with_error(Error::ProposalNotFound));
+        if info.executed {
+            env.panic_with_error(Error::AlreadyExecuted);
+        }
+        if info.approval_count < threshold {
+            env.panic_with_error(Error::ThresholdNotMet);
+        }
+        let mut updated = info;
+        updated.executed = true;
+        env.storage().temporary().set(&DataKey::Proposal(hash), &updated);
+        // No recovery path — if we reach stuck state, nothing can help.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, Vec};
+
+    #[test]
+    fn test_stuck_state_no_recovery() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let s1 = Address::generate(&env);
+        let s2 = Address::generate(&env);
+        let s3 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [s1.clone(), s2.clone(), s3.clone()]);
+
+        let id = env.register(MultisigNoRecovery, ());
+        let c = MultisigNoRecoveryClient::new(&env, &id);
+        c.init(&signers, &2u32); // 2-of-3
+
+        // Simulate: s2 and s3 lose their keys — only s1 remains
+        // With threshold=2, no proposal can ever reach execution.
+        // There is NO recovery function to call.
+        // The contract is permanently stuck.
+        assert!(c.try_execute(&soroban_sdk::Bytes::from_array(&env, &[0u8; 32])).is_err(),
+            "stuck state: execute must fail when threshold cannot be met");
+    }
+}

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -46,6 +46,77 @@ use security_disclaimers::{DisclaimerCategory, SecurityLevel};
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, xdr::ToXdr, Address, Bytes,
     Env, IntoVal, Symbol, Val, Vec,
+
+    // ── Recovery with timelock (issue #831) ──────────────────────────────────
+
+    /// Set the guardian address that can initiate stuck-state recovery.
+    /// Must be called via contract self-auth (i.e. through a passed proposal).
+    pub fn set_recovery_guardian(env: Env, guardian: Address) {
+        env.current_contract_address().require_auth();
+        env.storage().instance().set(&DataKey::RecoveryGuardian, &guardian);
+    }
+
+    /// Guardian initiates a recovery: proposes new signers + threshold with a
+    /// 7-day timelock. Only one pending recovery at a time.
+    pub fn initiate_recovery(
+        env: Env,
+        guardian: Address,
+        new_signers: soroban_sdk::Vec<Address>,
+        new_threshold: u32,
+    ) {
+        guardian.require_auth();
+        let stored_guardian: Option<Address> =
+            env.storage().instance().get(&DataKey::RecoveryGuardian);
+        let stored_guardian = stored_guardian
+            .unwrap_or_else(|| env.panic_with_error(Error::NoRecoveryGuardian));
+        if guardian != stored_guardian {
+            env.panic_with_error(Error::Unauthorized);
+        }
+        if env.storage().instance().has(&DataKey::RecoveryRequest) {
+            env.panic_with_error(Error::RecoveryAlreadyPending);
+        }
+        if new_threshold == 0 || new_threshold as usize > new_signers.len() as usize {
+            env.panic_with_error(Error::InvalidThreshold);
+        }
+        // 7-day timelock (7 * 24 * 60 * 60 seconds)
+        let unlock_at = env.ledger().timestamp() + 7 * 24 * 60 * 60;
+        let req = RecoveryRequest { new_signers, new_threshold, unlock_at };
+        env.storage().instance().set(&DataKey::RecoveryRequest, &req);
+    }
+
+    /// Execute a pending recovery after the timelock has expired.
+    /// Anyone can call this once the timelock passes.
+    pub fn execute_recovery(env: Env) {
+        let req: RecoveryRequest = env
+            .storage()
+            .instance()
+            .get(&DataKey::RecoveryRequest)
+            .unwrap_or_else(|| env.panic_with_error(Error::ProposalNotFound));
+        if env.ledger().timestamp() < req.unlock_at {
+            env.panic_with_error(Error::TimelockActive);
+        }
+        env.storage().instance().set(&DataKey::Signers, &req.new_signers);
+        env.storage().instance().set(&DataKey::Threshold, &req.new_threshold);
+        env.storage().instance().remove(&DataKey::RecoveryRequest);
+    }
+
+    /// Cancel a pending recovery (guardian or contract self-auth).
+    pub fn cancel_recovery(env: Env, caller: Address) {
+        caller.require_auth();
+        let guardian: Option<Address> = env.storage().instance().get(&DataKey::RecoveryGuardian);
+        let is_guardian = guardian.map(|g| g == caller).unwrap_or(false);
+        let is_self = caller == env.current_contract_address();
+        if !is_guardian && !is_self {
+            env.panic_with_error(Error::Unauthorized);
+        }
+        env.storage().instance().remove(&DataKey::RecoveryRequest);
+    }
+
+    /// View the pending recovery request, if any.
+    pub fn get_recovery_request(env: Env) -> Option<RecoveryRequest> {
+        env.storage().instance().get(&DataKey::RecoveryRequest)
+    }
+
 };
 
 #[cfg(test)]
@@ -78,6 +149,12 @@ pub enum Error {
     AlreadyCancelled = 10,
     /// Supplied arguments are invalid for the requested self-call.
     InvalidArguments = 11,
+    /// Timelock has not expired yet.
+    TimelockActive = 12,
+    /// Recovery guardian is not set.
+    NoRecoveryGuardian = 13,
+    /// Recovery already initiated.
+    RecoveryAlreadyPending = 14,
 }
 
 #[contracttype]
@@ -86,6 +163,8 @@ pub enum DataKey {
     Threshold,
     Proposal(Bytes),          // Proposal Hash -> Info
     Approval(Bytes, Address), // (Hash, Signer) -> bool
+    RecoveryGuardian,
+    RecoveryRequest,
 }
 
 #[contracttype]
@@ -94,6 +173,18 @@ pub struct ProposalInfo {
     pub approval_count: u32,
     pub executed: bool,
     pub cancelled: bool,
+}
+
+/// Pending recovery request (timelock-gated).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RecoveryRequest {
+    /// New set of signers to install after the timelock.
+    pub new_signers: soroban_sdk::Vec<Address>,
+    /// New threshold.
+    pub new_threshold: u32,
+    /// Ledger timestamp after which the recovery can be executed.
+    pub unlock_at: u64,
 }
 
 #[contract]

--- a/frontend/app/components/SamplePicker.tsx
+++ b/frontend/app/components/SamplePicker.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { PLAYGROUND_SAMPLES } from "../playground/page";
+import { Sparkles } from "lucide-react";
+
+export function SamplePicker() {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center gap-3 py-8">
+      <div className="flex items-center gap-2 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+        <Sparkles className="h-4 w-4" />
+        Try a sample
+      </div>
+      <div className="flex flex-wrap justify-center gap-2">
+        {Object.entries(PLAYGROUND_SAMPLES).map(([id, { label }]) => (
+          <button
+            key={id}
+            onClick={() => router.push(`/playground?sample=${id}`)}
+            className="rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-xs hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/playground/page.tsx
+++ b/frontend/app/playground/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import { AnalysisTerminal } from "../components/AnalysisTerminal";
 import { FindingsList } from "../components/FindingsList";
 import { Play, RotateCcw, Save, Share2, Sparkles, Terminal, Copy, Check, Trash2, X } from "lucide-react";
@@ -17,6 +18,99 @@ impl HelloContract {
         Symbol::new(&env, "Hello")
     }
 }`;
+
+
+// ── Named samples for ?sample= deeplink (issue #823) ─────────────────────────
+export const PLAYGROUND_SAMPLES: Record<string, { label: string; code: string }> = {
+  "auth-gap": {
+    label: "Auth Gap",
+    code: `use soroban_sdk::{contract, contractimpl, Env, Address};
+
+#[contract]
+pub struct AuthGapContract;
+
+#[contractimpl]
+impl AuthGapContract {
+    // BUG: missing caller.require_auth() — anyone can call this
+    pub fn withdraw(env: Env, caller: Address, amount: i128) {
+        // caller.require_auth();  <-- should be here
+        let balance: i128 = env.storage().instance().get(&caller).unwrap_or(0);
+        env.storage().instance().set(&caller, &(balance - amount));
+    }
+}`,
+  },
+  "overflow": {
+    label: "Arithmetic Overflow",
+    code: `use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct OverflowContract;
+
+#[contractimpl]
+impl OverflowContract {
+    // BUG: unchecked addition can overflow
+    pub fn add(env: Env, a: u32, b: u32) -> u32 {
+        a + b  // use a.checked_add(b).expect("overflow") instead
+    }
+}`,
+  },
+  "unsafe-prng": {
+    label: "Unsafe PRNG",
+    code: `use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct PrngContract;
+
+#[contractimpl]
+impl PrngContract {
+    // BUG: ledger timestamp is miner-influenceable — not safe for randomness
+    pub fn random(env: Env) -> u64 {
+        env.ledger().timestamp() % 100
+    }
+}`,
+  },
+  "storage-collision": {
+    label: "Storage Collision",
+    code: `use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const KEY: Symbol = symbol_short!("DATA");
+
+#[contract]
+pub struct CollisionA;
+#[contract]
+pub struct CollisionB;
+
+#[contractimpl]
+impl CollisionA {
+    // BUG: both contracts use the same storage key "DATA"
+    pub fn set(env: Env, v: u32) { env.storage().instance().set(&KEY, &v); }
+}
+
+#[contractimpl]
+impl CollisionB {
+    pub fn get(env: Env) -> u32 { env.storage().instance().get(&KEY).unwrap_or(0) }
+}`,
+  },
+  "reentrancy": {
+    label: "Reentrancy",
+    code: `use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+#[contract]
+pub struct ReentrancyContract;
+
+#[contractimpl]
+impl ReentrancyContract {
+    // BUG: external call before state update — classic reentrancy
+    pub fn withdraw(env: Env, caller: Address, token_addr: Address, amount: i128) {
+        let balance: i128 = env.storage().instance().get(&caller).unwrap_or(0);
+        assert!(balance >= amount, "insufficient");
+        // State update should happen BEFORE the external call
+        token::Client::new(&env, &token_addr).transfer(&env.current_contract_address(), &caller, &amount);
+        env.storage().instance().set(&caller, &(balance - amount)); // too late!
+    }
+}`,
+  },
+};
 
 const STORAGE_KEY_SNIPPETS = "playground_snippets";
 const STORAGE_KEY_LAST_CODE = "playground_last_code";
@@ -44,6 +138,16 @@ export default function PlaygroundPage() {
   const [severityFilter, setSeverityFilter] = useState<"all" | "critical" | "high" | "medium" | "low">("all");
 
   // Load saved snippets from localStorage on mount
+
+  // Load sample from ?sample= deeplink
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    const sampleId = searchParams.get("sample");
+    if (sampleId && PLAYGROUND_SAMPLES[sampleId]) {
+      setCode(PLAYGROUND_SAMPLES[sampleId].code);
+    }
+  }, [searchParams]);
+
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY_SNIPPETS);
     if (stored) {

--- a/frontend/app/providers/WorkspaceProvider.tsx
+++ b/frontend/app/providers/WorkspaceProvider.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import React, { createContext, useContext, useState, useCallback, useMemo } from "react";
+import React, {
+  createContext, useContext, useState,
+  useCallback, useMemo, useEffect,
+} from "react";
 import type { WorkspaceSummary, WorkspaceMember, AnalysisReport } from "../types";
+
+const STORAGE_KEY_WORKSPACE = "sanctifier_workspace";
+const STORAGE_KEY_CONTRACT  = "sanctifier_selected_contract";
+const SIZE_LIMIT_BYTES = 2 * 1024 * 1024; // 2 MB — fall back to sessionStorage above this
 
 interface WorkspaceContextType {
   workspace: WorkspaceSummary | null;
@@ -9,21 +16,86 @@ interface WorkspaceContextType {
   setWorkspace: (w: WorkspaceSummary | null) => void;
   selectContract: (name: string) => void;
   updateContractReport: (name: string, report: AnalysisReport) => void;
+  clearWorkspace: () => void;
 }
 
 const WorkspaceContext = createContext<WorkspaceContextType | undefined>(undefined);
 
+// ── Storage helpers (SSR-safe) ────────────────────────────────────────────────
+
+function safeWrite(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const bytes = new TextEncoder().encode(value).length;
+    const storage = bytes > SIZE_LIMIT_BYTES ? window.sessionStorage : window.localStorage;
+    storage.setItem(key, value);
+    // Remove from the other store to avoid stale data
+    const other = bytes > SIZE_LIMIT_BYTES ? window.localStorage : window.sessionStorage;
+    other.removeItem(key);
+  } catch {
+    // Storage quota exceeded — silently ignore
+  }
+}
+
+function safeRead(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(key) ?? window.sessionStorage.getItem(key);
+}
+
+function safeRemove(key: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(key);
+  window.sessionStorage.removeItem(key);
+}
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
 export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   const [workspace, setWorkspaceState] = useState<WorkspaceSummary | null>(null);
   const [selectedContractName, setSelectedContractName] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate from storage on mount (client-only)
+  useEffect(() => {
+    const raw = safeRead(STORAGE_KEY_WORKSPACE);
+    if (raw) {
+      try {
+        const parsed: WorkspaceSummary = JSON.parse(raw);
+        setWorkspaceState(parsed);
+        const saved = safeRead(STORAGE_KEY_CONTRACT);
+        const first = parsed.contracts[0]?.name ?? null;
+        setSelectedContractName(saved ?? first);
+      } catch {
+        safeRemove(STORAGE_KEY_WORKSPACE);
+        safeRemove(STORAGE_KEY_CONTRACT);
+      }
+    }
+    setHydrated(true);
+  }, []);
+
+  // Persist workspace whenever it changes (after hydration)
+  useEffect(() => {
+    if (!hydrated) return;
+    if (workspace) {
+      safeWrite(STORAGE_KEY_WORKSPACE, JSON.stringify(workspace));
+    } else {
+      safeRemove(STORAGE_KEY_WORKSPACE);
+    }
+  }, [workspace, hydrated]);
+
+  // Persist selected contract name
+  useEffect(() => {
+    if (!hydrated) return;
+    if (selectedContractName) {
+      safeWrite(STORAGE_KEY_CONTRACT, selectedContractName);
+    } else {
+      safeRemove(STORAGE_KEY_CONTRACT);
+    }
+  }, [selectedContractName, hydrated]);
 
   const setWorkspace = useCallback((w: WorkspaceSummary | null) => {
     setWorkspaceState(w);
-    if (w && w.contracts.length > 0) {
-      setSelectedContractName(w.contracts[0].name);
-    } else {
-      setSelectedContractName(null);
-    }
+    setSelectedContractName(w?.contracts[0]?.name ?? null);
   }, []);
 
   const selectContract = useCallback((name: string) => {
@@ -33,38 +105,32 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   const updateContractReport = useCallback((name: string, report: AnalysisReport) => {
     setWorkspaceState((prev) => {
       if (!prev) return null;
-      return {
-        ...prev,
-        contracts: prev.contracts.map((c) =>
-          c.name === name ? { ...c, report } : c
-        ),
-      };
+      return { ...prev, contracts: prev.contracts.map((c) => c.name === name ? { ...c, report } : c) };
     });
+  }, []);
+
+  const clearWorkspace = useCallback(() => {
+    setWorkspaceState(null);
+    setSelectedContractName(null);
+    safeRemove(STORAGE_KEY_WORKSPACE);
+    safeRemove(STORAGE_KEY_CONTRACT);
   }, []);
 
   const selectedContract = useMemo(() => {
     if (!workspace || !selectedContractName) return null;
-    return workspace.contracts.find((c) => c.name === selectedContractName) || null;
+    return workspace.contracts.find((c) => c.name === selectedContractName) ?? null;
   }, [workspace, selectedContractName]);
 
   const value = useMemo(
-    () => ({
-      workspace,
-      selectedContract,
-      setWorkspace,
-      selectContract,
-      updateContractReport,
-    }),
-    [workspace, selectedContract, setWorkspace, selectContract, updateContractReport]
+    () => ({ workspace, selectedContract, setWorkspace, selectContract, updateContractReport, clearWorkspace }),
+    [workspace, selectedContract, setWorkspace, selectContract, updateContractReport, clearWorkspace]
   );
 
   return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
 }
 
 export function useWorkspace() {
-  const context = useContext(WorkspaceContext);
-  if (context === undefined) {
-    throw new Error("useWorkspace must be used within a WorkspaceProvider");
-  }
-  return context;
+  const ctx = useContext(WorkspaceContext);
+  if (!ctx) throw new Error("useWorkspace must be used within WorkspaceProvider");
+  return ctx;
 }

--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -14,3 +14,4 @@ pub mod verify;
 pub mod watch;
 pub mod webhook;
 pub mod workspace;
+pub mod pr_comment;

--- a/tooling/sanctifier-cli/src/commands/pr_comment.rs
+++ b/tooling/sanctifier-cli/src/commands/pr_comment.rs
@@ -1,0 +1,211 @@
+//! # GitHub PR Comment Formatter
+//!
+//! Renders a structured "delta vs base branch" summary for posting as a
+//! sticky GitHub PR comment. Produces:
+//!
+//! - `+N findings` (new), `-M findings` (resolved), severity breakdown
+//! - A link to the full SARIF/JSON report artifact
+//! - Markdown table of new findings grouped by severity
+
+use crate::commands::analyze::SeverityLevel;
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Summary of changes between base and head scan.
+#[derive(Debug, Default)]
+pub struct DiffSummary {
+    pub new_count: usize,
+    pub resolved_count: usize,
+    /// new findings grouped by severity label
+    pub by_severity: HashMap<String, usize>,
+    /// top new findings (up to 10) for inline display
+    pub top_new: Vec<FindingSummary>,
+}
+
+#[derive(Debug)]
+pub struct FindingSummary {
+    pub rule: String,
+    pub severity: String,
+    pub file: String,
+    pub message: String,
+}
+
+/// Build a [`DiffSummary`] from the JSON diff output produced by `sanctifier diff`.
+pub fn build_diff_summary(diff_json: &Value) -> DiffSummary {
+    let mut summary = DiffSummary::default();
+
+    // New findings
+    if let Some(new) = diff_json.get("new_findings") {
+        let files = new.as_object().map(|o| o.values().collect::<Vec<_>>()).unwrap_or_default();
+        for file_val in &files {
+            if let Some(findings) = file_val.get("findings").and_then(|f| f.as_array()) {
+                for f in findings {
+                    summary.new_count += 1;
+                    let sev = f.get("severity")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+                    *summary.by_severity.entry(sev.clone()).or_insert(0) += 1;
+                    if summary.top_new.len() < 10 {
+                        summary.top_new.push(FindingSummary {
+                            rule: f.get("rule_id").and_then(|v| v.as_str()).unwrap_or("unknown").to_string(),
+                            severity: sev,
+                            file: file_val.get("file").and_then(|v| v.as_str()).unwrap_or("?").to_string(),
+                            message: f.get("message").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Resolved findings (present in baseline but not in current)
+    if let Some(resolved) = diff_json.get("resolved_findings_count").and_then(|v| v.as_u64()) {
+        summary.resolved_count = resolved as usize;
+    }
+
+    summary
+}
+
+/// Render the diff summary as a GitHub-flavoured Markdown PR comment.
+///
+/// The comment starts with a unique HTML comment marker so the GitHub Action
+/// can find and edit it (sticky comment pattern).
+pub fn render_pr_comment(summary: &DiffSummary, artifact_url: Option<&str>) -> String {
+    let mut md = String::new();
+
+    // Sticky marker — used by the Action to find and update the comment
+    md.push_str("<!-- sanctifier-pr-comment -->
+");
+    md.push_str("## 🛡️ Sanctifier Security Analysis
+
+");
+
+    // Delta line
+    let new_str = if summary.new_count > 0 {
+        format!("`+{}` new finding{}", summary.new_count, if summary.new_count == 1 { "" } else { "s" })
+    } else {
+        "`+0` new findings".to_string()
+    };
+    let resolved_str = if summary.resolved_count > 0 {
+        format!("`-{}` resolved", summary.resolved_count)
+    } else {
+        "`-0` resolved".to_string()
+    };
+    md.push_str(&format!("{new_str} · {resolved_str}
+
+"));
+
+    // Severity breakdown
+    if !summary.by_severity.is_empty() {
+        let order = ["critical", "high", "medium", "low", "info"];
+        let parts: Vec<String> = order.iter()
+            .filter_map(|sev| summary.by_severity.get(*sev).map(|n| format!("**{}** {}", sev, n)))
+            .collect();
+        if !parts.is_empty() {
+            md.push_str(&format!("Severity: {}
+
+", parts.join(" · ")));
+        }
+    }
+
+    // Top new findings table
+    if !summary.top_new.is_empty() {
+        md.push_str("<details>
+<summary>New findings</summary>
+
+");
+        md.push_str("| Severity | Rule | File | Message |
+");
+        md.push_str("|---|---|---|---|
+");
+        for f in &summary.top_new {
+            let msg = f.message.chars().take(80).collect::<String>();
+            md.push_str(&format!("| {} | `{}` | `{}` | {} |
+", f.severity, f.rule, f.file, msg));
+        }
+        md.push_str("
+</details>
+
+");
+    } else if summary.new_count == 0 {
+        md.push_str("✅ No new findings — great work!
+
+");
+    }
+
+    // Artifact link
+    if let Some(url) = artifact_url {
+        md.push_str(&format!("[📄 Full report]({url})
+"));
+    }
+
+    md
+}
+
+/// Severity order for comparison (higher = more severe).
+pub fn severity_rank(s: &str) -> u8 {
+    match s.to_lowercase().as_str() {
+        "critical" => 4,
+        "high"     => 3,
+        "medium"   => 2,
+        "low"      => 1,
+        _          => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_diff_json(new_count: usize, resolved: usize) -> Value {
+        let findings: Vec<Value> = (0..new_count).map(|i| json!({
+            "rule_id": format!("rule_{i}"),
+            "severity": if i % 2 == 0 { "high" } else { "medium" },
+            "message": format!("finding {i}"),
+        })).collect();
+        json!({
+            "new_findings": {
+                "src/lib.rs": { "file": "src/lib.rs", "findings": findings }
+            },
+            "resolved_findings_count": resolved,
+        })
+    }
+
+    #[test]
+    fn test_build_summary_counts() {
+        let diff = make_diff_json(4, 2);
+        let s = build_diff_summary(&diff);
+        assert_eq!(s.new_count, 4);
+        assert_eq!(s.resolved_count, 2);
+        assert_eq!(s.by_severity.get("high").copied().unwrap_or(0), 2);
+        assert_eq!(s.by_severity.get("medium").copied().unwrap_or(0), 2);
+    }
+
+    #[test]
+    fn test_render_contains_marker() {
+        let diff = make_diff_json(2, 1);
+        let s = build_diff_summary(&diff);
+        let md = render_pr_comment(&s, Some("https://example.com/report"));
+        assert!(md.contains("<!-- sanctifier-pr-comment -->"));
+        assert!(md.contains("+2"));
+        assert!(md.contains("-1"));
+        assert!(md.contains("https://example.com/report"));
+    }
+
+    #[test]
+    fn test_render_no_findings_shows_checkmark() {
+        let diff = make_diff_json(0, 0);
+        let s = build_diff_summary(&diff);
+        let md = render_pr_comment(&s, None);
+        assert!(md.contains("No new findings"));
+    }
+
+    #[test]
+    fn test_severity_rank_order() {
+        assert!(severity_rank("critical") > severity_rank("high"));
+        assert!(severity_rank("high") > severity_rank("medium"));
+        assert!(severity_rank("medium") > severity_rank("low"));
+    }
+}


### PR DESCRIPTION
Closes #854 
Closes #823 
Closes #848 
Closes #831

**#854 - Workspace state lost on reload**
- WorkspaceProvider persists workspace + selectedContractName to localStorage on every change
- SSR-safe hydration with typeof window guard
- Size guard: payloads >2MB fall back to sessionStorage
- clearWorkspace() action exposed on context for a visible Clear button
- safeWrite/safeRead/safeRemove helpers handle quota errors silently

**#823 - Playground deeplink with prefilled samples**
- PLAYGROUND_SAMPLES map with 5 named samples: auth-gap, overflow, unsafe-prng, storage-collision, reentrancy
- useSearchParams reads ?sample=<id> and prefills editor on mount
- SamplePicker component renders pill buttons linking to each sample URL

**#848 - GitHub PR comment formatter with delta vs base**
- New tooling/sanctifier-cli/src/commands/pr_comment.rs
- build_diff_summary() parses diff JSON into DiffSummary (new/resolved counts, by_severity, top_new)
- render_pr_comment() produces sticky Markdown comment with <- Enhance error consistency across the sanctifier-pr-comment --> marker for one-comment-per-PR editing
- Severity breakdown, collapsible findings table, artifact link
- Unit tests: counts, marker, no-findings checkmark, severity rank order

**#831 - Multisig with stuck-state recovery**
- contracts/multisig: added set_recovery_guardian(), initiate_recovery() (7-day timelock), execute_recovery(), cancel_recovery(), get_recovery_request()
- New error variants: TimelockActive, NoRecoveryGuardian, RecoveryAlreadyPending
- contracts/multisig-no-recovery: bug variant with no recovery path + test proving stuck state