### PR TITLE
feat(engine): S022 — detect raw invoke_contract without try_* error handling

### DIFF
--- a/contracts/fixtures/finding-codes/README.md
+++ b/contracts/fixtures/finding-codes/README.md
@@ -32,6 +32,7 @@ This directory contains fixture source files used as deterministic scan inputs f
 | `S019` | `s019_unchecked_calls.rs` |
 | `S020` | `s020_missing_events.rs` |
 | `S021` | `s021_storage_misuse.rs` |
+| `S022` | `s022_raw_invoke_contract.rs` |
 
 ## Usage
 

--- a/contracts/fixtures/finding-codes/s022_raw_invoke_contract.rs
+++ b/contracts/fixtures/finding-codes/s022_raw_invoke_contract.rs
@@ -1,0 +1,29 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+#[contract]
+pub struct RawInvokeFixture;
+
+#[contractimpl]
+impl RawInvokeFixture {
+    /// ❌ S022: `invoke_contract` panics when the callee returns an error.
+    /// There is no way for the caller to recover — the transaction aborts.
+    pub fn unsafe_cross_call(env: Env, target: Address) {
+        env.invoke_contract::<()>(
+            &target,
+            &symbol_short!("ping"),
+            soroban_sdk::vec![&env],
+        );
+    }
+
+    /// ✅ Preferred: `try_invoke_contract` surfaces the callee result as a
+    /// typed `Result`, allowing the caller to handle failure without panicking.
+    pub fn safe_cross_call(env: Env, target: Address) -> Result<(), soroban_sdk::Error> {
+        env.try_invoke_contract::<(), soroban_sdk::Error>(
+            &target,
+            &symbol_short!("ping"),
+            soroban_sdk::vec![&env],
+        )?;
+        Ok(())
+    }
+}

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -16,6 +16,7 @@ Sanctifier uses a unified finding code system across `sanctifier-core` and `sanc
 | `S010` | upgrades | Security risk in contract upgrade or admin mechanisms |
 | `S011` | formal_verification | Z3 proved a mathematical violation of an invariant |
 | `S012` | token_interface | SEP-41 token interface compatibility or authorization deviation |
+| `S022` | error_handling | Raw `invoke_contract` call that panics on callee failure; use `try_invoke_contract` with explicit `Result` handling |
 
 ## Vulnerability Database Codes
 

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -65,6 +65,8 @@ pub const UNCHECKED_EXTERNAL_CALL: &str = "S019";
 pub const MISSING_STATE_EVENT: &str = "S020";
 /// Per-user or large dataset stored in Instance storage instead of Persistent.
 pub const INSTANCE_STORAGE_MISUSE: &str = "S021";
+/// Raw `invoke_contract` call without `try_invoke_contract` error handling.
+pub const RAW_INVOKE_CONTRACT: &str = "S022";
 
 /// A single finding-code entry with machine-readable code, category, and
 /// human-readable description.
@@ -192,6 +194,11 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             category: "storage_type",
             description: "Per-user or large dataset stored in Instance storage instead of Persistent, causing ledger entry bloat",
         },
+        FindingCode {
+            code: RAW_INVOKE_CONTRACT,
+            category: "error_handling",
+            description: "Cross-contract call via `invoke_contract` panics on callee failure; use `try_invoke_contract` with explicit Result handling",
+        },
     ]
 }
 
@@ -226,5 +233,6 @@ mod tests {
         assert!(codes.iter().any(|c| c.code == UNCHECKED_EXTERNAL_CALL));
         assert!(codes.iter().any(|c| c.code == MISSING_STATE_EVENT));
         assert!(codes.iter().any(|c| c.code == INSTANCE_STORAGE_MISUSE));
+        assert!(codes.iter().any(|c| c.code == RAW_INVOKE_CONTRACT));
     }
 }

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -34,6 +34,8 @@ pub mod unused_variable;
 
 /// Variable shadowing in nested scopes.
 pub mod variable_shadowing;
+/// Raw `invoke_contract` call without `try_invoke_contract` error handling.
+pub mod raw_invoke_contract;
 use serde::Serialize;
 use std::any::Any;
 
@@ -194,6 +196,7 @@ impl RuleRegistry {
         registry.register(unchecked_external_call::UncheckedExternalCallRule::new());
         registry.register(missing_state_event::MissingStateEventRule::new());
         registry.register(instance_storage_misuse::InstanceStorageMisuseRule::new());
+        registry.register(raw_invoke_contract::RawInvokeContractRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/src/rules/raw_invoke_contract.rs
+++ b/tooling/sanctifier-core/src/rules/raw_invoke_contract.rs
@@ -1,0 +1,247 @@
+//! S022 — Raw `invoke_contract` without `try_*` error handling.
+//!
+//! `env.invoke_contract()` panics when the callee returns an error, leaving no
+//! opportunity for the caller to handle the failure gracefully.  Prefer
+//! `env.try_invoke_contract()`, which surfaces the callee result as a typed
+//! `Result`, and handle errors explicitly.
+
+use crate::rules::{Patch, Rule, RuleViolation, Severity};
+use syn::spanned::Spanned;
+use syn::{parse_str, File, Item};
+
+/// Rule that flags raw `env.invoke_contract(…)` calls that should use
+/// `env.try_invoke_contract(…)` with explicit `Result` handling.
+pub struct RawInvokeContractRule;
+
+impl RawInvokeContractRule {
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RawInvokeContractRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for RawInvokeContractRule {
+    fn name(&self) -> &str {
+        "raw_invoke_contract"
+    }
+
+    fn description(&self) -> &str {
+        "Detects cross-contract calls via `invoke_contract` that lack `try_invoke_contract` \
+         error handling — raw calls panic on callee failure instead of returning a Result"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+        for item in &file.items {
+            if let Item::Impl(impl_block) = item {
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(f) = impl_item {
+                        scan_block(&f.block, &mut violations);
+                    }
+                }
+            }
+        }
+        violations
+    }
+
+    fn fix(&self, _source: &str) -> Vec<Patch> {
+        vec![]
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn scan_block(block: &syn::Block, violations: &mut Vec<RuleViolation>) {
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Expr(expr, _) => scan_expr(expr, violations),
+            syn::Stmt::Local(local) => {
+                if let Some(init) = &local.init {
+                    scan_expr(&init.expr, violations);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn scan_expr(expr: &syn::Expr, violations: &mut Vec<RuleViolation>) {
+    match expr {
+        syn::Expr::MethodCall(mc) => {
+            let method = mc.method.to_string();
+            if method == "invoke_contract" {
+                let line = mc.span().start().line;
+                violations.push(
+                    RuleViolation::new(
+                        "raw_invoke_contract",
+                        Severity::Warning,
+                        format!(
+                            "Cross-contract call via `invoke_contract` at line {} panics on \
+                             callee failure; use `try_invoke_contract` with explicit Result handling",
+                            line
+                        ),
+                        format!("line {}", line),
+                    )
+                    .with_suggestion(
+                        "Replace `env.invoke_contract::<T>(…)` with \
+                         `env.try_invoke_contract::<T, E>(…)?` or match on the returned Result \
+                         to handle callee errors without panicking"
+                            .to_string(),
+                    ),
+                );
+            }
+            scan_expr(&mc.receiver, violations);
+            for arg in &mc.args {
+                scan_expr(arg, violations);
+            }
+        }
+        syn::Expr::Call(c) => {
+            for arg in &c.args {
+                scan_expr(arg, violations);
+            }
+        }
+        syn::Expr::Block(b) => scan_block(&b.block, violations),
+        syn::Expr::If(i) => {
+            scan_expr(&i.cond, violations);
+            scan_block(&i.then_branch, violations);
+            if let Some((_, else_expr)) = &i.else_branch {
+                scan_expr(else_expr, violations);
+            }
+        }
+        syn::Expr::Match(m) => {
+            scan_expr(&m.expr, violations);
+            for arm in &m.arms {
+                scan_expr(&arm.body, violations);
+            }
+        }
+        syn::Expr::Loop(l) => scan_block(&l.body, violations),
+        syn::Expr::ForLoop(f) => scan_block(&f.body, violations),
+        syn::Expr::While(w) => {
+            scan_expr(&w.cond, violations);
+            scan_block(&w.body, violations);
+        }
+        syn::Expr::Closure(c) => scan_expr(&c.body, violations),
+        syn::Expr::Paren(p) => scan_expr(&p.expr, violations),
+        syn::Expr::Try(t) => scan_expr(&t.expr, violations),
+        syn::Expr::Await(a) => scan_expr(&a.base, violations),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_raw_invoke_contract() {
+        let rule = RawInvokeContractRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn call_other(env: Env, target: Address) {
+                    let _result = env.invoke_contract::<()>(
+                        &target,
+                        &symbol_short!("ping"),
+                        soroban_sdk::vec![&env],
+                    );
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty(), "raw invoke_contract must be flagged");
+        assert!(violations[0].message.contains("invoke_contract"));
+        assert!(violations[0].suggestion.is_some());
+    }
+
+    #[test]
+    fn does_not_flag_try_invoke_contract() {
+        let rule = RawInvokeContractRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn call_other(env: Env, target: Address) -> Result<(), Error> {
+                    env.try_invoke_contract::<(), Error>(
+                        &target,
+                        &symbol_short!("ping"),
+                        soroban_sdk::vec![&env],
+                    )?;
+                    Ok(())
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            violations.is_empty(),
+            "try_invoke_contract must not be flagged"
+        );
+    }
+
+    #[test]
+    fn flags_invoke_contract_inside_if_branch() {
+        let rule = RawInvokeContractRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn conditional_call(env: Env, target: Address, flag: bool) {
+                    if flag {
+                        env.invoke_contract::<()>(
+                            &target,
+                            &symbol_short!("act"),
+                            soroban_sdk::vec![&env],
+                        );
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            !violations.is_empty(),
+            "invoke_contract inside if-branch must be flagged"
+        );
+    }
+
+    #[test]
+    fn suggestion_mentions_try_invoke_contract() {
+        let rule = RawInvokeContractRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn call_other(env: Env, target: Address) {
+                    env.invoke_contract::<()>(
+                        &target,
+                        &symbol_short!("ping"),
+                        soroban_sdk::vec![&env],
+                    );
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty());
+        let suggestion = violations[0].suggestion.as_deref().unwrap_or("");
+        assert!(
+            suggestion.contains("try_invoke_contract"),
+            "suggestion must reference try_invoke_contract"
+        );
+    }
+
+    #[test]
+    fn empty_source_produces_no_violations() {
+        let rule = RawInvokeContractRule::new();
+        assert!(rule.check("").is_empty());
+    }
+
+    #[test]
+    fn invalid_source_produces_no_panic() {
+        let rule = RawInvokeContractRule::new();
+        assert!(rule.check("not valid rust {{{{").is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #803 from the contrib-wave milestone.

- Adds a new static-analysis rule **S022 `raw_invoke_contract`** that detects every call to `env.invoke_contract()` inside `#[contractimpl]` blocks. Raw `invoke_contract` panics when the callee returns an error, giving the caller no opportunity to recover. The rule emits a `Warning`-severity finding with a suggestion to migrate to `env.try_invoke_contract()` and propagate the `Result` explicitly.
- Registers the rule in `RuleRegistry::with_default_rules`.
- Adds the `S022` constant and `FindingCode` entry to `finding_codes.rs`.
- Adds fixture `contracts/fixtures/finding-codes/s022_raw_invoke_contract.rs` showing both the unsafe pattern and the safe alternative side-by-side.
- Updates `docs/error-codes.md` and the fixture index in `contracts/fixtures/finding-codes/README.md`.
- Six unit tests: detection, no false-positive on `try_invoke_contract`, nested if-branch detection, suggestion text check, empty source, and invalid source.

## Issues

Closes #803
Closes #806
Closes #807
Closes #811

## Test plan

- [ ] `cargo check -p sanctifier-core --no-default-features` passes
- [ ] Unit tests in `raw_invoke_contract.rs` all pass
- [ ] Fixture `s022_raw_invoke_contract.rs` produces exactly one S022 finding on the `unsafe_cross_call` function and zero findings on `safe_cross_call`
- [ ] `finding_codes_are_unique` test still passes (no duplicate codes)