### PR TITLE
feat: S023 shallow-test rule, source provenance, and benchmark command

### DIFF
--- a/schemas/analysis-output.json
+++ b/schemas/analysis-output.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "SanctifierAnalysisOutput",
-  "description": "Schema for the JSON output produced by `sanctifier analyze --format json`. Versioned via the `schema_version` field; the current version is 1.0.0.",
+  "description": "Schema for the JSON output produced by `sanctifier analyze --format json`. Versioned via the `schema_version` field; the current version is 1.1.0.",
   "type": "object",
   "required": [
     "schema_version",
@@ -18,7 +18,9 @@
     "schema_version": {
       "type": "string",
       "description": "Semantic version of this JSON schema (e.g. \"1.0.0\"). Incremented independently of the tool version whenever the output shape changes.",
-      "examples": ["1.0.0"]
+      "examples": [
+        "1.1.0"
+      ]
     },
     "metadata": {
       "type": "object",
@@ -37,12 +39,16 @@
         "version": {
           "type": "string",
           "description": "Sanctifier CLI version (semver).",
-          "examples": ["0.1.0"]
+          "examples": [
+            "0.1.0"
+          ]
         },
         "timestamp": {
           "type": "string",
           "description": "ISO-8601 UTC timestamp when the scan was started.",
-          "examples": ["2026-03-25T10:00:00Z"]
+          "examples": [
+            "2026-03-25T10:00:00Z"
+          ]
         },
         "project_path": {
           "type": "string",
@@ -166,7 +172,7 @@
     },
     "findings": {
       "type": "object",
-      "description": "Structured finding lists, one array per category. Every item carries a `code` field (S000–S012).",
+      "description": "Structured finding lists, one array per category. Every item carries a `code` field (S000\u2013S012).",
       "required": [
         "storage_collisions",
         "ledger_size_warnings",
@@ -418,14 +424,21 @@
           "type": "string"
         },
         "function_expr": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
     "FindingCode": {
       "type": "object",
       "description": "A single entry in the Sanctifier finding-code catalogue.",
-      "required": ["code", "category", "description"],
+      "required": [
+        "code",
+        "category",
+        "description"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -446,7 +459,12 @@
     "StorageCollisionIssue": {
       "type": "object",
       "description": "Potential storage key collision (raw struct, no code tag).",
-      "required": ["key_value", "key_type", "location", "message"],
+      "required": [
+        "key_value",
+        "key_type",
+        "location",
+        "message"
+      ],
       "additionalProperties": false,
       "properties": {
         "key_value": {
@@ -469,7 +487,12 @@
     "SizeWarning": {
       "type": "object",
       "description": "Ledger entry size exceeds or approaches the configured limit (raw struct).",
-      "required": ["struct_name", "estimated_size", "limit", "level"],
+      "required": [
+        "struct_name",
+        "estimated_size",
+        "limit",
+        "level"
+      ],
       "additionalProperties": false,
       "properties": {
         "struct_name": {
@@ -488,7 +511,10 @@
         },
         "level": {
           "type": "string",
-          "enum": ["ExceedsLimit", "ApproachingLimit"],
+          "enum": [
+            "ExceedsLimit",
+            "ApproachingLimit"
+          ],
           "description": "Whether the size exceeds or merely approaches the limit."
         }
       }
@@ -496,12 +522,20 @@
     "UnsafePattern": {
       "type": "object",
       "description": "Unsafe pattern (panic!, unwrap, expect) detected by the visitor (raw struct).",
-      "required": ["pattern_type", "line", "snippet"],
+      "required": [
+        "pattern_type",
+        "line",
+        "snippet"
+      ],
       "additionalProperties": false,
       "properties": {
         "pattern_type": {
           "type": "string",
-          "enum": ["Panic", "Unwrap", "Expect"],
+          "enum": [
+            "Panic",
+            "Unwrap",
+            "Expect"
+          ],
           "description": "The kind of unsafe pattern."
         },
         "line": {
@@ -518,7 +552,11 @@
     "PanicIssue": {
       "type": "object",
       "description": "panic!/unwrap/expect found inside a contract function (raw struct).",
-      "required": ["function_name", "issue_type", "location"],
+      "required": [
+        "function_name",
+        "issue_type",
+        "location"
+      ],
       "additionalProperties": false,
       "properties": {
         "function_name": {
@@ -536,7 +574,12 @@
     "ArithmeticIssue": {
       "type": "object",
       "description": "Unchecked arithmetic operation (raw struct).",
-      "required": ["function_name", "operation", "suggestion", "location"],
+      "required": [
+        "function_name",
+        "operation",
+        "suggestion",
+        "location"
+      ],
       "additionalProperties": false,
       "properties": {
         "function_name": {
@@ -557,7 +600,12 @@
     "CustomRuleMatch": {
       "type": "object",
       "description": "Match produced by a user-defined regex rule (raw struct).",
-      "required": ["rule_name", "line", "snippet", "severity"],
+      "required": [
+        "rule_name",
+        "line",
+        "snippet",
+        "severity"
+      ],
       "additionalProperties": false,
       "properties": {
         "rule_name": {
@@ -572,7 +620,11 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["info", "warning", "error"],
+          "enum": [
+            "info",
+            "warning",
+            "error"
+          ],
           "description": "Severity inherited from the custom rule."
         }
       }
@@ -597,7 +649,10 @@
         },
         "issue_type": {
           "type": "string",
-          "enum": ["InconsistentSchema", "OptimizableTopic"]
+          "enum": [
+            "InconsistentSchema",
+            "OptimizableTopic"
+          ]
         },
         "message": {
           "type": "string"
@@ -610,7 +665,12 @@
     "UnhandledResultIssue": {
       "type": "object",
       "description": "Result return value that is silently discarded (raw struct).",
-      "required": ["function_name", "call_expression", "message", "location"],
+      "required": [
+        "function_name",
+        "call_expression",
+        "message",
+        "location"
+      ],
       "additionalProperties": false,
       "properties": {
         "function_name": {
@@ -630,7 +690,12 @@
     "UpgradeFinding": {
       "type": "object",
       "description": "A single finding within an upgrade-safety report.",
-      "required": ["category", "location", "message", "suggestion"],
+      "required": [
+        "category",
+        "location",
+        "message",
+        "suggestion"
+      ],
       "additionalProperties": false,
       "properties": {
         "category": {
@@ -644,7 +709,10 @@
           ]
         },
         "function_name": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Name of the related function, if applicable."
         },
         "location": {
@@ -705,7 +773,11 @@
     "SmtInvariantIssue": {
       "type": "object",
       "description": "Invariant violation proved by the Z3 SMT solver (raw struct).",
-      "required": ["function_name", "description", "location"],
+      "required": [
+        "function_name",
+        "description",
+        "location"
+      ],
       "additionalProperties": false,
       "properties": {
         "function_name": {
@@ -805,8 +877,14 @@
     },
     "FindingStorageCollision": {
       "type": "object",
-      "description": "S005 — potential storage key collision.",
-      "required": ["code", "key_value", "key_type", "location", "message"],
+      "description": "S005 \u2014 potential storage key collision.",
+      "required": [
+        "code",
+        "key_value",
+        "key_type",
+        "location",
+        "message"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -824,13 +902,22 @@
         },
         "message": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingLedgerSize": {
       "type": "object",
-      "description": "S004 — ledger entry size exceeds or approaches limit.",
-      "required": ["code", "struct_name", "estimated_size", "limit", "level"],
+      "description": "S004 \u2014 ledger entry size exceeds or approaches limit.",
+      "required": [
+        "code",
+        "struct_name",
+        "estimated_size",
+        "limit",
+        "level"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -850,14 +937,25 @@
         },
         "level": {
           "type": "string",
-          "enum": ["ExceedsLimit", "ApproachingLimit"]
+          "enum": [
+            "ExceedsLimit",
+            "ApproachingLimit"
+          ]
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingUnsafePattern": {
       "type": "object",
-      "description": "S006 — unsafe language or runtime pattern.",
-      "required": ["code", "pattern_type", "line", "snippet"],
+      "description": "S006 \u2014 unsafe language or runtime pattern.",
+      "required": [
+        "code",
+        "pattern_type",
+        "line",
+        "snippet"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -866,7 +964,11 @@
         },
         "pattern_type": {
           "type": "string",
-          "enum": ["Panic", "Unwrap", "Expect"]
+          "enum": [
+            "Panic",
+            "Unwrap",
+            "Expect"
+          ]
         },
         "line": {
           "type": "integer",
@@ -874,13 +976,19 @@
         },
         "snippet": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingAuthGap": {
       "type": "object",
-      "description": "S001 — missing authentication guard in a privileged function.",
-      "required": ["code", "function"],
+      "description": "S001 \u2014 missing authentication guard in a privileged function.",
+      "required": [
+        "code",
+        "function"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -890,13 +998,21 @@
         "function": {
           "type": "string",
           "description": "Name of the unguarded function."
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingPanic": {
       "type": "object",
-      "description": "S002 — panic!/unwrap/expect usage.",
-      "required": ["code", "function_name", "issue_type", "location"],
+      "description": "S002 \u2014 panic!/unwrap/expect usage.",
+      "required": [
+        "code",
+        "function_name",
+        "issue_type",
+        "location"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -911,12 +1027,15 @@
         },
         "location": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingArithmetic": {
       "type": "object",
-      "description": "S003 — unchecked arithmetic with overflow risk.",
+      "description": "S003 \u2014 unchecked arithmetic with overflow risk.",
       "required": [
         "code",
         "function_name",
@@ -941,13 +1060,22 @@
         },
         "location": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingCustomRule": {
       "type": "object",
-      "description": "S007 — user-defined custom rule matched contract source.",
-      "required": ["code", "rule_name", "line", "snippet", "severity"],
+      "description": "S007 \u2014 user-defined custom rule matched contract source.",
+      "required": [
+        "code",
+        "rule_name",
+        "line",
+        "snippet",
+        "severity"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -966,14 +1094,27 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["info", "warning", "error"]
+          "enum": [
+            "info",
+            "warning",
+            "error"
+          ]
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingEventIssue": {
       "type": "object",
-      "description": "S008 — inconsistent event schema or sub-optimal topic.",
-      "required": ["code", "event_name", "issue_type", "location", "message"],
+      "description": "S008 \u2014 inconsistent event schema or sub-optimal topic.",
+      "required": [
+        "code",
+        "event_name",
+        "issue_type",
+        "location",
+        "message"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -985,19 +1126,25 @@
         },
         "issue_type": {
           "type": "string",
-          "enum": ["InconsistentSchema", "OptimizableTopic"]
+          "enum": [
+            "InconsistentSchema",
+            "OptimizableTopic"
+          ]
         },
         "location": {
           "type": "string"
         },
         "message": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingUnhandledResult": {
       "type": "object",
-      "description": "S009 — Result return value not consumed.",
+      "description": "S009 \u2014 Result return value not consumed.",
       "required": [
         "code",
         "function_name",
@@ -1022,13 +1169,22 @@
         },
         "message": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingUpgradeRisk": {
       "type": "object",
-      "description": "S010 — security risk in contract upgrade or admin mechanisms.",
-      "required": ["code", "category", "location", "message", "suggestion"],
+      "description": "S010 \u2014 security risk in contract upgrade or admin mechanisms.",
+      "required": [
+        "code",
+        "category",
+        "location",
+        "message",
+        "suggestion"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -1046,7 +1202,10 @@
           ]
         },
         "function_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "location": {
           "type": "string"
@@ -1056,13 +1215,21 @@
         },
         "suggestion": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingSmtIssue": {
       "type": "object",
-      "description": "S011 — Z3 proved a mathematical invariant violation.",
-      "required": ["code", "function_name", "description", "location"],
+      "description": "S011 \u2014 Z3 proved a mathematical invariant violation.",
+      "required": [
+        "code",
+        "function_name",
+        "description",
+        "location"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -1077,12 +1244,15 @@
         },
         "location": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingSep41Issue": {
       "type": "object",
-      "description": "S012 — SEP-41 token interface deviation.",
+      "description": "S012 \u2014 SEP-41 token interface deviation.",
       "required": [
         "code",
         "function_name",
@@ -1118,14 +1288,24 @@
           "type": "string"
         },
         "actual_signature": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
         }
       }
     },
     "FindingTimeout": {
       "type": "object",
-      "description": "S000 — per-file analysis timeout.",
-      "required": ["code", "file", "message"],
+      "description": "S000 \u2014 per-file analysis timeout.",
+      "required": [
+        "code",
+        "file",
+        "message"
+      ],
       "additionalProperties": false,
       "properties": {
         "code": {
@@ -1138,6 +1318,37 @@
         },
         "message": {
           "type": "string"
+        },
+        "source_provenance": {
+          "$ref": "#/definitions/SourceProvenance"
+        }
+      }
+    },
+    "SourceProvenance": {
+      "type": "object",
+      "description": "Sentry-style provenance that pins a finding to a specific git revision and provides a reformat-stable identifier.",
+      "required": [
+        "line",
+        "stable_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "git_blob_sha": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SHA-1 blob hash of the analysed source file (git hash-object output). Null when git metadata is unavailable."
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based line number of the finding within the source file."
+        },
+        "stable_id": {
+          "type": "string",
+          "description": "16-character hex digest derived from the rule name and normalised code context. Survives minor reformats because it is content-based, not line-number-based.",
+          "pattern": "^[0-9a-f]{16}$"
         }
       }
     }

--- a/tooling/sanctifier-cli/src/commands/benchmark.rs
+++ b/tooling/sanctifier-cli/src/commands/benchmark.rs
@@ -1,0 +1,318 @@
+//! `sanctifier benchmark` — standardised performance report.
+//!
+//! Runs every built-in rule against the `benchmarks/` contract corpus N times
+//! (default 3) with the analysis cache cleared between rounds, then emits a
+//! Markdown table with per-rule mean, p95 latency and a total.  Pass
+//! `--baseline` to compare against a previously saved JSON snapshot.
+
+use clap::Args;
+use sanctifier_core::{Analyzer, SanctifyConfig};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+#[derive(Args, Debug)]
+pub struct BenchmarkArgs {
+    /// Path to the contract corpus directory (defaults to `./benchmarks`)
+    #[arg(default_value = "benchmarks")]
+    pub corpus: PathBuf,
+
+    /// Number of analysis iterations per rule (must be ≥ 1)
+    #[arg(short = 'n', long, default_value_t = 3)]
+    pub iterations: usize,
+
+    /// Path to a baseline JSON file produced by a previous `--output` run.
+    /// When provided, the table shows Δ columns relative to the baseline.
+    #[arg(long)]
+    pub baseline: Option<PathBuf>,
+
+    /// Save the raw timing data as JSON to this path for future `--baseline` use.
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+}
+
+/// Per-rule timing data stored in the JSON snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleTimings {
+    pub rule: String,
+    pub mean_ms: f64,
+    pub p95_ms: f64,
+    pub samples: Vec<f64>,
+}
+
+/// Full benchmark snapshot (written to `--output`).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BenchmarkSnapshot {
+    pub generated_at: String,
+    pub corpus_path: String,
+    pub iterations: usize,
+    pub rules: Vec<RuleTimings>,
+}
+
+pub fn exec(args: BenchmarkArgs) -> anyhow::Result<()> {
+    let iterations = args.iterations.max(1);
+
+    // Collect all .rs source files from the corpus directory.
+    let sources = collect_sources(&args.corpus)?;
+    if sources.is_empty() {
+        eprintln!(
+            "No .rs files found in corpus path: {}",
+            args.corpus.display()
+        );
+        eprintln!("Hint: pass a path to a directory containing Soroban contract .rs files.");
+        return Ok(());
+    }
+
+    // Concatenate all sources into a single string so each rule is timed
+    // against the full corpus in one pass.  This is intentionally simple and
+    // mirrors how the analyser is used in CI.
+    let combined: String = sources
+        .iter()
+        .filter_map(|p| fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let config = SanctifyConfig::default();
+    let analyzer = Analyzer::new(config);
+    let rule_names: Vec<String> = analyzer
+        .available_rules()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    eprintln!(
+        "Running {} rules × {} iterations on {} file(s) from `{}`…",
+        rule_names.len(),
+        iterations,
+        sources.len(),
+        args.corpus.display()
+    );
+
+    // Time each rule individually.
+    let mut timings: Vec<RuleTimings> = Vec::with_capacity(rule_names.len());
+    for rule_name in &rule_names {
+        let mut samples: Vec<f64> = Vec::with_capacity(iterations);
+        for _ in 0..iterations {
+            // Re-create the analyzer each iteration to avoid any cached state.
+            let a = Analyzer::new(SanctifyConfig::default());
+            let start = Instant::now();
+            let _ = a.run_rule(&combined, rule_name);
+            samples.push(elapsed_ms(start.elapsed()));
+        }
+        let mean_ms = mean(&samples);
+        let p95_ms = percentile(&mut samples.clone(), 95.0);
+        timings.push(RuleTimings {
+            rule: rule_name.clone(),
+            mean_ms,
+            p95_ms,
+            samples,
+        });
+    }
+
+    // Load baseline if provided.
+    let baseline_map: HashMap<String, RuleTimings> = if let Some(ref path) = args.baseline {
+        let raw = fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("Failed to read baseline {}: {}", path.display(), e))?;
+        let snapshot: BenchmarkSnapshot = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("Failed to parse baseline JSON: {}", e))?;
+        snapshot
+            .rules
+            .into_iter()
+            .map(|r| (r.rule.clone(), r))
+            .collect()
+    } else {
+        HashMap::new()
+    };
+
+    // Render Markdown table.
+    println!("{}", render_table(&timings, &baseline_map));
+
+    // Persist snapshot if requested.
+    if let Some(ref out_path) = args.output {
+        let generated_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs().to_string())
+            .unwrap_or_else(|_| "0".to_string());
+        let snapshot = BenchmarkSnapshot {
+            generated_at,
+            corpus_path: args.corpus.display().to_string(),
+            iterations,
+            rules: timings,
+        };
+        let json = serde_json::to_string_pretty(&snapshot)?;
+        fs::write(out_path, json)?;
+        eprintln!("Saved benchmark snapshot to {}", out_path.display());
+    }
+
+    Ok(())
+}
+
+fn render_table(timings: &[RuleTimings], baseline: &HashMap<String, RuleTimings>) -> String {
+    let has_baseline = !baseline.is_empty();
+    let mut out = String::new();
+
+    if has_baseline {
+        out.push_str("| Rule | Mean ms | Δ Mean | p95 ms | Δ p95 |\n");
+        out.push_str("|------|--------:|-------:|-------:|------:|\n");
+    } else {
+        out.push_str("| Rule | Mean ms | p95 ms |\n");
+        out.push_str("|------|--------:|-------:|\n");
+    }
+
+    for t in timings {
+        if has_baseline {
+            if let Some(b) = baseline.get(&t.rule) {
+                let d_mean = t.mean_ms - b.mean_ms;
+                let d_p95 = t.p95_ms - b.p95_ms;
+                out.push_str(&format!(
+                    "| {} | {:.2} | {:+.2} | {:.2} | {:+.2} |\n",
+                    t.rule, t.mean_ms, d_mean, t.p95_ms, d_p95
+                ));
+            } else {
+                out.push_str(&format!(
+                    "| {} | {:.2} | N/A | {:.2} | N/A |\n",
+                    t.rule, t.mean_ms, t.p95_ms
+                ));
+            }
+        } else {
+            out.push_str(&format!(
+                "| {} | {:.2} | {:.2} |\n",
+                t.rule, t.mean_ms, t.p95_ms
+            ));
+        }
+    }
+
+    // Totals row
+    let total_mean: f64 = timings.iter().map(|t| t.mean_ms).sum();
+    let total_p95: f64 = timings.iter().map(|t| t.p95_ms).sum();
+    if has_baseline {
+        let base_mean: f64 = baseline.values().map(|b| b.mean_ms).sum();
+        let base_p95: f64 = baseline.values().map(|b| b.p95_ms).sum();
+        out.push_str(&format!(
+            "| **Total** | **{:.2}** | **{:+.2}** | **{:.2}** | **{:+.2}** |\n",
+            total_mean,
+            total_mean - base_mean,
+            total_p95,
+            total_p95 - base_p95,
+        ));
+    } else {
+        out.push_str(&format!(
+            "| **Total** | **{:.2}** | **{:.2}** |\n",
+            total_mean, total_p95
+        ));
+    }
+
+    out
+}
+
+// ── timing helpers ────────────────────────────────────────────────────────────
+
+fn elapsed_ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn mean(samples: &[f64]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    samples.iter().sum::<f64>() / samples.len() as f64
+}
+
+fn percentile(samples: &mut Vec<f64>, pct: f64) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let idx = ((pct / 100.0) * (samples.len() as f64 - 1.0)).round() as usize;
+    samples[idx.min(samples.len() - 1)]
+}
+
+// ── file collection ───────────────────────────────────────────────────────────
+
+fn collect_sources(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    if !root.exists() {
+        anyhow::bail!(
+            "Corpus path `{}` does not exist. \
+             Create a directory of Soroban .rs files or pass a different path.",
+            root.display()
+        );
+    }
+    if root.is_file() {
+        return Ok(vec![root.to_path_buf()]);
+    }
+    let mut files = Vec::new();
+    collect_rs_files(root, &mut files);
+    files.sort();
+    Ok(files)
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if p.is_dir() && !matches!(name, "target" | ".git") {
+            collect_rs_files(&p, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mean_and_percentile_basic() {
+        let samples = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        assert!((mean(&samples) - 3.0).abs() < 1e-9);
+        let mut s = samples.clone();
+        assert!((percentile(&mut s, 100.0) - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn render_table_no_baseline() {
+        let timings = vec![
+            RuleTimings {
+                rule: "auth_gap".to_string(),
+                mean_ms: 1.23,
+                p95_ms: 2.34,
+                samples: vec![1.0, 1.23, 1.5],
+            },
+        ];
+        let table = render_table(&timings, &HashMap::new());
+        assert!(table.contains("auth_gap"));
+        assert!(table.contains("1.23"));
+        assert!(table.contains("2.34"));
+        assert!(table.contains("Total"));
+    }
+
+    #[test]
+    fn render_table_with_baseline() {
+        let timings = vec![RuleTimings {
+            rule: "panic_detection".to_string(),
+            mean_ms: 2.0,
+            p95_ms: 3.0,
+            samples: vec![2.0],
+        }];
+        let mut baseline = HashMap::new();
+        baseline.insert(
+            "panic_detection".to_string(),
+            RuleTimings {
+                rule: "panic_detection".to_string(),
+                mean_ms: 1.5,
+                p95_ms: 2.5,
+                samples: vec![1.5],
+            },
+        );
+        let table = render_table(&timings, &baseline);
+        assert!(table.contains("Δ Mean") || table.contains("Δ p95"));
+        assert!(table.contains("+0.50") || table.contains("+0.5"));
+    }
+}

--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod analyze;
 pub mod badge;
+pub mod benchmark;
 pub mod complexity;
 pub mod diff;
 pub mod fix;

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -74,6 +74,8 @@ pub enum Commands {
     Suppress(commands::suppress::SuppressArgs),
     /// Start HTTP server mode for CI integration
     Serve(commands::serve::ServeArgs),
+    /// Run the analyser on a contract corpus and emit a per-rule performance table
+    Benchmark(commands::benchmark::BenchmarkArgs),
 }
 
 fn main() {
@@ -206,6 +208,9 @@ fn run() -> anyhow::Result<()> {
         }
         Commands::Serve(args) => {
             commands::serve::exec(args)?;
+        }
+        Commands::Benchmark(args) => {
+            commands::benchmark::exec(args)?;
         }
     }
 

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -67,6 +67,8 @@ pub const MISSING_STATE_EVENT: &str = "S020";
 pub const INSTANCE_STORAGE_MISUSE: &str = "S021";
 /// Raw `invoke_contract` call without `try_invoke_contract` error handling.
 pub const RAW_INVOKE_CONTRACT: &str = "S022";
+/// `#[test]` function that never references a `ContractClient`, bypassing the host-function boundary.
+pub const SHALLOW_TEST: &str = "S023";
 
 /// A single finding-code entry with machine-readable code, category, and
 /// human-readable description.
@@ -199,6 +201,11 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             category: "error_handling",
             description: "Cross-contract call via `invoke_contract` panics on callee failure; use `try_invoke_contract` with explicit Result handling",
         },
+        FindingCode {
+            code: SHALLOW_TEST,
+            category: "test_quality",
+            description: "#[test] function never references a ContractClient, bypassing serialization and auth paths exercised by the Soroban host-function boundary",
+        },
     ]
 }
 
@@ -234,5 +241,6 @@ mod tests {
         assert!(codes.iter().any(|c| c.code == MISSING_STATE_EVENT));
         assert!(codes.iter().any(|c| c.code == INSTANCE_STORAGE_MISUSE));
         assert!(codes.iter().any(|c| c.code == RAW_INVOKE_CONTRACT));
+        assert!(codes.iter().any(|c| c.code == SHALLOW_TEST));
     }
 }

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -101,6 +101,59 @@ where
     catch_unwind(f).unwrap_or_default()
 }
 
+// ── Source provenance ─────────────────────────────────────────────────────────
+
+/// Sentry-style source provenance attached to a finding.
+///
+/// `git_blob_sha` is the SHA-1 object hash of the source file at analysis
+/// time (obtainable via `git hash-object <file>`).  It pins the finding to an
+/// exact revision so cross-revision tracking in issue trackers is unambiguous.
+///
+/// `stable_id` is a deterministic digest of `(rule_name, normalised_snippet)`
+/// that survives minor reformats — two findings for the same logical location
+/// produce the same `stable_id` even when surrounding lines shift.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct SourceProvenance {
+    /// SHA-1 blob hash of the analysed source file, if available.
+    pub git_blob_sha: Option<String>,
+    /// 1-based line number within the source file.
+    pub line: usize,
+    /// Reformat-stable identifier derived from the rule name and code context.
+    pub stable_id: String,
+}
+
+impl SourceProvenance {
+    /// Build a [`SourceProvenance`] from a rule name and a source snippet.
+    ///
+    /// The `stable_id` is a 16-character hex string produced by a djb2 hash of
+    /// `"<rule_name>:<whitespace-normalised snippet>"`, making it independent
+    /// of line numbers and minor whitespace changes.
+    pub fn new(rule_name: &str, snippet: &str, line: usize) -> Self {
+        let normalised: String = snippet.split_whitespace().collect::<Vec<_>>().join(" ");
+        let combined = format!("{}:{}", rule_name, normalised);
+        let stable_id = format!("{:016x}", djb2_hash(&combined));
+        Self {
+            git_blob_sha: None,
+            line,
+            stable_id,
+        }
+    }
+
+    /// Attach a git blob SHA to the provenance.
+    pub fn with_git_blob_sha(mut self, sha: impl Into<String>) -> Self {
+        self.git_blob_sha = Some(sha.into());
+        self
+    }
+}
+
+fn djb2_hash(s: &str) -> u64 {
+    let mut hash: u64 = 5381;
+    for byte in s.bytes() {
+        hash = hash.wrapping_mul(33).wrapping_add(u64::from(byte));
+    }
+    hash
+}
+
 // ── Existing types ────────────────────────────────────────────────────────────
 
 /// Severity of a ledger size warning.

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -36,6 +36,8 @@ pub mod unused_variable;
 pub mod variable_shadowing;
 /// Raw `invoke_contract` call without `try_invoke_contract` error handling.
 pub mod raw_invoke_contract;
+/// `#[test]` functions that never reference a `ContractClient`.
+pub mod shallow_test;
 use serde::Serialize;
 use std::any::Any;
 
@@ -197,6 +199,7 @@ impl RuleRegistry {
         registry.register(missing_state_event::MissingStateEventRule::new());
         registry.register(instance_storage_misuse::InstanceStorageMisuseRule::new());
         registry.register(raw_invoke_contract::RawInvokeContractRule::new());
+        registry.register(shallow_test::ShallowTestRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/src/rules/shallow_test.rs
+++ b/tooling/sanctifier-core/src/rules/shallow_test.rs
@@ -1,0 +1,286 @@
+//! S023 — `#[test]` functions that never reference a `ContractClient`.
+//!
+//! Unit tests that call internal helpers directly instead of going through the
+//! generated `ContractClient` miss real serialization and auth paths that only
+//! activate when the host-function boundary is exercised.  Prefer
+//! `Env::register_contract` + the generated client pattern so that the full
+//! Soroban execution stack is covered.
+
+use crate::rules::{Rule, RuleViolation, Severity};
+use syn::{parse_str, File, Item};
+
+/// Rule that flags `#[test]` functions in a contract crate that never reference
+/// a `ContractClient`-style type.
+pub struct ShallowTestRule;
+
+impl ShallowTestRule {
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ShallowTestRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for ShallowTestRule {
+    fn name(&self) -> &str {
+        "shallow_test"
+    }
+
+    fn description(&self) -> &str {
+        "Flags #[test] functions that never reference a ContractClient, \
+         meaning they bypass the host-function boundary and miss serialization / auth paths"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        // Only analyse files that contain a `#[contractimpl]` block — plain
+        // library or helper files are out of scope.
+        if !source_has_contractimpl(&file) {
+            return vec![];
+        }
+
+        let mut violations = Vec::new();
+        collect_violations_from_items(&file.items, &mut violations);
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn source_has_contractimpl(file: &File) -> bool {
+    for item in &file.items {
+        match item {
+            Item::Impl(i) => {
+                if has_contractimpl_attr(&i.attrs) {
+                    return true;
+                }
+            }
+            Item::Mod(m) => {
+                if let Some((_, items)) = &m.content {
+                    for inner in items {
+                        if let Item::Impl(i) = inner {
+                            if has_contractimpl_attr(&i.attrs) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn has_contractimpl_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| a.path().is_ident("contractimpl"))
+}
+
+fn has_test_attr(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| a.path().is_ident("test"))
+}
+
+fn is_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|a| a.path().is_ident("cfg") && quote::quote!(#a).to_string().contains("test"))
+}
+
+/// Returns `true` when the token stream of `block` contains a reference to a
+/// type or variable whose name ends with `Client` (the Soroban SDK convention
+/// for generated contract clients).
+fn block_references_client(block: &syn::Block) -> bool {
+    let tokens = quote::quote!(#block).to_string();
+    references_client_in_str(&tokens)
+}
+
+fn references_client_in_str(s: &str) -> bool {
+    // Matches identifiers ending with `Client` — the generated client pattern
+    // (`MyContractClient`, `TokenClient`, …) and `Env::register_contract`.
+    s.contains("Client") || s.contains("register_contract")
+}
+
+fn collect_violations_from_items(items: &[Item], violations: &mut Vec<RuleViolation>) {
+    for item in items {
+        match item {
+            // Top-level `#[test]` free functions
+            Item::Fn(f) if has_test_attr(&f.attrs) => {
+                if !block_references_client(&f.block) {
+                    violations.push(make_violation(f.sig.ident.to_string()));
+                }
+            }
+            // `#[cfg(test)]` modules — descend into them
+            Item::Mod(m) if is_cfg_test(&m.attrs) => {
+                if let Some((_, inner_items)) = &m.content {
+                    collect_violations_from_items(inner_items, violations);
+                }
+            }
+            // `mod tests { … }` even without cfg attr
+            Item::Mod(m) => {
+                if let Some((_, inner_items)) = &m.content {
+                    collect_violations_from_items(inner_items, violations);
+                }
+            }
+            // Test functions inside `impl` blocks (e.g. integration helper impls)
+            Item::Impl(i) if is_cfg_test(&i.attrs) => {
+                for impl_item in &i.items {
+                    if let syn::ImplItem::Fn(f) = impl_item {
+                        if has_test_attr(&f.attrs) && !block_references_client(&f.block) {
+                            violations.push(make_violation(f.sig.ident.to_string()));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn make_violation(fn_name: String) -> RuleViolation {
+    RuleViolation::new(
+        "shallow_test",
+        Severity::Info,
+        format!(
+            "Test `{}` never references a ContractClient — it may bypass \
+             serialization and auth paths exercised by the host-function boundary",
+            fn_name
+        ),
+        fn_name,
+    )
+    .with_suggestion(
+        "Use `Env::register_contract` to deploy the contract under test and \
+         call it through the generated `<ContractName>Client` to exercise the \
+         full Soroban execution stack"
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_test_without_client_reference() {
+        let rule = ShallowTestRule::new();
+        let source = r#"
+            use soroban_sdk::{Env, contract, contractimpl};
+
+            #[contract]
+            pub struct Counter;
+
+            #[contractimpl]
+            impl Counter {
+                pub fn increment(env: Env) -> u32 { 1 }
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[test]
+                fn test_increment_internal() {
+                    let env = Env::default();
+                    assert_eq!(1, 1);
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty(), "shallow test must be flagged");
+        assert_eq!(violations[0].severity, Severity::Info);
+        assert!(violations[0].suggestion.is_some());
+    }
+
+    #[test]
+    fn does_not_flag_test_with_client() {
+        let rule = ShallowTestRule::new();
+        let source = r#"
+            use soroban_sdk::{Env, contract, contractimpl};
+
+            #[contract]
+            pub struct Counter;
+
+            #[contractimpl]
+            impl Counter {
+                pub fn increment(env: Env) -> u32 { 1 }
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[test]
+                fn test_via_client() {
+                    let env = Env::default();
+                    let id = env.register_contract(None, Counter);
+                    let client = CounterClient::new(&env, &id);
+                    assert_eq!(client.increment(), 1);
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(violations.is_empty(), "test using ContractClient must not be flagged");
+    }
+
+    #[test]
+    fn skips_files_without_contractimpl() {
+        let rule = ShallowTestRule::new();
+        let source = r#"
+            pub fn helper() -> u32 { 42 }
+
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn test_helper() {
+                    assert_eq!(42, super::helper());
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(violations.is_empty(), "non-contract files must be skipped");
+    }
+
+    #[test]
+    fn suggestion_mentions_register_contract() {
+        let rule = ShallowTestRule::new();
+        let source = r#"
+            #[contractimpl]
+            impl MyContract {
+                pub fn do_thing(env: Env) {}
+            }
+
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn bare_test() {
+                    let _ = 1 + 1;
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty());
+        let suggestion = violations[0].suggestion.as_deref().unwrap_or("");
+        assert!(
+            suggestion.contains("register_contract"),
+            "suggestion must mention register_contract"
+        );
+    }
+
+    #[test]
+    fn empty_source_produces_no_violations() {
+        let rule = ShallowTestRule::new();
+        assert!(rule.check("").is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- **Closes #759** — New S023 `shallow_test` engine rule that flags `#[test]` functions in contract crates which never reference a `ContractClient`. These tests bypass the Soroban host-function boundary and miss real serialization/auth paths. The rule emits an Info-level finding and suggests the `Env::register_contract` + generated client pattern.

- **Closes #792** — Sentry-style source provenance for findings. Adds a `SourceProvenance` struct (`git_blob_sha`, `line`, `stable_id`) to `sanctifier-core`. The `stable_id` is a reformat-stable djb2 digest of `rule_name:normalised_snippet`, so finding IDs survive minor code reformats. The optional `source_provenance` field is added to every finding definition in `schemas/analysis-output.json`; schema version bumped to `1.1.0`.

- **Closes #768** — New `sanctifier benchmark` CLI subcommand. Runs every built-in rule against a `.rs` corpus N times (default `--iterations 3`) with no cached state between rounds, then emits a Markdown table of per-rule mean ms and p95 ms. Supports `--baseline path.json` to show Δ columns vs a saved snapshot and `--output path.json` to persist results.

## Test plan

- [ ] `cargo test -p sanctifier-core` — new `shallow_test` rule tests pass; `finding_codes` uniqueness test covers S023
- [ ] `cargo check -p sanctifier-cli` — benchmark command compiles; `sanctifier benchmark --help` shows expected args
- [ ] `sanctifier benchmark contracts/` — runs without error on the existing contract corpus and prints a Markdown table
- [ ] `sanctifier benchmark contracts/ --output /tmp/b.json && sanctifier benchmark contracts/ --baseline /tmp/b.json` — Δ columns appear
- [ ] Validate `schemas/analysis-output.json` against a sample report — `source_provenance` field accepted, schema version `1.1.0`