### PR TITLE
feat: add rules for issues #754 #755 #756 #760 (contrib-wave engine)

### DIFF
--- a/benchmarks/static_reentrancy_fp_corpus.md
+++ b/benchmarks/static_reentrancy_fp_corpus.md
@@ -1,0 +1,105 @@
+# Static Reentrancy — False-Positive Corpus & Evaluation
+
+This document catalogues known-safe patterns that the `static_reentrancy` (S027)
+rule must **not** flag, along with the reasoning for each.
+
+---
+
+## Corpus Entries
+
+### FP-01: Correct CEI order (write before call)
+
+```rust
+pub fn safe_withdraw(env: Env, other: Address, amount: i128) {
+    // Effects first
+    env.storage().persistent().set(&symbol_short!("BAL"), &amount);
+    // Interaction last — correct CEI
+    let _ = env.invoke_contract::<()>(&other, &symbol_short!("recv"), vec![&env]);
+}
+```
+
+**Expected result:** No violation.  
+**Reason:** Storage mutation happens before the external call — the canonical safe order.
+
+---
+
+### FP-02: External call with no subsequent write
+
+```rust
+pub fn just_call(env: Env, other: Address) {
+    let _ = env.invoke_contract::<()>(&other, &symbol_short!("ping"), vec![&env]);
+}
+```
+
+**Expected result:** No violation.  
+**Reason:** There is no storage mutation following the call; no reentrancy window exists.
+
+---
+
+### FP-03: Reentrancy guard present
+
+```rust
+pub fn guarded_call(env: Env, other: Address) {
+    let locked: bool = env.storage().instance()
+        .get(&symbol_short!("RE_LOCK")).unwrap_or(false);
+    if locked { panic!("reentrant call"); }
+    env.storage().instance().set(&symbol_short!("RE_LOCK"), &true);
+    let _ = env.invoke_contract::<()>(&other, &symbol_short!("cb"), vec![&env]);
+    env.storage().persistent().set(&symbol_short!("STATE"), &1u32);
+    env.storage().instance().set(&symbol_short!("RE_LOCK"), &false);
+}
+```
+
+**Expected result:** No violation.  
+**Reason:** The `REENTRANCY_LOCK` / `RE_LOCK` guard pattern is detected; re-entry will panic.
+
+---
+
+### FP-04: Read-only function
+
+```rust
+pub fn query(env: Env) -> i128 {
+    env.storage().persistent().get(&symbol_short!("BAL")).unwrap_or(0)
+}
+```
+
+**Expected result:** No violation.  
+**Reason:** No storage mutations; no call → write sequence possible.
+
+---
+
+### FP-05: Multiple writes all before a single call
+
+```rust
+pub fn multi_write_then_call(env: Env, other: Address) {
+    env.storage().persistent().set(&symbol_short!("A"), &1u32);
+    env.storage().persistent().set(&symbol_short!("B"), &2u32);
+    let _ = env.invoke_contract::<()>(&other, &symbol_short!("go"), vec![&env]);
+}
+```
+
+**Expected result:** No violation.  
+**Reason:** All writes precede the external call; CEI order is satisfied.
+
+---
+
+## Evaluation Summary
+
+| ID | Pattern | Rule result | Expected | Pass? |
+|----|---------|-------------|----------|-------|
+| FP-01 | CEI correct order | No violation | No violation | ✅ |
+| FP-02 | Call without write | No violation | No violation | ✅ |
+| FP-03 | Guard present | No violation | No violation | ✅ |
+| FP-04 | Read-only | No violation | No violation | ✅ |
+| FP-05 | All writes before call | No violation | No violation | ✅ |
+
+---
+
+## Known True Positives (for completeness)
+
+| Pattern | Confidence |
+|---------|-----------|
+| `invoke_contract` → `persistent().set()` | high |
+| `try_invoke_contract` → `persistent().set()` | medium |
+| `invoke_contract_check` → `instance().set()` | medium |
+| Call in `if` branch → write outside | low |

--- a/contracts/fixtures/finding-codes/s025_missing_ttl_bump.rs
+++ b/contracts/fixtures/finding-codes/s025_missing_ttl_bump.rs
@@ -1,0 +1,42 @@
+//! S025 — Missing TTL bump on Persistent/Temporary storage write.
+//!
+//! Demonstrates contracts that write to expiring storage tiers without calling
+//! `extend_ttl`, causing silent data loss once the ledger TTL elapses.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+#[contract]
+pub struct MissingTtlBuggy;
+
+#[contract]
+pub struct MissingTtlGood;
+
+#[contractimpl]
+impl MissingTtlBuggy {
+    // ❌ BAD: writes to persistent storage without bumping TTL.
+    pub fn store(env: Env, key: Symbol, val: i128) {
+        env.storage().persistent().set(&key, &val);
+        // Missing: env.storage().persistent().extend_ttl(&key, 1000, 5000);
+    }
+
+    // ❌ BAD: temporary write also needs a TTL bump.
+    pub fn cache(env: Env, key: Symbol, val: i128) {
+        env.storage().temporary().set(&key, &val);
+    }
+}
+
+#[contractimpl]
+impl MissingTtlGood {
+    // ✅ GOOD: write is accompanied by extend_ttl.
+    pub fn store_safe(env: Env, key: Symbol, val: i128) {
+        env.storage().persistent().set(&key, &val);
+        env.storage().persistent().extend_ttl(&key, 1000, 5000);
+    }
+
+    // ✅ GOOD: instance storage has different lifecycle — not flagged.
+    pub fn set_instance_flag(env: Env) {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("flag"), &true);
+    }
+}

--- a/contracts/fixtures/finding-codes/s026_taint_propagation.rs
+++ b/contracts/fixtures/finding-codes/s026_taint_propagation.rs
@@ -1,0 +1,48 @@
+//! S026 — Taint propagation through tuple/struct destructures.
+//!
+//! Demonstrates cases where user-controlled data flows through destructuring
+//! assignments to storage sinks without authentication.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct TaintBuggy;
+
+#[contract]
+pub struct TaintGood;
+
+/// Helper struct for the struct-destructure test case.
+pub struct KeyValuePair {
+    pub key: Symbol,
+    pub value: i128,
+}
+
+#[contractimpl]
+impl TaintBuggy {
+    // ❌ BAD: taint flows through tuple destructure to storage key.
+    pub fn store_pair(env: Env, pair: (Symbol, i128)) {
+        let (key, val) = pair;
+        env.storage().persistent().set(&key, &val);
+    }
+
+    // ❌ BAD: taint flows through struct destructure to storage key.
+    pub fn store_record(env: Env, record: KeyValuePair) {
+        let KeyValuePair { key, value } = record;
+        env.storage().persistent().set(&key, &value);
+    }
+
+    // ❌ BAD: direct parameter taint to storage — simpler but same issue.
+    pub fn bad_set(env: Env, key: Symbol, val: i128) {
+        env.storage().persistent().set(&key, &val);
+    }
+}
+
+#[contractimpl]
+impl TaintGood {
+    // ✅ GOOD: require_auth gates the operation before any storage write.
+    pub fn store_pair_safe(env: Env, caller: Address, pair: (Symbol, i128)) {
+        caller.require_auth();
+        let (key, val) = pair;
+        env.storage().persistent().set(&key, &val);
+    }
+}

--- a/contracts/fixtures/finding-codes/s027_static_reentrancy.rs
+++ b/contracts/fixtures/finding-codes/s027_static_reentrancy.rs
@@ -1,0 +1,68 @@
+//! S027 — Static reentrancy (external call before state write).
+//!
+//! Demonstrates the checks-effects-interactions anti-pattern at the AST level:
+//! an external call that precedes a storage mutation without a reentrancy guard.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Address, Env};
+
+#[contract]
+pub struct StaticReentrancyBuggy;
+
+#[contract]
+pub struct StaticReentrancyGood;
+
+#[contractimpl]
+impl StaticReentrancyBuggy {
+    // ❌ BAD (high confidence): invoke_contract (panicking) before storage write.
+    pub fn unsafe_withdraw(env: Env, other: Address, amount: i128) {
+        // Interaction first — callee can re-enter with stale balance
+        let _result = env.invoke_contract::<()>(&other, &symbol_short!("recv"), vec![&env]);
+        // Effect too late — reentrancy has already exploited stale state
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("BAL"), &amount);
+    }
+
+    // ❌ BAD (medium confidence): try_invoke_contract before storage write.
+    pub fn try_call_then_write(env: Env, other: Address) {
+        let _ = env.try_invoke_contract::<(), ()>(&other, &symbol_short!("cb"), vec![&env]);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("STATE"), &1u32);
+    }
+}
+
+#[contractimpl]
+impl StaticReentrancyGood {
+    // ✅ GOOD: effects first (CEI pattern), then interaction.
+    pub fn safe_withdraw(env: Env, other: Address, amount: i128) {
+        // Effect first
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("BAL"), &amount);
+        // Interaction last — safe CEI order
+        let _result = env.invoke_contract::<()>(&other, &symbol_short!("recv"), vec![&env]);
+    }
+
+    // ✅ GOOD: reentrancy guard around the external call.
+    pub fn guarded_call(env: Env, other: Address) {
+        let locked: bool = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("RE_LOCK"))
+            .unwrap_or(false);
+        if locked {
+            panic!("reentrant call");
+        }
+        env.storage()
+            .instance()
+            .set(&symbol_short!("RE_LOCK"), &true);
+        let _result = env.invoke_contract::<()>(&other, &symbol_short!("cb"), vec![&env]);
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("STATE"), &1u32);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("RE_LOCK"), &false);
+    }
+}

--- a/docs/rule-authoring-guide.md
+++ b/docs/rule-authoring-guide.md
@@ -168,9 +168,56 @@ Downstream users who add your crate automatically inherit the rules.
 
 ---
 
+## 7. Taint Propagation and Destructures (Built-in Rule S026)
+
+When writing built-in Rust rules that perform taint analysis, be aware that taint
+**must** be propagated through all pattern-binding forms — not just simple `let x = ...`
+assignments.
+
+### 7.1 Tuple destructures
+
+```rust
+// user_data is a tainted function parameter
+let (key, val) = user_data;   // key AND val must inherit taint
+env.storage().persistent().set(&key, &val);  // should be flagged
+```
+
+In the AST this is a `syn::Stmt::Local` whose `pat` is `syn::Pat::Tuple`.  Iterate
+`pt.elems` and mark every bound identifier as tainted.
+
+### 7.2 Struct destructures
+
+```rust
+let MyRecord { key, value } = record;  // key AND value must inherit taint
+```
+
+The pattern is `syn::Pat::Struct`; iterate `ps.fields` and recurse into each
+`field.pat`.
+
+### 7.3 Implementation pattern
+
+```rust
+fn collect_pat_idents(pat: &Pat, out: &mut HashSet<String>) {
+    match pat {
+        Pat::Ident(pi)        => { out.insert(pi.ident.to_string()); }
+        Pat::Tuple(pt)        => pt.elems.iter().for_each(|e| collect_pat_idents(e, out)),
+        Pat::Struct(ps)       => ps.fields.iter().for_each(|f| collect_pat_idents(&f.pat, out)),
+        Pat::TupleStruct(pts) => pts.elems.iter().for_each(|e| collect_pat_idents(e, out)),
+        Pat::Reference(pr)    => collect_pat_idents(&pr.pat, out),
+        _                     => {}
+    }
+}
+```
+
+Not handling `Pat::Tuple` / `Pat::Struct` is the most common source of false negatives
+in taint passes — taint silently disappears at the destructure boundary.
+
+---
+
 ## Further Reading
 
 - [`custom-rules.example.yaml`](../custom-rules.example.yaml) — full example rule set
 - [`tooling/sanctifier-core/src/custom_yaml_rules.rs`](../tooling/sanctifier-core/src/custom_yaml_rules.rs) — rule engine source
+- [`tooling/sanctifier-core/src/rules/taint_propagation.rs`](../tooling/sanctifier-core/src/rules/taint_propagation.rs) — reference taint implementation
 - [Troubleshooting Guide](troubleshooting-guide.md)
 - [Contributing](../CONTRIBUTING.md)

--- a/docs/rules/missing-ttl-bump.md
+++ b/docs/rules/missing-ttl-bump.md
@@ -1,0 +1,70 @@
+# Missing TTL Bump (S025)
+
+## Overview
+
+The `missing_ttl_bump` rule detects writes to `persistent()` or `temporary()` Soroban storage tiers without a corresponding `extend_ttl` call in the same function. Entries in these tiers expire; without a TTL bump the data silently vanishes after the ledger TTL elapses.
+
+## Severity
+
+**Warning** — data loss will occur silently; fix before production deployment.
+
+## Description
+
+Soroban storage has three tiers with different lifetime semantics:
+
+| Tier | Expires? | Needs extend_ttl? |
+|------|----------|--------------------|
+| `instance()` | Yes, but tied to contract instance | Managed separately |
+| `persistent()` | Yes — after `max_ttl` ledgers | **Yes — bump each write** |
+| `temporary()` | Yes — after a short TTL | **Yes — bump each write** |
+
+When a function writes to `persistent()` or `temporary()` but never calls `extend_ttl`, the stored value may expire before it is ever read, causing silent data loss that is hard to debug.
+
+## Examples
+
+### ❌ Vulnerable Code
+
+```rust
+pub fn store(env: Env, key: Symbol, val: i128) {
+    // Write without TTL bump — entry expires silently
+    env.storage().persistent().set(&key, &val);
+}
+```
+
+### ✅ Safe Code
+
+```rust
+pub fn store_safe(env: Env, key: Symbol, val: i128) {
+    env.storage().persistent().set(&key, &val);
+    // Bump TTL so the entry survives until the contract is next active
+    env.storage().persistent().extend_ttl(&key, 1000, 5000);
+}
+```
+
+## Mitigation
+
+After every `persistent()` or `temporary()` write, call `extend_ttl` with appropriate `low` and `high` ledger thresholds.
+
+```rust
+env.storage().persistent().set(&key, &value);
+env.storage().persistent().extend_ttl(&key, low_ttl, high_ttl);
+```
+
+For `instance()` storage, manage TTL at the contract-instance level via `env.storage().instance().extend_ttl(low, high)`.
+
+## Related Rules
+
+- **S004 `ledger_size`** — entry size approaching ledger limits
+- **S021 `instance_storage_misuse`** — per-user data in Instance instead of Persistent
+
+## References
+
+- [Soroban Storage TTL](https://developers.stellar.org/docs/build/smart-contracts/storage/state-expiration)
+- [extend_ttl API](https://docs.rs/soroban-sdk/latest/soroban_sdk/storage/struct.Storage.html)
+
+## Testing
+
+```bash
+cargo test -p sanctifier-core missing_ttl_bump
+cargo run -p sanctifier-cli -- analyze contracts/fixtures/finding-codes/s025_missing_ttl_bump.rs
+```

--- a/docs/rules/static-reentrancy.md
+++ b/docs/rules/static-reentrancy.md
@@ -1,0 +1,93 @@
+# Static Reentrancy — External Call Before State Write (S027)
+
+## Overview
+
+The `static_reentrancy` rule detects the checks-effects-interactions (CEI) anti-pattern at the AST level: an external contract call (`invoke_contract` / `try_invoke_contract` / `invoke_contract_check`) that is followed by a storage mutation in the same function, without a reentrancy guard.
+
+This rule is the **static complement** to the runtime reentrancy guard. It catches the pattern *before* deployment by inspecting the source AST.
+
+## Severity
+
+**Warning** — with a per-finding **confidence score** (high / medium / low).
+
+## Description
+
+The safe order for contract operations is:
+
+1. **Checks** — validate inputs, read state
+2. **Effects** — update storage state
+3. **Interactions** — call external contracts
+
+When interactions happen before effects, a malicious callee can re-enter the function and observe stale state, typically enabling double-spend or state corruption.
+
+### Confidence Scoring
+
+| Call type | Confidence | Reasoning |
+|-----------|-----------|-----------|
+| `invoke_contract` | **high** | Panics on failure; state write unreachable on error, so re-entrancy window is open on success |
+| `try_invoke_contract` | **medium** | Recoverable, but state write still follows the call |
+| `invoke_contract_check` | **medium** | Auth-checked call; re-entrancy still possible |
+| Call inside a branch, write outside | **low** | Less direct, but still a potential vector |
+
+## Examples
+
+### ❌ Vulnerable Code (high confidence)
+
+```rust
+pub fn unsafe_withdraw(env: Env, other: Address, amount: i128) {
+    // Interaction first — callee can re-enter and see old balance
+    let _ = env.invoke_contract::<()>(&other, &symbol_short!("recv"), vec![&env]);
+    // Effect too late
+    env.storage().persistent().set(&symbol_short!("BAL"), &amount);
+}
+```
+
+### ✅ Safe Code — CEI order
+
+```rust
+pub fn safe_withdraw(env: Env, other: Address, amount: i128) {
+    // Effects first
+    env.storage().persistent().set(&symbol_short!("BAL"), &amount);
+    // Interaction last
+    let _ = env.invoke_contract::<()>(&other, &symbol_short!("recv"), vec![&env]);
+}
+```
+
+### ✅ Safe Code — reentrancy guard
+
+```rust
+pub fn guarded_call(env: Env, other: Address) {
+    let locked: bool = env.storage().instance().get(&symbol_short!("RE_LOCK")).unwrap_or(false);
+    if locked { panic!("reentrant call"); }
+    env.storage().instance().set(&symbol_short!("RE_LOCK"), &true);
+    let _ = env.invoke_contract::<()>(&other, &symbol_short!("cb"), vec![&env]);
+    env.storage().persistent().set(&symbol_short!("STATE"), &1u32);
+    env.storage().instance().set(&symbol_short!("RE_LOCK"), &false);
+}
+```
+
+## Relationship to S013 (reentrancy)
+
+| Rule | Pattern detected |
+|------|-----------------|
+| S013 `reentrancy` | State write **before** external call (mutation precedes call) |
+| S027 `static_reentrancy` | External call **before** state write (call precedes mutation) |
+
+Both patterns are dangerous; S027 catches the classic re-entrancy vector (stale-state exploitation on re-entry).
+
+## False-Positive Corpus
+
+See `benchmarks/static_reentrancy_fp_corpus.md` for a documented set of known safe patterns and their reasoning.
+
+## Related Rules
+
+- **S013 `reentrancy`** — state mutation before external call
+- **S019 `unchecked_external_call`** — unhandled Result from cross-contract call
+- **S022 `raw_invoke_contract`** — panicking invoke_contract usage
+
+## Testing
+
+```bash
+cargo test -p sanctifier-core static_reentrancy
+cargo run -p sanctifier-cli -- analyze contracts/fixtures/finding-codes/s027_static_reentrancy.rs
+```

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -70,7 +70,13 @@ pub const RAW_INVOKE_CONTRACT: &str = "S022";
 /// `#[test]` function that never references a `ContractClient`, bypassing the host-function boundary.
 pub const SHALLOW_TEST: &str = "S023";
 /// transfer_from-style function consumes 'from' balance without allowance check.
-pub const TRANSFER_FROM_NO_ALLOWANCE: &str = "S023";
+pub const TRANSFER_FROM_NO_ALLOWANCE: &str = "S024";
+/// Persistent or Temporary storage write without a corresponding TTL bump (extend_ttl).
+pub const MISSING_TTL_BUMP: &str = "S025";
+/// Taint propagation finding — user-controlled data reaches a sensitive sink.
+pub const TAINT_PROPAGATION: &str = "S026";
+/// External call before state write without a reentrancy guard (static, complement to runtime guard).
+pub const STATIC_REENTRANCY: &str = "S027";
 
 /// A single finding-code entry with machine-readable code, category, and
 /// human-readable description.
@@ -207,9 +213,26 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             code: SHALLOW_TEST,
             category: "test_quality",
             description: "#[test] function never references a ContractClient, bypassing serialization and auth paths exercised by the Soroban host-function boundary",
+        },
+        FindingCode {
             code: TRANSFER_FROM_NO_ALLOWANCE,
             category: "token_safety",
             description: "transfer_from-style function moves 'from' balance without checking or decrementing the spender's allowance, allowing any caller to drain any account",
+        },
+        FindingCode {
+            code: MISSING_TTL_BUMP,
+            category: "storage_ttl",
+            description: "Persistent or Temporary storage entry written without a corresponding extend_ttl call — entry may silently expire",
+        },
+        FindingCode {
+            code: TAINT_PROPAGATION,
+            category: "taint_analysis",
+            description: "User-controlled data (tainted source) reaches a sensitive sink without sanitisation, including through tuple/struct destructures",
+        },
+        FindingCode {
+            code: STATIC_REENTRANCY,
+            category: "reentrancy",
+            description: "External contract call precedes a storage mutation without a reentrancy guard — classic checks-effects-interactions violation",
         },
     ]
 }
@@ -248,5 +271,8 @@ mod tests {
         assert!(codes.iter().any(|c| c.code == RAW_INVOKE_CONTRACT));
         assert!(codes.iter().any(|c| c.code == SHALLOW_TEST));
         assert!(codes.iter().any(|c| c.code == TRANSFER_FROM_NO_ALLOWANCE));
+        assert!(codes.iter().any(|c| c.code == MISSING_TTL_BUMP));
+        assert!(codes.iter().any(|c| c.code == TAINT_PROPAGATION));
+        assert!(codes.iter().any(|c| c.code == STATIC_REENTRANCY));
     }
 }

--- a/tooling/sanctifier-core/src/rules/missing_ttl_bump.rs
+++ b/tooling/sanctifier-core/src/rules/missing_ttl_bump.rs
@@ -1,0 +1,261 @@
+//! Rule S025 — detect Persistent/Temporary storage writes without a TTL bump.
+//!
+//! Soroban storage entries expire. A contract that writes to `persistent()` or
+//! `temporary()` storage but never calls `extend_ttl` on that entry will
+//! silently lose data once the ledger TTL elapses.
+
+use super::{Rule, RuleViolation, Severity};
+use syn::spanned::Spanned;
+use syn::{parse_str, File, Item};
+
+pub struct MissingTtlBumpRule;
+
+impl MissingTtlBumpRule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MissingTtlBumpRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Internal state ─────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct FnTtlState {
+    /// Locations (fn_name, line) where persistent/temporary writes happen.
+    writes: Vec<(String, usize)>,
+    /// True if the function calls extend_ttl anywhere.
+    has_extend_ttl: bool,
+}
+
+// ── Rule impl ──────────────────────────────────────────────────────────────────
+
+impl Rule for MissingTtlBumpRule {
+    fn name(&self) -> &str {
+        "missing_ttl_bump"
+    }
+
+    fn description(&self) -> &str {
+        "Detects writes to Persistent or Temporary storage without a corresponding \
+         extend_ttl call — entries may silently expire and lose data"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+
+        for item in &file.items {
+            if let Item::Impl(impl_block) = item {
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(f) = impl_item {
+                        let fn_name = f.sig.ident.to_string();
+                        let mut state = FnTtlState::default();
+                        scan_block(&f.block, &fn_name, &mut state);
+
+                        if !state.has_extend_ttl {
+                            for (name, line) in &state.writes {
+                                violations.push(
+                                    RuleViolation::new(
+                                        self.name(),
+                                        Severity::Warning,
+                                        format!(
+                                            "Function '{}' writes to Persistent/Temporary storage \
+                                             but never calls extend_ttl — the entry may expire",
+                                            name
+                                        ),
+                                        format!("{}:{}", name, line),
+                                    )
+                                    .with_suggestion(
+                                        "Call env.storage().persistent().extend_ttl(&key, low, high) \
+                                         (or temporary()) after each write to prevent the entry \
+                                         from expiring. Example: \
+                                         env.storage().instance().extend_ttl(1000, 5000);"
+                                            .to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ── AST helpers ────────────────────────────────────────────────────────────────
+
+fn scan_block(block: &syn::Block, fn_name: &str, state: &mut FnTtlState) {
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Local(l) => {
+                if let Some(init) = &l.init {
+                    scan_expr(&init.expr, fn_name, state);
+                }
+            }
+            syn::Stmt::Expr(e, _) => scan_expr(e, fn_name, state),
+            _ => {}
+        }
+    }
+}
+
+fn scan_expr(expr: &syn::Expr, fn_name: &str, state: &mut FnTtlState) {
+    match expr {
+        syn::Expr::MethodCall(mc) => {
+            let method = mc.method.to_string();
+
+            if method == "extend_ttl" || method == "bump" {
+                state.has_extend_ttl = true;
+            }
+
+            if is_persistent_or_temporary_write(&method, &mc.receiver) {
+                let span = mc.span();
+                state.writes.push((fn_name.to_string(), span.start().line));
+            }
+
+            scan_expr(&mc.receiver, fn_name, state);
+            for arg in &mc.args {
+                scan_expr(arg, fn_name, state);
+            }
+        }
+        syn::Expr::Block(b) => scan_block(&b.block, fn_name, state),
+        syn::Expr::If(i) => {
+            scan_expr(&i.cond, fn_name, state);
+            scan_block(&i.then_branch, fn_name, state);
+            if let Some((_, else_expr)) = &i.else_branch {
+                scan_expr(else_expr, fn_name, state);
+            }
+        }
+        syn::Expr::Match(m) => {
+            scan_expr(&m.expr, fn_name, state);
+            for arm in &m.arms {
+                scan_expr(&arm.body, fn_name, state);
+            }
+        }
+        syn::Expr::Assign(a) => {
+            scan_expr(&a.left, fn_name, state);
+            scan_expr(&a.right, fn_name, state);
+        }
+        syn::Expr::Call(c) => {
+            for arg in &c.args {
+                scan_expr(arg, fn_name, state);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Returns true when `method` is a storage-mutating operation on a
+/// `persistent()` or `temporary()` storage tier.
+fn is_persistent_or_temporary_write(method: &str, receiver: &syn::Expr) -> bool {
+    if !matches!(method, "set" | "update" | "remove") {
+        return false;
+    }
+    let receiver_str = quote::quote!(#receiver).to_string();
+    // Only flag persistent/temporary — instance storage has different TTL semantics
+    receiver_str.contains("persistent") || receiver_str.contains("temporary")
+}
+
+// ── Unit tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule() -> MissingTtlBumpRule {
+        MissingTtlBumpRule::new()
+    }
+
+    #[test]
+    fn flags_persistent_write_without_extend_ttl() {
+        let source = r#"
+            impl MyContract {
+                pub fn store(env: Env, key: Symbol, val: i128) {
+                    env.storage().persistent().set(&key, &val);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(!v.is_empty(), "persistent write without TTL bump must be flagged");
+        assert!(v[0].message.contains("store"));
+        assert_eq!(v[0].severity, Severity::Warning);
+        assert!(v[0].suggestion.is_some());
+    }
+
+    #[test]
+    fn flags_temporary_write_without_extend_ttl() {
+        let source = r#"
+            impl MyContract {
+                pub fn cache(env: Env, key: Symbol, val: i128) {
+                    env.storage().temporary().set(&key, &val);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(!v.is_empty(), "temporary write without TTL bump must be flagged");
+    }
+
+    #[test]
+    fn no_violation_when_extend_ttl_present() {
+        let source = r#"
+            impl MyContract {
+                pub fn store_safe(env: Env, key: Symbol, val: i128) {
+                    env.storage().persistent().set(&key, &val);
+                    env.storage().persistent().extend_ttl(&key, 1000, 5000);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "function with extend_ttl must not be flagged");
+    }
+
+    #[test]
+    fn no_violation_when_instance_write_only() {
+        // Instance storage has its own TTL semantics and is excluded from this rule
+        let source = r#"
+            impl MyContract {
+                pub fn set_instance(env: Env) {
+                    env.storage().instance().set(&symbol_short!("K"), &true);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "instance-only writes must not be flagged");
+    }
+
+    #[test]
+    fn no_violation_for_read_only_function() {
+        let source = r#"
+            impl MyContract {
+                pub fn get(env: Env, key: Symbol) -> i128 {
+                    env.storage().persistent().get(&key).unwrap_or(0)
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "read-only function must not be flagged");
+    }
+
+    #[test]
+    fn empty_source_no_panic() {
+        assert!(rule().check("").is_empty());
+    }
+
+    #[test]
+    fn invalid_source_no_panic() {
+        assert!(rule().check("not valid rust {{{").is_empty());
+    }
+}

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -40,6 +40,12 @@ pub mod raw_invoke_contract;
 pub mod shallow_test;
 /// transfer_from-style flows that consume 'from' balance without allowance checks.
 pub mod transfer_from_no_allowance;
+/// Persistent/Temporary storage writes without a TTL bump (extend_ttl).
+pub mod missing_ttl_bump;
+/// Taint propagation through tuple and struct destructures.
+pub mod taint_propagation;
+/// Static reentrancy — external call before state write (complement to runtime guard).
+pub mod static_reentrancy;
 use serde::Serialize;
 use std::any::Any;
 
@@ -203,6 +209,9 @@ impl RuleRegistry {
         registry.register(raw_invoke_contract::RawInvokeContractRule::new());
         registry.register(shallow_test::ShallowTestRule::new());
         registry.register(transfer_from_no_allowance::TransferFromNoAllowanceRule::new());
+        registry.register(missing_ttl_bump::MissingTtlBumpRule::new());
+        registry.register(taint_propagation::TaintPropagationRule::new());
+        registry.register(static_reentrancy::StaticReentrancyRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/src/rules/static_reentrancy.rs
+++ b/tooling/sanctifier-core/src/rules/static_reentrancy.rs
@@ -1,0 +1,404 @@
+//! Rule S027 — static reentrancy detection (complement to runtime guard).
+//!
+//! Detects the classic checks-effects-interactions violation at the AST level:
+//! an external contract call (`invoke_contract` / `try_invoke_contract` /
+//! `invoke_contract_check`) that is followed by a storage mutation in the same
+//! function body, without a reentrancy guard.
+//!
+//! This is the **reverse** pattern of the existing `reentrancy` rule (S013),
+//! which flags *mutations before calls*.  Here we flag *calls before mutations*,
+//! the pattern that allows a malicious callee to re-enter with stale state.
+//!
+//! Each finding carries a confidence score:
+//! - **High** — `invoke_contract` (panicking) directly precedes a storage write.
+//! - **Medium** — `try_invoke_contract` precedes a storage write (recoverable call).
+//! - **Low** — external call is separated from the write by control flow.
+
+use super::{Rule, RuleViolation, Severity};
+use syn::spanned::Spanned;
+use syn::{parse_str, File, Item};
+
+pub struct StaticReentrancyRule;
+
+impl StaticReentrancyRule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for StaticReentrancyRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Confidence level ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Confidence {
+    High,
+    Medium,
+    Low,
+}
+
+impl Confidence {
+    fn as_str(self) -> &'static str {
+        match self {
+            Confidence::High => "high",
+            Confidence::Medium => "medium",
+            Confidence::Low => "low",
+        }
+    }
+}
+
+// ── Internal state ─────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct FnCallState {
+    /// True once we have seen an external call.
+    has_prior_external_call: bool,
+    /// The kind of external call seen (for confidence scoring).
+    external_call_kind: Option<ExternalCallKind>,
+    /// True if a reentrancy guard is detected.
+    has_guard: bool,
+    violations: Vec<StaticReentrancyViolation>,
+}
+
+#[derive(Clone)]
+struct StaticReentrancyViolation {
+    fn_name: String,
+    line: usize,
+    confidence: Confidence,
+    call_kind: ExternalCallKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ExternalCallKind {
+    /// `invoke_contract` — panics on callee failure.
+    Panicking,
+    /// `try_invoke_contract` — returns Result.
+    Recoverable,
+    /// `invoke_contract_check` — with auth check.
+    Checked,
+}
+
+impl ExternalCallKind {
+    fn confidence(self) -> Confidence {
+        match self {
+            ExternalCallKind::Panicking => Confidence::High,
+            ExternalCallKind::Checked => Confidence::Medium,
+            ExternalCallKind::Recoverable => Confidence::Medium,
+        }
+    }
+}
+
+// ── Rule impl ──────────────────────────────────────────────────────────────────
+
+impl Rule for StaticReentrancyRule {
+    fn name(&self) -> &str {
+        "static_reentrancy"
+    }
+
+    fn description(&self) -> &str {
+        "Detects external contract calls that precede storage mutations in the same \
+         function — classic checks-effects-interactions violation enabling reentrancy"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+
+        for item in &file.items {
+            if let Item::Impl(impl_block) = item {
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(f) = impl_item {
+                        let fn_name = f.sig.ident.to_string();
+                        let mut state = FnCallState::default();
+                        scan_block(&f.block, &fn_name, &mut state);
+
+                        for v in &state.violations {
+                            let confidence = v.confidence;
+                            violations.push(
+                                RuleViolation::new(
+                                    self.name(),
+                                    Severity::Warning,
+                                    format!(
+                                        "Function '{}': external call precedes storage mutation \
+                                         at line {} without a reentrancy guard [confidence: {}]",
+                                        v.fn_name, v.line, confidence.as_str()
+                                    ),
+                                    format!("{}:{}", v.fn_name, v.line),
+                                )
+                                .with_suggestion(
+                                    "Follow the checks-effects-interactions pattern: \
+                                     update all storage state BEFORE making external calls. \
+                                     Or use a boolean instance-storage reentrancy lock: \
+                                     set REENTRANCY_LOCK=true before the call, false after, \
+                                     panicking if already locked."
+                                        .to_string(),
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ── AST helpers ────────────────────────────────────────────────────────────────
+
+fn scan_block(block: &syn::Block, fn_name: &str, state: &mut FnCallState) {
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Local(l) => {
+                if let Some(init) = &l.init {
+                    scan_expr(&init.expr, fn_name, state);
+                }
+            }
+            syn::Stmt::Expr(e, _) => scan_expr(e, fn_name, state),
+            syn::Stmt::Macro(m) if m.mac.path.is_ident("panic") => {
+                let tokens = m.mac.tokens.to_string();
+                if tokens.contains("reentrant") || tokens.contains("reentrancy") {
+                    state.has_guard = true;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn scan_expr(expr: &syn::Expr, fn_name: &str, state: &mut FnCallState) {
+    match expr {
+        syn::Expr::MethodCall(mc) => {
+            let method = mc.method.to_string();
+
+            // Detect reentrancy guard via lock key
+            if method == "set" {
+                let s = quote::quote!(#mc).to_string();
+                if s.contains("REENTRANCY_LOCK")
+                    || s.contains("reentrancy_lock")
+                    || s.contains("RE_GRD")
+                {
+                    state.has_guard = true;
+                }
+            }
+
+            // Detect external calls — record the first one seen
+            if let Some(kind) = external_call_kind(&method) {
+                if state.external_call_kind.is_none() {
+                    state.has_prior_external_call = true;
+                    state.external_call_kind = Some(kind);
+                }
+            }
+
+            // Detect storage mutations that follow an external call
+            if state.has_prior_external_call && !state.has_guard {
+                if is_storage_mutation(&method, &mc.receiver) {
+                    let span = mc.span();
+                    let call_kind = state.external_call_kind.unwrap();
+                    state.violations.push(StaticReentrancyViolation {
+                        fn_name: fn_name.to_string(),
+                        line: span.start().line,
+                        confidence: call_kind.confidence(),
+                        call_kind,
+                    });
+                }
+            }
+
+            scan_expr(&mc.receiver, fn_name, state);
+            for arg in &mc.args {
+                scan_expr(arg, fn_name, state);
+            }
+        }
+        syn::Expr::Call(c) => {
+            if let syn::Expr::Path(p) = &*c.func {
+                if let Some(seg) = p.path.segments.last() {
+                    let ident = seg.ident.to_string();
+                    if let Some(kind) = external_call_kind(&ident) {
+                        if state.external_call_kind.is_none() {
+                            state.has_prior_external_call = true;
+                            state.external_call_kind = Some(kind);
+                        }
+                    }
+                }
+            }
+            for arg in &c.args {
+                scan_expr(arg, fn_name, state);
+            }
+        }
+        syn::Expr::Block(b) => scan_block(&b.block, fn_name, state),
+        syn::Expr::If(i) => {
+            scan_expr(&i.cond, fn_name, state);
+            // Track state before entering branches; mutations in else-branch after a
+            // call in the then-branch get a lower confidence score.
+            let had_call = state.has_prior_external_call;
+            scan_block(&i.then_branch, fn_name, state);
+            if !had_call && state.has_prior_external_call {
+                // Call was inside then-branch; mutations in else get Low confidence.
+                // Mark any subsequent violations as Low.
+                let call_before = state.violations.len();
+                if let Some((_, else_expr)) = &i.else_branch {
+                    scan_expr(else_expr, fn_name, state);
+                }
+                for v in state.violations.iter_mut().skip(call_before) {
+                    v.confidence = Confidence::Low;
+                }
+            } else if let Some((_, else_expr)) = &i.else_branch {
+                scan_expr(else_expr, fn_name, state);
+            }
+        }
+        syn::Expr::Match(m) => {
+            scan_expr(&m.expr, fn_name, state);
+            for arm in &m.arms {
+                scan_expr(&arm.body, fn_name, state);
+            }
+        }
+        syn::Expr::Assign(a) => {
+            scan_expr(&a.left, fn_name, state);
+            scan_expr(&a.right, fn_name, state);
+        }
+        _ => {}
+    }
+}
+
+fn external_call_kind(method: &str) -> Option<ExternalCallKind> {
+    match method {
+        "invoke_contract" => Some(ExternalCallKind::Panicking),
+        "try_invoke_contract" => Some(ExternalCallKind::Recoverable),
+        "invoke_contract_check" => Some(ExternalCallKind::Checked),
+        _ => None,
+    }
+}
+
+fn is_storage_mutation(method: &str, receiver: &syn::Expr) -> bool {
+    if !matches!(method, "set" | "update" | "remove" | "extend_ttl") {
+        return false;
+    }
+    let s = quote::quote!(#receiver).to_string();
+    s.contains("storage") || s.contains("persistent") || s.contains("temporary") || s.contains("instance")
+}
+
+// ── Unit tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule() -> StaticReentrancyRule {
+        StaticReentrancyRule::new()
+    }
+
+    // ── True-positive cases ───────────────────────────────────────────────────
+
+    #[test]
+    fn detects_invoke_contract_before_storage_write() {
+        let source = r#"
+            impl MyContract {
+                pub fn unsafe_withdraw(env: Env, amount: i128) {
+                    let result = env.invoke_contract(&other, &sym, vec![]);
+                    env.storage().persistent().set(&symbol_short!("BAL"), &0i128);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(!v.is_empty(), "invoke_contract before storage write must be flagged");
+        assert!(v[0].message.contains("unsafe_withdraw"));
+        assert!(v[0].message.contains("high"));
+    }
+
+    #[test]
+    fn detects_try_invoke_before_storage_write() {
+        let source = r#"
+            impl MyContract {
+                pub fn call_then_write(env: Env) {
+                    let _ = env.try_invoke_contract::<_, ()>(&other, &sym, vec![]);
+                    env.storage().persistent().set(&symbol_short!("STATE"), &1u32);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(!v.is_empty(), "try_invoke_contract before write must be flagged");
+        assert!(v[0].message.contains("medium"));
+    }
+
+    // ── False-positive / safe cases ───────────────────────────────────────────
+
+    #[test]
+    fn no_violation_when_write_before_call() {
+        let source = r#"
+            impl MyContract {
+                pub fn safe_cei(env: Env, amount: i128) {
+                    // Effects first, then interaction — correct CEI order
+                    env.storage().persistent().set(&symbol_short!("BAL"), &0i128);
+                    let result = env.invoke_contract(&other, &sym, vec![]);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(
+            v.is_empty(),
+            "write-before-call is the safe CEI pattern and must not be flagged by static_reentrancy"
+        );
+    }
+
+    #[test]
+    fn no_violation_when_guard_present() {
+        let source = r#"
+            impl MyContract {
+                pub fn guarded(env: Env) {
+                    let g = env.storage().instance().get::<_, bool>(&REENTRANCY_LOCK).unwrap_or(false);
+                    if g { panic!("reentrant call"); }
+                    env.storage().instance().set(&REENTRANCY_LOCK, &true);
+                    let result = env.invoke_contract(&other, &sym, vec![]);
+                    env.storage().persistent().set(&symbol_short!("S"), &1u32);
+                    env.storage().instance().set(&REENTRANCY_LOCK, &false);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "guarded function must not be flagged");
+    }
+
+    #[test]
+    fn no_violation_for_read_only_function() {
+        let source = r#"
+            impl MyContract {
+                pub fn query(env: Env) -> i128 {
+                    let val: i128 = env.storage().persistent().get(&symbol_short!("BAL")).unwrap_or(0);
+                    val
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "read-only function must not be flagged");
+    }
+
+    #[test]
+    fn no_violation_on_empty_source() {
+        assert!(rule().check("").is_empty());
+    }
+
+    #[test]
+    fn no_violation_for_external_call_only() {
+        let source = r#"
+            impl MyContract {
+                pub fn just_call(env: Env) {
+                    let result = env.invoke_contract(&other, &sym, vec![]);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "external call without subsequent write must not be flagged");
+    }
+}

--- a/tooling/sanctifier-core/src/rules/taint_propagation.rs
+++ b/tooling/sanctifier-core/src/rules/taint_propagation.rs
@@ -1,0 +1,420 @@
+//! Rule S026 — taint propagation through tuple and struct destructures.
+//!
+//! Tracks user-controlled data (function parameters marked as tainted) through
+//! variable assignments, including `let (a, b) = ...` (Pat::Tuple) and
+//! `let Foo { x, y } = ...` (Pat::Struct) destructures.  Emits a finding when
+//! a tainted value reaches a sensitive sink (storage write or external call)
+//! without an intervening `require_auth` or explicit validation.
+
+use super::{Rule, RuleViolation, Severity};
+use std::collections::HashSet;
+use syn::{parse_str, File, Item, Pat};
+
+pub struct TaintPropagationRule;
+
+impl TaintPropagationRule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TaintPropagationRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Internal state ─────────────────────────────────────────────────────────────
+
+struct TaintState<'a> {
+    fn_name: &'a str,
+    /// Variables currently considered tainted.
+    tainted: HashSet<String>,
+    /// True once require_auth / require_auth_for_args has been seen.
+    has_auth: bool,
+    violations: Vec<TaintViolation>,
+}
+
+struct TaintViolation {
+    fn_name: String,
+    tainted_var: String,
+    sink: String,
+    line: usize,
+}
+
+// ── Rule impl ──────────────────────────────────────────────────────────────────
+
+impl Rule for TaintPropagationRule {
+    fn name(&self) -> &str {
+        "taint_propagation"
+    }
+
+    fn description(&self) -> &str {
+        "Tracks user-controlled data through tuple/struct destructures and flags \
+         when tainted values reach storage or external-call sinks without auth"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+
+        for item in &file.items {
+            if let Item::Impl(impl_block) = item {
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(f) = impl_item {
+                        if !matches!(f.vis, syn::Visibility::Public(_)) {
+                            continue;
+                        }
+
+                        let fn_name = f.sig.ident.to_string();
+
+                        // Seed taint from parameters (excluding `env: Env` and `self`)
+                        let tainted = collect_param_names(&f.sig);
+                        if tainted.is_empty() {
+                            continue;
+                        }
+
+                        let mut state = TaintState {
+                            fn_name: &fn_name,
+                            tainted,
+                            has_auth: false,
+                            violations: Vec::new(),
+                        };
+
+                        scan_block(&f.block, &mut state);
+
+                        for v in state.violations {
+                            violations.push(
+                                RuleViolation::new(
+                                    self.name(),
+                                    Severity::Warning,
+                                    format!(
+                                        "Function '{}': tainted variable '{}' reaches '{}' \
+                                         sink without prior require_auth",
+                                        v.fn_name, v.tainted_var, v.sink
+                                    ),
+                                    format!("{}:{}", v.fn_name, v.line),
+                                )
+                                .with_suggestion(
+                                    "Call require_auth() on any address parameter before using \
+                                     user-controlled data in storage or external calls."
+                                        .to_string(),
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+// ── Parameter extraction ───────────────────────────────────────────────────────
+
+fn collect_param_names(sig: &syn::Signature) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for arg in &sig.inputs {
+        if let syn::FnArg::Typed(pt) = arg {
+            // Skip Env parameters
+            let ty_str = quote::quote!(#pt.ty).to_string();
+            if ty_str.contains("Env") {
+                continue;
+            }
+            collect_pat_idents(&pt.pat, &mut names);
+        }
+    }
+    names
+}
+
+// ── Block / expression scanner ────────────────────────────────────────────────
+
+fn scan_block(block: &syn::Block, state: &mut TaintState<'_>) {
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Local(local) => {
+                // Check if the RHS expression contains a tainted variable
+                if let Some(init) = &local.init {
+                    let rhs_tainted = expr_is_tainted(&init.expr, &state.tainted);
+                    // Also propagate auth checks from init expression
+                    check_auth_in_expr(&init.expr, state);
+                    if rhs_tainted {
+                        // Propagate taint to all variables bound in the pattern
+                        let mut new_tainted = HashSet::new();
+                        collect_pat_idents(&local.pat, &mut new_tainted);
+                        state.tainted.extend(new_tainted);
+                    }
+                }
+            }
+            syn::Stmt::Expr(e, _) => scan_expr(e, state),
+            _ => {}
+        }
+    }
+}
+
+fn scan_expr(expr: &syn::Expr, state: &mut TaintState<'_>) {
+    match expr {
+        syn::Expr::MethodCall(mc) => {
+            let method = mc.method.to_string();
+
+            // Detect auth
+            if method == "require_auth" || method == "require_auth_for_args" {
+                state.has_auth = true;
+            }
+
+            // Detect sink: storage write or external call
+            if is_storage_write(&method, &mc.receiver) || is_external_call(&method) {
+                if !state.has_auth {
+                    // Check if any argument uses a tainted variable
+                    for arg in &mc.args {
+                        if let Some(var) = first_tainted_ident(arg, &state.tainted) {
+                            use syn::spanned::Spanned;
+                            let line = mc.span().start().line;
+                            state.violations.push(TaintViolation {
+                                fn_name: state.fn_name.to_string(),
+                                tainted_var: var,
+                                sink: method.clone(),
+                                line,
+                            });
+                        }
+                    }
+                }
+            }
+
+            scan_expr(&mc.receiver, state);
+            for arg in &mc.args {
+                scan_expr(arg, state);
+            }
+        }
+        syn::Expr::Block(b) => scan_block(&b.block, state),
+        syn::Expr::If(i) => {
+            scan_expr(&i.cond, state);
+            scan_block(&i.then_branch, state);
+            if let Some((_, e)) = &i.else_branch {
+                scan_expr(e, state);
+            }
+        }
+        syn::Expr::Match(m) => {
+            scan_expr(&m.expr, state);
+            for arm in &m.arms {
+                scan_expr(&arm.body, state);
+            }
+        }
+        syn::Expr::Assign(a) => {
+            scan_expr(&a.left, state);
+            scan_expr(&a.right, state);
+        }
+        syn::Expr::Call(c) => {
+            for arg in &c.args {
+                scan_expr(arg, state);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn check_auth_in_expr(expr: &syn::Expr, state: &mut TaintState<'_>) {
+    if let syn::Expr::MethodCall(mc) = expr {
+        let method = mc.method.to_string();
+        if method == "require_auth" || method == "require_auth_for_args" {
+            state.has_auth = true;
+        }
+    }
+}
+
+// ── Pattern helpers ────────────────────────────────────────────────────────────
+
+/// Recursively collect all identifier names bound by a pattern.
+/// Handles Pat::Ident, Pat::Tuple, and Pat::Struct — the key cases for #760.
+fn collect_pat_idents(pat: &Pat, out: &mut HashSet<String>) {
+    match pat {
+        Pat::Ident(pi) => {
+            out.insert(pi.ident.to_string());
+        }
+        // Pat::Tuple: let (a, b) = ...
+        Pat::Tuple(pt) => {
+            for elem in &pt.elems {
+                collect_pat_idents(elem, out);
+            }
+        }
+        // Pat::Struct: let Foo { x, y } = ...
+        Pat::Struct(ps) => {
+            for field in &ps.fields {
+                collect_pat_idents(&field.pat, out);
+            }
+        }
+        // Pat::TupleStruct: let Some(x) = ...
+        Pat::TupleStruct(pts) => {
+            for elem in &pts.elems {
+                collect_pat_idents(elem, out);
+            }
+        }
+        // Pat::Reference: let &x = ...
+        Pat::Reference(pr) => collect_pat_idents(&pr.pat, out),
+        _ => {}
+    }
+}
+
+// ── Expression taint helpers ───────────────────────────────────────────────────
+
+/// Returns true if the expression references any tainted variable.
+fn expr_is_tainted(expr: &syn::Expr, tainted: &HashSet<String>) -> bool {
+    first_tainted_ident(expr, tainted).is_some()
+}
+
+/// Returns the first tainted identifier name found in expr, or None.
+fn first_tainted_ident(expr: &syn::Expr, tainted: &HashSet<String>) -> Option<String> {
+    match expr {
+        syn::Expr::Path(p) => {
+            if let Some(seg) = p.path.segments.last() {
+                let name = seg.ident.to_string();
+                if tainted.contains(&name) {
+                    return Some(name);
+                }
+            }
+            None
+        }
+        syn::Expr::Reference(r) => first_tainted_ident(&r.expr, tainted),
+        syn::Expr::MethodCall(mc) => {
+            if let Some(v) = first_tainted_ident(&mc.receiver, tainted) {
+                return Some(v);
+            }
+            for arg in &mc.args {
+                if let Some(v) = first_tainted_ident(arg, tainted) {
+                    return Some(v);
+                }
+            }
+            None
+        }
+        syn::Expr::Call(c) => {
+            for arg in &c.args {
+                if let Some(v) = first_tainted_ident(arg, tainted) {
+                    return Some(v);
+                }
+            }
+            None
+        }
+        syn::Expr::Tuple(t) => {
+            for elem in &t.elems {
+                if let Some(v) = first_tainted_ident(elem, tainted) {
+                    return Some(v);
+                }
+            }
+            None
+        }
+        syn::Expr::Binary(b) => {
+            first_tainted_ident(&b.left, tainted)
+                .or_else(|| first_tainted_ident(&b.right, tainted))
+        }
+        _ => None,
+    }
+}
+
+fn is_storage_write(method: &str, receiver: &syn::Expr) -> bool {
+    if !matches!(method, "set" | "update" | "remove") {
+        return false;
+    }
+    let s = quote::quote!(#receiver).to_string();
+    s.contains("storage") || s.contains("persistent") || s.contains("temporary") || s.contains("instance")
+}
+
+fn is_external_call(method: &str) -> bool {
+    matches!(method, "invoke_contract" | "try_invoke_contract" | "invoke_contract_check")
+}
+
+// ── Unit tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule() -> TaintPropagationRule {
+        TaintPropagationRule::new()
+    }
+
+    #[test]
+    fn detects_taint_through_tuple_destructure() {
+        // Taint flows: user_data → (a, b) via tuple destructure → storage set with a
+        let source = r#"
+            impl MyContract {
+                pub fn store_pair(env: Env, user_data: (Symbol, i128)) {
+                    let (key, val) = user_data;
+                    env.storage().persistent().set(&key, &val);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(!v.is_empty(), "taint through tuple destructure must be flagged");
+        assert!(v[0].message.contains("store_pair"));
+    }
+
+    #[test]
+    fn detects_taint_through_struct_destructure() {
+        let source = r#"
+            impl MyContract {
+                pub fn store_record(env: Env, record: MyRecord) {
+                    let MyRecord { key, value } = record;
+                    env.storage().persistent().set(&key, &value);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(!v.is_empty(), "taint through struct destructure must be flagged");
+    }
+
+    #[test]
+    fn no_violation_when_require_auth_present() {
+        let source = r#"
+            impl MyContract {
+                pub fn store_pair(env: Env, caller: Address, user_data: (Symbol, i128)) {
+                    caller.require_auth();
+                    let (key, val) = user_data;
+                    env.storage().persistent().set(&key, &val);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "function with require_auth must not be flagged");
+    }
+
+    #[test]
+    fn no_violation_for_private_function() {
+        let source = r#"
+            impl MyContract {
+                fn internal_store(env: Env, key: Symbol, val: i128) {
+                    env.storage().persistent().set(&key, &val);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(v.is_empty(), "private functions are not entry points and must not be flagged");
+    }
+
+    #[test]
+    fn direct_param_taint_to_storage() {
+        // No destructure — param goes directly to storage key
+        let source = r#"
+            impl MyContract {
+                pub fn bad_set(env: Env, key: Symbol, val: i128) {
+                    env.storage().persistent().set(&key, &val);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(!v.is_empty(), "direct taint to storage must be flagged");
+    }
+
+    #[test]
+    fn empty_source_no_panic() {
+        assert!(rule().check("").is_empty());
+    }
+}


### PR DESCRIPTION
- S025 missing_ttl_bump: detect Persistent/Temporary storage writes without extend_ttl — entries silently expire after ledger TTL (#756)
- S026 taint_propagation: track user-controlled data through Pat::Tuple and Pat::Struct destructures to storage/call sinks (#760)
- S027 static_reentrancy: detect external call before state write (CEI violation) with high/medium/low confidence scoring — static complement to the runtime reentrancy guard (#755)
- Fix finding_codes.rs: S023 duplicate (SHALLOW_TEST vs TRANSFER_FROM_NO_ALLOWANCE); fix broken struct literal in all_finding_codes(); add S024–S027 entries (#754)
- Fixture pairs good/bad for S025–S027 under contracts/fixtures/
- Doc pages docs/rules/missing-ttl-bump.md, static-reentrancy.md
- Taint-propagation authoring note in docs/rule-authoring-guide.md
- False-positive corpus benchmarks/static_reentrancy_fp_corpus.md

## Summary

Describe the change, the motivation behind it, and any important implementation details.

Fixes #754 
Fixes #755 
Fixes #756 
Fixes #760 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Maintenance or refactor

## Testing

List the commands you ran and the scope of validation.

```text
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p sanctifier-core --all-features
cargo test -p sanctifier-cli
cd frontend && npm test
```

## Checklist

- [ ] I ran the relevant tests locally, or explained why they were not needed.
- [ ] I updated documentation for any user-facing behavior changes.
- [ ] I added or updated tests for the change when appropriate.
- [ ] I added a changelog or release-notes entry when needed, or confirmed none is required.
- [ ] I verified this branch is up to date with `main` and merge conflicts are resolved.
