### PR TITLE
feat(S016): extend truncation_bounds to detect wider→narrower and signed↔unsigned integer casts

### DIFF
--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -16,7 +16,9 @@ pub mod patcher;
 pub mod reentrancy;
 pub mod rules;
 pub mod sep41;
+#[cfg(feature = "smt")]
 pub mod smt;
+pub mod soroban_v21;
 pub mod storage_collision;
 
 // Re-export common types for easier CLI access
@@ -26,6 +28,7 @@ pub use finding_codes::FindingSeverity;
 pub use reentrancy::ReentrancyEdge;
 pub use rules::{Patch, Rule, RuleRegistry, RuleViolation, Severity};
 pub use sep41::{Sep41Issue, Sep41IssueKind, Sep41VerificationReport};
+#[cfg(feature = "smt")]
 pub use smt::SmtInvariantIssue;
 pub use storage_collision::StorageCollisionIssue;
 
@@ -221,6 +224,15 @@ pub struct PanicIssue {
 pub struct ArithmeticIssue {
     pub function_name: String,
     pub operation: String,
+    pub suggestion: String,
+    pub location: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct TruncationBoundsIssue {
+    pub function_name: String,
+    pub kind: String,
+    pub expression: String,
     pub suggestion: String,
     pub location: String,
 }

--- a/tooling/sanctifier-core/src/reentrancy.rs
+++ b/tooling/sanctifier-core/src/reentrancy.rs
@@ -2,11 +2,11 @@
 use quote::quote;
 use serde::Serialize;
 use syn::visit::Visit;
-use syn::{ExprCall, ExprMethodCall, File};
+use syn::{ExprMethodCall, File};
 
 use crate::rules::{Patch, Rule, RuleViolation, Severity};
 use syn::spanned::Spanned;
-use syn::{parse_str, File, Item};
+use syn::{parse_str, Item};
 
 /// Storage key used by the auto-generated reentrancy guard.
 const REENTRANCY_LOCK_KEY: &str = "REENTRANCY_LOCK";
@@ -282,6 +282,58 @@ fn is_storage_mutation(method: &str, receiver: &syn::Expr) -> bool {
         || receiver_str.contains("instance")
 }
 
+fn is_token_transfer(method: &str) -> bool {
+    matches!(method, "transfer" | "transfer_from" | "burn")
+}
+
+/// An edge in the contract call graph produced by `scan_invoke_contract_calls`.
+#[derive(Debug, Serialize, Clone)]
+pub struct ReentrancyEdge {
+    pub caller_function: String,
+    pub target_contract: String,
+    pub target_function: String,
+    pub function_expr: Option<String>,
+}
+
+struct CallVisitor {
+    edges: Vec<ReentrancyEdge>,
+    current_fn: String,
+}
+
+impl<'ast> Visit<'ast> for CallVisitor {
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        let prev = self.current_fn.clone();
+        self.current_fn = node.sig.ident.to_string();
+        syn::visit::visit_impl_item_fn(self, node);
+        self.current_fn = prev;
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        let prev = self.current_fn.clone();
+        self.current_fn = node.sig.ident.to_string();
+        syn::visit::visit_item_fn(self, node);
+        self.current_fn = prev;
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        if node.method == "invoke_contract" || node.method == "call" {
+            self.edges.push(ReentrancyEdge {
+                caller_function: self.current_fn.clone(),
+                target_contract: "Unknown".to_string(),
+                target_function: "Unknown".to_string(),
+                function_expr: Some(quote!(#node).to_string()),
+            });
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+pub fn scan_invoke_contract_calls(source: &str) -> Vec<ReentrancyEdge> {
+    let file = match parse_str::<File>(source) {
+        Ok(f) => f,
+        Err(_) => return vec![],
+    };
+
     let mut visitor = CallVisitor {
         edges: Vec::new(),
         current_fn: String::new(),
@@ -399,14 +451,24 @@ fn build_guard_patch(block: &syn::Block, fn_name: &str) -> Option<Patch> {
     None
 }
 
-    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
-        if node.method == "invoke_contract" || node.method == "call" {
-            self.edges.push(ReentrancyEdge {
-                caller_function: self.current_fn.clone(),
-                target_contract: "Unknown".to_string(), // Placeholder
-                target_function: "Unknown".to_string(), // Placeholder
-                function_expr: Some(quote!(#node).to_string()),
-            });
+fn contains_invoke_contract(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::MethodCall(mc) => {
+            mc.method == "invoke_contract"
+                || mc.method == "invoke_contract_check"
+                || contains_invoke_contract(&mc.receiver)
+                || mc.args.iter().any(contains_invoke_contract)
+        }
+        syn::Expr::Call(c) => {
+            if let syn::Expr::Path(p) = &*c.func {
+                if let Some(seg) = p.path.segments.last() {
+                    let ident = seg.ident.to_string();
+                    if ident == "invoke_contract" || ident == "invoke_contract_check" {
+                        return true;
+                    }
+                }
+            }
+            c.args.iter().any(contains_invoke_contract)
         }
         syn::Expr::Block(b) => b.block.stmts.iter().any(|s| match s {
             syn::Stmt::Expr(e, _) => contains_invoke_contract(e),
@@ -576,8 +638,4 @@ mod tests {
         assert!(patch.replacement.contains("invoke_contract"));
     }
 
-    fn visit_expr_call(&mut self, node: &'ast ExprCall) {
-        // Handle direct calls if needed
-        syn::visit::visit_expr_call(self, node);
-    }
 }

--- a/tooling/sanctifier-core/src/rules/crlf_tests.rs
+++ b/tooling/sanctifier-core/src/rules/crlf_tests.rs
@@ -5,9 +5,12 @@
 
 #[cfg(test)]
 mod crlf_tests {
-    use sanctifier_core::rules::{
-        PanicDetectionRule, ReentrancyRule, UnhandledResultRule,
-        InstanceStorageMisuseRule, Rule,
+    use crate::rules::{
+        instance_storage_misuse::InstanceStorageMisuseRule,
+        panic_detection::PanicDetectionRule,
+        reentrancy::ReentrancyRule,
+        unhandled_result::UnhandledResultRule,
+        Rule,
     };
 
     /// Convert LF source to CRLF by replacing every `\n` with `\r\n`.

--- a/tooling/sanctifier-core/src/rules/truncation_bounds.rs
+++ b/tooling/sanctifier-core/src/rules/truncation_bounds.rs
@@ -80,8 +80,11 @@ pub(crate) struct TruncationBoundsVisitor {
     pub(crate) test_mod_depth: u32,
 }
 
-/// Narrowing target types that indicate potential truncation.
-const NARROWING_TYPES: &[&str] = &["u32", "u16", "u8", "i32", "i16", "i8"];
+/// Narrowing target types that may silently truncate bits (wider→narrower or signed↔unsigned).
+///
+/// Includes u64/i64 to catch u128→u64 and i128→i64 truncations, and also
+/// captures same-width sign changes like `u64 as i64` or `i32 as u32`.
+const NARROWING_TYPES: &[&str] = &["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64"];
 
 impl<'ast> Visit<'ast> for TruncationBoundsVisitor {
     // ── Module-level: skip #[cfg(test)] modules entirely ─────────────────────
@@ -99,6 +102,9 @@ impl<'ast> Visit<'ast> for TruncationBoundsVisitor {
         if self.test_mod_depth > 0 || has_test_attr(&node.attrs) {
             return;
         }
+        if has_allow_truncate(&node.attrs) {
+            return;
+        }
         let prev = self.current_fn.take();
         self.current_fn = Some(node.sig.ident.to_string());
         syn::visit::visit_impl_item_fn(self, node);
@@ -107,6 +113,9 @@ impl<'ast> Visit<'ast> for TruncationBoundsVisitor {
 
     fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
         if self.test_mod_depth > 0 || has_test_attr(&node.attrs) {
+            return;
+        }
+        if has_allow_truncate(&node.attrs) {
             return;
         }
         let prev = self.current_fn.take();
@@ -133,7 +142,8 @@ impl<'ast> Visit<'ast> for TruncationBoundsVisitor {
                                 expression: expr_str,
                                 suggestion: format!(
                                     "Use `{ty_name}::try_from(val).unwrap_or(...)` or \
-                                     `.try_into()` with proper error handling instead of `as {ty_name}`"
+                                     `.try_into()` with proper error handling instead of `as {ty_name}`; \
+                                     suppress with `#[allow(sanctifier::truncate)]` if intentional"
                                 ),
                                 location: format!("{}:{}", fn_name, line),
                             });
@@ -178,6 +188,16 @@ fn is_cfg_test(attrs: &[syn::Attribute]) -> bool {
     attrs
         .iter()
         .any(|a| a.path().is_ident("cfg") && quote::quote!(#a).to_string().contains("test"))
+}
+
+/// Returns true if the item has `#[allow(sanctifier::truncate)]`, allowing the
+/// developer to opt out of truncation warnings for a specific function.
+fn has_allow_truncate(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        a.path().is_ident("allow")
+            && quote::quote!(#a).to_string().contains("sanctifier")
+            && quote::quote!(#a).to_string().contains("truncate")
+    })
 }
 
 #[cfg(test)]
@@ -271,5 +291,149 @@ mod tests {
         "#;
         let violations = rule.check(source);
         assert_eq!(violations.len(), 2);
+    }
+
+    // ── Extended truncation detection (u64/i64 targets) ───────────────────────
+
+    #[test]
+    fn test_detect_u128_as_u64_truncation() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            fn compress(val: u128) -> u64 {
+                val as u64
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(violations.len(), 1, "u128 as u64 should be flagged as truncation");
+        assert!(violations[0].message.contains("truncation"));
+        assert!(violations[0].message.contains("as u64"));
+    }
+
+    #[test]
+    fn test_detect_i128_as_i64_truncation() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            fn compress(val: i128) -> i64 {
+                val as i64
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(violations.len(), 1, "i128 as i64 should be flagged as truncation");
+        assert!(violations[0].message.contains("as i64"));
+    }
+
+    #[test]
+    fn test_detect_u64_as_i64_sign_change() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            fn reinterpret(val: u64) -> i64 {
+                val as i64
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(violations.len(), 1, "u64 as i64 sign change should be flagged");
+        assert!(violations[0].message.contains("as i64"));
+    }
+
+    #[test]
+    fn test_detect_i64_as_u64_sign_change() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            fn reinterpret(val: i64) -> u64 {
+                val as u64
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(violations.len(), 1, "i64 as u64 sign change should be flagged");
+        assert!(violations[0].message.contains("as u64"));
+    }
+
+    #[test]
+    fn test_detect_i32_as_u32_sign_change() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            fn reinterpret(val: i32) -> u32 {
+                val as u32
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(violations.len(), 1, "i32 as u32 sign change should be flagged");
+    }
+
+    // ── #[allow(sanctifier::truncate)] opt-out ────────────────────────────────
+
+    #[test]
+    fn test_allow_truncate_suppresses_violation_on_item_fn() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            #[allow(sanctifier::truncate)]
+            fn convert(val: u128) -> u64 {
+                val as u64
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(
+            violations.len(),
+            0,
+            "#[allow(sanctifier::truncate)] should suppress truncation warnings"
+        );
+    }
+
+    #[test]
+    fn test_allow_truncate_suppresses_violation_on_impl_fn() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            impl Codec {
+                #[allow(sanctifier::truncate)]
+                pub fn pack(val: u128) -> u64 {
+                    val as u64
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(
+            violations.len(),
+            0,
+            "#[allow(sanctifier::truncate)] on impl fn should suppress warnings"
+        );
+    }
+
+    #[test]
+    fn test_allow_truncate_only_suppresses_annotated_function() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            #[allow(sanctifier::truncate)]
+            fn allowed(val: u128) -> u64 {
+                val as u64
+            }
+
+            fn not_allowed(val: u128) -> u64 {
+                val as u64
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(
+            violations.len(),
+            1,
+            "Only the un-annotated function should fire"
+        );
+        assert!(violations[0].location.contains("not_allowed"));
+    }
+
+    #[test]
+    fn test_suggestion_mentions_opt_out() {
+        let rule = TruncationBoundsRule::new();
+        let source = r#"
+            fn compress(val: u128) -> u64 {
+                val as u64
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(violations.len(), 1);
+        let suggestion = violations[0].suggestion.as_deref().unwrap_or("");
+        assert!(
+            suggestion.contains("sanctifier::truncate"),
+            "suggestion should mention the opt-out attribute"
+        );
     }
 }

--- a/tooling/sanctifier-core/src/storage_collision.rs
+++ b/tooling/sanctifier-core/src/storage_collision.rs
@@ -5,6 +5,22 @@ use syn::spanned::Spanned;
 use syn::visit::Visit;
 use syn::{Expr, ExprCall, ExprMacro, ItemConst, Lit};
 
+#[derive(Debug, Serialize, Clone)]
+pub struct StorageCollisionIssue {
+    pub key_value: String,
+    pub key_type: String,
+    pub location: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SorobanStorageType {
+    Instance,
+    Persistent,
+    Temporary,
+    Unknown,
+}
+
 impl SorobanStorageType {
     fn as_str(self) -> &'static str {
         match self {
@@ -39,13 +55,13 @@ impl StorageVisitor {
 
 
 
-    fn add_key(&mut self, value: String, key_type: String, location: String, line: usize) {
+    fn add_key(&mut self, value: String, key_type: String, storage_type: SorobanStorageType, location: String, line: usize) {
         let info = KeyInfo {
             key_type,
             location,
             line,
         };
-        self.keys.entry(value).or_default().push(info);
+        self.keys.entry((storage_type, value)).or_default().push(info);
     }
 
     pub fn final_check(&mut self) {
@@ -130,7 +146,7 @@ impl<'ast> Visit<'ast> for StorageVisitor {
                 );
             }
         }
-        visit::visit_item_const(self, i);
+        syn::visit::visit_item_const(self, i);
     }
 
     fn visit_expr_call(&mut self, i: &'ast ExprCall) {
@@ -147,6 +163,7 @@ impl<'ast> Visit<'ast> for StorageVisitor {
                             self.add_key(
                                 val,
                                 "Symbol::new".to_string(),
+                                SorobanStorageType::Unknown,
                                 "inline".to_string(),
                                 i.span().start().line,
                             );
@@ -155,7 +172,7 @@ impl<'ast> Visit<'ast> for StorageVisitor {
                 }
             }
         }
-        visit::visit_expr_call(self, i);
+        syn::visit::visit_expr_call(self, i);
     }
 
     fn visit_expr_macro(&mut self, i: &'ast ExprMacro) {
@@ -174,10 +191,11 @@ impl<'ast> Visit<'ast> for StorageVisitor {
             self.add_key(
                 val,
                 "symbol_short!".to_string(),
+                SorobanStorageType::Unknown,
                 "inline".to_string(),
                 i.span().start().line,
             );
         }
-        visit::visit_expr_method_call(self, i);
+        syn::visit::visit_expr_macro(self, i);
     }
 }


### PR DESCRIPTION
## Summary

- Extends the `TruncationBoundsRule` (S016) to flag a broader set of potentially lossy `as` casts
- Adds `u64` and `i64` to the narrowing-target list, catching `u128 as u64` / `i128 as i64` bit-dropping truncations and same-width sign changes (`u64 as i64`, `i64 as u64`, `i32 as u32`, etc.)
- Adds `#[allow(sanctifier::truncate)]` opt-out: annotating a function skips the entire function body, scoped per-function so other functions in the same file still fire
- Suggestion text updated to mention the opt-out attribute
- Fixes pre-existing compilation errors that prevented the crate from building (`reentrancy.rs` orphaned code, missing `ReentrancyEdge`/`CallVisitor`/`TruncationBoundsIssue`/`SorobanStorageType`/`StorageCollisionIssue` definitions, `smt` feature-gate, `soroban_v21` module declaration, `crlf_tests` import paths)

## Test plan

- [ ] `cargo test --no-default-features -p sanctifier-core --lib truncation_bounds` — 15/15 pass
- [ ] `u128 as u64` is flagged
- [ ] `i128 as i64` is flagged
- [ ] `u64 as i64` (sign change) is flagged
- [ ] `i64 as u64` (sign change) is flagged
- [ ] `#[allow(sanctifier::truncate)]` on a function suppresses its violations only
- [ ] Functions without the attribute in the same file still fire
- [ ] Suggestion text includes `sanctifier::truncate` opt-out hint

Closes #758