### PR TITLE
Modernize GitHub Actions and add anomaly detector

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,12 +13,15 @@ on:
       - 'tests/vulnerability_db/**'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Data/schemas JSON performance snapshot
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   ci:
@@ -19,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -32,7 +33,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -73,9 +74,9 @@ jobs:
           sudo apt-get install -y libdbus-1-dev libudev-dev pkg-config
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies and Lint (make lint smoke test)
         run: |
@@ -130,12 +131,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -156,7 +157,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-coverage
           path: frontend/coverage/
@@ -168,12 +169,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -188,7 +189,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -210,12 +211,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -236,7 +237,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-artifacts
           path: |
@@ -250,12 +251,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -280,13 +281,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -310,14 +311,14 @@ jobs:
         run: cargo test -p amm-pool --test integration_tests abi_ -- --nocapture
 
       - name: Upload rustdoc artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: contract-rustdoc
           path: target/doc/
           retention-days: 14
 
       - name: Upload interface JSON artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: contract-interfaces-json
           path: docs/generated/contract-interfaces.json
@@ -330,14 +331,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install commitlint
         run: |
@@ -355,7 +356,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -363,7 +364,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -395,7 +396,7 @@ jobs:
           node scripts/verify-csp-compliance.js
 
       - name: Upload WASM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sanctifier-wasm-pkg
           path: tooling/sanctifier-wasm/pkg/

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   workspace-check:
@@ -28,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -79,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -87,7 +88,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -131,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain with wasm32 target
         uses: dtolnay/rust-toolchain@stable
@@ -139,7 +140,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/contracts-fuzz.yml
+++ b/.github/workflows/contracts-fuzz.yml
@@ -8,15 +8,13 @@ on:
       - ".github/workflows/contracts-fuzz.yml"
   pull_request:
     branches: ["main"]
-    paths:
-      - "contracts/my-contract/**"
-      - ".github/workflows/contracts-fuzz.yml"
   schedule:
     # Nightly extended fuzzing — 02:00 UTC.
     - cron: "0 2 * * *"
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # -------------------------------------------------------------------------
@@ -29,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -47,7 +45,7 @@ jobs:
           restore-keys: ${{ runner.os }}-fuzz-smoke-
 
       - name: Run bolero fuzz tests + cross-contract e2e
-        run: cargo test -p my-contract --tests
+        run: cargo test -p my-contract --lib --tests
 
       - name: Build cargo-fuzz harness (compile-only)
         working-directory: contracts/my-contract/fuzz
@@ -65,13 +63,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Cache cargo artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -102,7 +100,7 @@ jobs:
 
       - name: Upload corpus and crashes (if any)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fuzz-artifacts
           path: |
@@ -110,3 +108,59 @@ jobs:
             contracts/my-contract/fuzz/artifacts/
           if-no-files-found: ignore
           retention-days: 14
+
+  fuzz-corpus-replay:
+    name: Fuzz corpus replay (PR)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-fuzz-replay-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-fuzz-replay-
+
+      - name: Install cargo-fuzz
+        run: cargo install --locked cargo-fuzz
+
+      - name: Seed replay corpus
+        run: |
+          corpus_dir="$RUNNER_TEMP/fuzz-corpus/fuzz_cross_contract"
+          mkdir -p "$corpus_dir"
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          corpus_dir = Path(os.environ["RUNNER_TEMP"]) / "fuzz-corpus" / "fuzz_cross_contract"
+          samples = {
+              "empty": b"",
+              "unknown-opcode": bytes([0xFF]) + bytes(64),
+              "truncated-mint": bytes([0x01]) + bytes([0x11]) * 32 + bytes(8),
+              "negative-mint": bytes([0x01]) + bytes([0x11]) * 32 + (-1).to_bytes(16, "little", signed=True),
+              "valid-mint": bytes([0x01]) + bytes([0x11]) * 32 + (1_000_000).to_bytes(16, "little", signed=True),
+              "valid-burn": bytes([0x02]) + bytes([0x22]) * 32 + (42).to_bytes(16, "little", signed=True),
+              "valid-transfer": bytes([0x03]) + bytes([0x11]) * 32 + bytes([0x22]) * 32 + (7).to_bytes(16, "little", signed=True),
+              "valid-approve": bytes([0x04]) + bytes([0x11]) * 32 + bytes([0x22]) * 32 + (1234).to_bytes(16, "little", signed=True) + (999_999).to_bytes(4, "little", signed=False),
+              "valid-transfer-from": bytes([0x05]) + bytes([0x33]) * 32 + bytes([0x11]) * 32 + bytes([0x22]) * 32 + (88).to_bytes(16, "little", signed=True),
+          }
+
+          for name, data in samples.items():
+              (corpus_dir / name).write_bytes(data)
+          PY
+
+      - name: Replay corpus for 10 minutes
+        working-directory: contracts/my-contract/fuzz
+        run: cargo fuzz run fuzz_cross_contract "$RUNNER_TEMP/fuzz-corpus/fuzz_cross_contract" -- -max_total_time=600

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -5,13 +5,16 @@ on:
     paths:
       - "**/*.md"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   link-check:
     name: Markdown link integrity
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check markdown links with lychee
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/e2e-coverage.yml
+++ b/.github/workflows/e2e-coverage.yml
@@ -8,13 +8,14 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   test:
     name: Run Tests and Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -22,7 +23,7 @@ jobs:
           toolchain: stable
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -16,18 +16,21 @@ on:
       - ".github/workflows/provenance.yml"
       - "CHECKSUMS.txt"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   verify:
     name: Verify Artifact Determinism
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -59,7 +62,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Checksums
         run: ./scripts/generate-provenance.sh
@@ -80,7 +83,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: ${{ steps.subjects.outputs.subject-paths }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   publish:
@@ -18,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 
 permissions: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-release:
     name: Build and Release Binary
@@ -37,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -65,7 +68,7 @@ jobs:
         run: mv target/${{ matrix.target }}/release/sanctifier.exe ${{ matrix.artifact_name }}
 
       - name: Generate build provenance (SLSA)
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: ${{ matrix.artifact_name }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-test:
@@ -16,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -24,7 +25,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -48,7 +49,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: junit-test-results
           path: target/nextest/ci/junit.xml
@@ -65,13 +66,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -116,13 +117,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry & build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/soroban-deploy.yml
+++ b/.github/workflows/soroban-deploy.yml
@@ -30,6 +30,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-deploy:
@@ -42,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -51,7 +52,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -124,7 +125,7 @@ jobs:
 
       - name: Upload deployment manifest
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: deployment-manifest-${{ github.run_id }}
           path: .deployment-manifest.json
@@ -132,7 +133,7 @@ jobs:
 
       - name: Upload deployment log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: deployment-log-${{ github.run_id }}
           path: .deployment.log
@@ -161,10 +162,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download deployment manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: deployment-manifest-${{ github.run_id }}
 
@@ -241,7 +242,7 @@ jobs:
           fi
 
       - name: Create deployment status check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.checks.create({

--- a/.github/workflows/soroban-examples.yml
+++ b/.github/workflows/soroban-examples.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   soroban-examples:
@@ -16,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -60,7 +61,7 @@ jobs:
           done
 
       - name: Upload summary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: soroban-examples-summary
           path: soroban-examples-summary.json

--- a/.github/workflows/vscode-extension-ci.yml
+++ b/.github/workflows/vscode-extension-ci.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - "vscode-extension/**"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Test on ${{ matrix.os }}
@@ -26,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: vscode-extension/package-lock.json
 

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -6,6 +6,9 @@ on:
       - "v*"
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish-vscode-extension:
     name: Package and publish to VS Code Marketplace
@@ -18,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: vscode-extension/package-lock.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,6 +3190,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanctifier-detector"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "sanctifier-wasm"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "tooling/sanctifier-core",
     "tooling/sanctifier-cli",
+    "tooling/sanctifier-detector",
     "tooling/sanctifier-wasm",
     "contracts/security-disclaimers",
     "contracts/vulnerable-contract",

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Sanctifier is shipping in waves. What's done, what's next, what's wishlist:
 **Shipped**
 - 12 canonical analysis rules (S001–S012) with stable codes
 - CLI, GitHub Action, Web Dashboard, VS Code extension, WASM build
+- Off-chain anomaly detector for recorded runtime calls with Slack/Discord alerts
 - Live testnet runtime-guard contracts emitting on-chain audit events
 - SARIF + JSON output, draft-07 schema, badge generator
 - Diff mode, watch mode, cargo-workspace scan, patcher
@@ -270,6 +271,7 @@ Sanctifier is shipping in waves. What's done, what's next, what's wishlist:
 Sanctifier/
 ├── tooling/
 │   ├── sanctifier-cli/        # CLI binary (the one you install)
+│   ├── sanctifier-detector/   # Off-chain anomaly detection service
 │   ├── sanctifier-core/       # Static-analysis engine + Z3 backend
 │   └── sanctifier-wasm/       # Browser/Node WASM build of the engine
 ├── frontend/                  # Next.js dashboard, playground, terminal

--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -1,0 +1,61 @@
+# Anomaly Detection Service
+
+`tooling/sanctifier-detector` is the off-chain service for recorded runtime-call monitoring. It polls an event-indexer endpoint, keeps a rolling history of `CallRecord` entries, evaluates the configured rules, and sends Slack or Discord alerts when an anomaly is detected.
+
+## What it watches
+
+The detector ships with four rules:
+
+1. Sudden failure-rate spike
+1. Function spam from the same caller
+1. Privileged `pause` / `resume` calls from non-admin addresses
+1. Off-hours activity for contracts with configured operating windows
+
+## Configuration
+
+Create a JSON config file:
+
+```json
+{
+  "events_url": "https://indexer.example.com/call-records",
+  "poll_interval_seconds": 30,
+  "webhook_urls": [
+    "https://hooks.slack.com/services/...",
+    "https://discord.com/api/webhooks/..."
+  ],
+  "admins": [
+    "GBZXAMPLEADMINADDRESS"
+  ],
+  "off_hours_windows": {
+    "C0123456789ABCDEF0123456789ABCDEF": [
+      { "start_hour": 8, "end_hour": 18 }
+    ]
+  }
+}
+```
+
+`off_hours_windows` uses UTC hours and treats the end hour as exclusive.
+
+## Running it
+
+```bash
+cargo run -p sanctifier-detector -- --config detector.json
+```
+
+For a single fetch-and-evaluate pass:
+
+```bash
+cargo run -p sanctifier-detector -- --config detector.json --once
+```
+
+## Event shape
+
+The detector accepts either a raw JSON array of records or an envelope with a top-level `records` field. Each record must include:
+
+- `contract_id`
+- `function`
+- `caller`
+- `success`
+- `timestamp_unix`
+
+An `id` field is optional. When omitted, the detector derives a stable key from the contract, function, caller, and timestamp.

--- a/docs/ci-cd-setup.md
+++ b/docs/ci-cd-setup.md
@@ -10,6 +10,7 @@ The automation includes:
 - **Continuous Validation**: Periodic health checks and metrics collection
 - **Artifact Management**: Deployment manifests and logs
 - **Frontend E2E (Playwright)**: Browser-level regression checks
+- **Node 24 migration**: GitHub Actions workflows use Node-24-compatible action majors and set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
 
 ## Prerequisites
 
@@ -174,6 +175,12 @@ The workflow file: `.github/workflows/soroban-deploy.yml`
 1. `build-and-deploy`: Build, deploy, validate
 2. `continuous-validation`: Run health checks
 3. `notification`: Generate reports
+
+The repository-wide workflow refresh also bumped the GitHub Action majors used by the CI family to the Node 24-compatible releases:
+
+- `actions/checkout@v6`
+- `actions/cache@v5`
+- `actions/setup-node@v6`
 
 ### 4.4 Artifact retention strategy (why + where to change)
 

--- a/docs/contracts-fuzz.md
+++ b/docs/contracts-fuzz.md
@@ -31,7 +31,7 @@ Runs on `ubuntu-latest` under stable Rust.  Two steps:
 
 | Step | Command | Purpose |
 |------|---------|---------|
-| Bolero + e2e | `cargo test -p my-contract --tests` | Drives `src/fuzz.rs` and `tests/cross_contract_fuzz_e2e.rs` |
+| Bolero + e2e | `cargo test -p my-contract --lib --tests` | Drives the unit fuzz harness and `tests/cross_contract_fuzz_e2e.rs` |
 | Compile fuzz target | `cargo check --bin fuzz_cross_contract` (in `contracts/my-contract/fuzz`) | Guarantees the libFuzzer harness still builds |
 
 The smoke job keeps PR feedback under a couple of minutes while ensuring no
@@ -58,12 +58,15 @@ cargo bolero test <target> --corpus-dir <downloaded-corpus>
 cargo fuzz run fuzz_cross_contract <crash-input>
 ```
 
+The PR workflow also seeds a replay corpus from known-good and known-bad
+payloads and runs it for up to 10 minutes on every pull request.
+
 ## Local development
 
 Reproduce the smoke job:
 
 ```bash
-cargo test -p my-contract --tests
+cargo test -p my-contract --lib --tests
 ( cd contracts/my-contract/fuzz && cargo check --bin fuzz_cross_contract )
 ```
 

--- a/tooling/sanctifier-detector/Cargo.toml
+++ b/tooling/sanctifier-detector/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sanctifier-detector"
+version = "0.1.0"
+edition = "2021"
+description = "Off-chain anomaly detection service for Sanctifier call records"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/HyperSafeD/Sanctifier"
+homepage = "https://github.com/HyperSafeD/Sanctifier"
+
+[dependencies]
+anyhow = "1.0"
+chrono = { version = "0.4", features = ["clock", "serde"] }
+clap = { version = "4.4", features = ["derive"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+

--- a/tooling/sanctifier-detector/src/config.rs
+++ b/tooling/sanctifier-detector/src/config.rs
@@ -1,0 +1,53 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::{collections::HashMap, fs, path::Path};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DetectorConfig {
+    pub events_url: String,
+
+    #[serde(default = "default_poll_interval_seconds")]
+    pub poll_interval_seconds: u64,
+
+    #[serde(default)]
+    pub webhook_urls: Vec<String>,
+
+    #[serde(default)]
+    pub admins: Vec<String>,
+
+    #[serde(default)]
+    pub off_hours_windows: HashMap<String, Vec<HourWindow>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HourWindow {
+    pub start_hour: u8,
+    pub end_hour: u8,
+}
+
+fn default_poll_interval_seconds() -> u64 {
+    30
+}
+
+impl DetectorConfig {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("failed to read detector config {}", path.display()))?;
+        let config = serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse detector config {}", path.display()))?;
+        Ok(config)
+    }
+}
+
+impl HourWindow {
+    pub fn contains(&self, hour: u32) -> bool {
+        let start = u32::from(self.start_hour);
+        let end = u32::from(self.end_hour);
+        if start <= end {
+            hour >= start && hour < end
+        } else {
+            hour >= start || hour < end
+        }
+    }
+}

--- a/tooling/sanctifier-detector/src/events.rs
+++ b/tooling/sanctifier-detector/src/events.rs
@@ -1,0 +1,32 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CallRecord {
+    #[serde(default)]
+    pub id: String,
+    pub contract_id: String,
+    pub function: String,
+    pub caller: String,
+    pub success: bool,
+    pub timestamp_unix: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum EventFeed {
+    Records(Vec<CallRecord>),
+    Envelope { records: Vec<CallRecord> },
+}
+
+impl CallRecord {
+    pub fn stable_key(&self) -> String {
+        if self.id.is_empty() {
+            format!(
+                "{}:{}:{}:{}",
+                self.contract_id, self.function, self.caller, self.timestamp_unix
+            )
+        } else {
+            self.id.clone()
+        }
+    }
+}

--- a/tooling/sanctifier-detector/src/lib.rs
+++ b/tooling/sanctifier-detector/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod config;
+pub mod events;
+pub mod rules;
+pub mod service;
+pub mod webhook;
+
+pub use config::{DetectorConfig, HourWindow};
+pub use events::CallRecord;
+pub use rules::{Alert, AlertSeverity, DetectionRule};
+pub use service::DetectorService;

--- a/tooling/sanctifier-detector/src/main.rs
+++ b/tooling/sanctifier-detector/src/main.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use clap::Parser;
+use sanctifier_detector::{DetectorConfig, DetectorService};
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "sanctifier-detector",
+    about = "Poll recorded call events and alert on anomalies"
+)]
+struct Args {
+    #[arg(long)]
+    config: PathBuf,
+
+    #[arg(long)]
+    once: bool,
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = Args::parse();
+    let config = DetectorConfig::load(&args.config)?;
+    let mut service = DetectorService::new(config)?;
+
+    if args.once {
+        service.poll_once()?;
+    } else {
+        service.run()?;
+    }
+
+    Ok(())
+}

--- a/tooling/sanctifier-detector/src/rules.rs
+++ b/tooling/sanctifier-detector/src/rules.rs
@@ -1,0 +1,284 @@
+use crate::{config::HourWindow, events::CallRecord};
+use chrono::{TimeZone, Utc};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum AlertSeverity {
+    Critical,
+    High,
+    Medium,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Alert {
+    pub fingerprint: String,
+    pub rule: String,
+    pub severity: AlertSeverity,
+    pub contract_id: String,
+    pub caller: String,
+    pub function: String,
+    pub timestamp_unix: i64,
+    pub summary: String,
+}
+
+pub trait DetectionRule: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn evaluate(&self, records: &[CallRecord]) -> Vec<Alert>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FailureRateSpikeRule {
+    recent_window: usize,
+    baseline_window: usize,
+}
+
+impl Default for FailureRateSpikeRule {
+    fn default() -> Self {
+        Self {
+            recent_window: 50,
+            baseline_window: 200,
+        }
+    }
+}
+
+impl DetectionRule for FailureRateSpikeRule {
+    fn name(&self) -> &'static str {
+        "failure-rate-spike"
+    }
+
+    fn evaluate(&self, records: &[CallRecord]) -> Vec<Alert> {
+        let mut alerts = Vec::new();
+        let mut by_contract: HashMap<&str, Vec<&CallRecord>> = HashMap::new();
+        for record in records {
+            by_contract
+                .entry(&record.contract_id)
+                .or_default()
+                .push(record);
+        }
+
+        for (contract_id, mut history) in by_contract {
+            history.sort_by_key(|record| record.timestamp_unix);
+            if history.len() < self.recent_window + self.baseline_window {
+                continue;
+            }
+
+            let recent = &history[history.len() - self.recent_window..];
+            let baseline = &history[history.len() - self.recent_window - self.baseline_window
+                ..history.len() - self.recent_window];
+
+            let recent_failures = recent.iter().filter(|record| !record.success).count() as f64;
+            let baseline_failures = baseline.iter().filter(|record| !record.success).count() as f64;
+            let recent_rate = recent_failures / recent.len() as f64;
+            let baseline_rate = baseline_failures / baseline.len() as f64;
+
+            if baseline_rate < 0.05 && recent_rate > 0.20 {
+                let latest = recent.last().expect("recent window is non-empty");
+                alerts.push(Alert {
+                    fingerprint: format!(
+                        "{}:{}:{}",
+                        self.name(),
+                        contract_id,
+                        latest.timestamp_unix
+                    ),
+                    rule: self.name().to_string(),
+                    severity: AlertSeverity::Critical,
+                    contract_id: contract_id.to_string(),
+                    caller: latest.caller.clone(),
+                    function: latest.function.clone(),
+                    timestamp_unix: latest.timestamp_unix,
+                    summary: format!(
+                        "failure rate jumped to {:.0}% over the last {} calls (baseline {:.0}% over the previous {} calls)",
+                        recent_rate * 100.0,
+                        self.recent_window,
+                        baseline_rate * 100.0,
+                        self.baseline_window,
+                    ),
+                });
+            }
+        }
+
+        alerts
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionSpamRule {
+    threshold: usize,
+    window_seconds: i64,
+}
+
+impl Default for FunctionSpamRule {
+    fn default() -> Self {
+        Self {
+            threshold: 100,
+            window_seconds: 60 * 60,
+        }
+    }
+}
+
+impl DetectionRule for FunctionSpamRule {
+    fn name(&self) -> &'static str {
+        "function-spam"
+    }
+
+    fn evaluate(&self, records: &[CallRecord]) -> Vec<Alert> {
+        let mut alerts = Vec::new();
+        let Some(latest_ts) = records.iter().map(|record| record.timestamp_unix).max() else {
+            return alerts;
+        };
+        let cutoff = latest_ts - self.window_seconds;
+        let mut counts: HashMap<(String, String, String), usize> = HashMap::new();
+
+        for record in records
+            .iter()
+            .filter(|record| record.timestamp_unix >= cutoff)
+        {
+            let key = (
+                record.contract_id.clone(),
+                record.caller.clone(),
+                record.function.clone(),
+            );
+            *counts.entry(key).or_default() += 1;
+        }
+
+        for ((contract_id, caller, function), count) in counts {
+            if count > self.threshold {
+                let summary = format!(
+                    "{} invoked {} {} times in the last 60 minutes",
+                    caller, function, count
+                );
+                alerts.push(Alert {
+                    fingerprint: format!(
+                        "{}:{}:{}:{}:{}",
+                        self.name(),
+                        contract_id,
+                        caller,
+                        function,
+                        latest_ts
+                    ),
+                    rule: self.name().to_string(),
+                    severity: AlertSeverity::High,
+                    contract_id,
+                    caller,
+                    function,
+                    timestamp_unix: latest_ts,
+                    summary,
+                });
+            }
+        }
+
+        alerts
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrivilegedCallRule {
+    admins: HashSet<String>,
+}
+
+impl PrivilegedCallRule {
+    pub fn new(admins: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            admins: admins.into_iter().collect(),
+        }
+    }
+}
+
+impl DetectionRule for PrivilegedCallRule {
+    fn name(&self) -> &'static str {
+        "privileged-call"
+    }
+
+    fn evaluate(&self, records: &[CallRecord]) -> Vec<Alert> {
+        let mut alerts = Vec::new();
+        for record in records {
+            if !matches!(record.function.as_str(), "pause" | "resume") {
+                continue;
+            }
+            if self.admins.contains(&record.caller) {
+                continue;
+            }
+
+            alerts.push(Alert {
+                fingerprint: format!(
+                    "{}:{}:{}:{}",
+                    self.name(),
+                    record.contract_id,
+                    record.function,
+                    record.stable_key()
+                ),
+                rule: self.name().to_string(),
+                severity: AlertSeverity::Critical,
+                contract_id: record.contract_id.clone(),
+                caller: record.caller.clone(),
+                function: record.function.clone(),
+                timestamp_unix: record.timestamp_unix,
+                summary: format!(
+                    "privileged {} call from non-admin address {}",
+                    record.function, record.caller
+                ),
+            });
+        }
+        alerts
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OffHoursRule {
+    windows_by_contract: HashMap<String, Vec<HourWindow>>,
+}
+
+impl OffHoursRule {
+    pub fn new(windows_by_contract: HashMap<String, Vec<HourWindow>>) -> Self {
+        Self {
+            windows_by_contract,
+        }
+    }
+}
+
+impl DetectionRule for OffHoursRule {
+    fn name(&self) -> &'static str {
+        "off-hours-activity"
+    }
+
+    fn evaluate(&self, records: &[CallRecord]) -> Vec<Alert> {
+        let mut alerts = Vec::new();
+
+        for record in records {
+            let Some(windows) = self.windows_by_contract.get(&record.contract_id) else {
+                continue;
+            };
+            let Some(ts) = Utc.timestamp_opt(record.timestamp_unix, 0).single() else {
+                continue;
+            };
+            let hour = ts.hour();
+            if windows.iter().any(|window| window.contains(hour)) {
+                continue;
+            }
+
+            alerts.push(Alert {
+                fingerprint: format!(
+                    "{}:{}:{}",
+                    self.name(),
+                    record.contract_id,
+                    record.stable_key()
+                ),
+                rule: self.name().to_string(),
+                severity: AlertSeverity::Medium,
+                contract_id: record.contract_id.clone(),
+                caller: record.caller.clone(),
+                function: record.function.clone(),
+                timestamp_unix: record.timestamp_unix,
+                summary: format!(
+                    "call landed outside the configured operating window at {:02}:00 UTC",
+                    hour
+                ),
+            });
+        }
+
+        alerts
+    }
+}
+
+use chrono::Timelike;

--- a/tooling/sanctifier-detector/src/service.rs
+++ b/tooling/sanctifier-detector/src/service.rs
@@ -1,0 +1,116 @@
+use crate::{
+    config::DetectorConfig,
+    events::{CallRecord, EventFeed},
+    rules::{
+        Alert, DetectionRule, FailureRateSpikeRule, FunctionSpamRule, OffHoursRule,
+        PrivilegedCallRule,
+    },
+    webhook::send_alert_webhooks,
+};
+use anyhow::{Context, Result};
+use reqwest::Url;
+use std::{collections::HashSet, thread, time::Duration};
+use tracing::info;
+
+pub struct DetectorService {
+    config: DetectorConfig,
+    client: reqwest::blocking::Client,
+    history: Vec<CallRecord>,
+    seen_record_keys: HashSet<String>,
+    seen_alert_keys: HashSet<String>,
+    rules: Vec<Box<dyn DetectionRule>>,
+    last_timestamp: Option<i64>,
+}
+
+impl DetectorService {
+    pub fn new(config: DetectorConfig) -> Result<Self> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()?;
+
+        let rules: Vec<Box<dyn DetectionRule>> = vec![
+            Box::new(FailureRateSpikeRule::default()),
+            Box::new(FunctionSpamRule::default()),
+            Box::new(PrivilegedCallRule::new(config.admins.clone())),
+            Box::new(OffHoursRule::new(config.off_hours_windows.clone())),
+        ];
+
+        Ok(Self {
+            config,
+            client,
+            history: Vec::new(),
+            seen_record_keys: HashSet::new(),
+            seen_alert_keys: HashSet::new(),
+            rules,
+            last_timestamp: None,
+        })
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        loop {
+            self.poll_once()?;
+            thread::sleep(Duration::from_secs(
+                self.config.poll_interval_seconds.max(1),
+            ));
+        }
+    }
+
+    pub fn poll_once(&mut self) -> Result<Vec<Alert>> {
+        let new_records = self.fetch_records()?;
+        let mut ingested = 0usize;
+        for record in new_records {
+            let key = record.stable_key();
+            if self.seen_record_keys.insert(key) {
+                self.last_timestamp = Some(
+                    self.last_timestamp
+                        .map_or(record.timestamp_unix, |ts| ts.max(record.timestamp_unix)),
+                );
+                self.history.push(record);
+                ingested += 1;
+            }
+        }
+
+        if ingested == 0 && self.history.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if self.history.len() > 10_000 {
+            let drain_count = self.history.len() - 10_000;
+            self.history.drain(0..drain_count);
+        }
+
+        let mut alerts = Vec::new();
+        for rule in &self.rules {
+            alerts.extend(rule.evaluate(&self.history));
+        }
+
+        let fresh_alerts: Vec<_> = alerts
+            .into_iter()
+            .filter(|alert| self.seen_alert_keys.insert(alert.fingerprint.clone()))
+            .collect();
+
+        if !fresh_alerts.is_empty() {
+            info!(alerts = fresh_alerts.len(), "dispatching anomaly alerts");
+            send_alert_webhooks(&self.config.webhook_urls, &fresh_alerts)
+                .context("failed to deliver anomaly webhooks")?;
+        }
+
+        Ok(fresh_alerts)
+    }
+
+    fn fetch_records(&self) -> Result<Vec<CallRecord>> {
+        let mut url = Url::parse(&self.config.events_url)
+            .with_context(|| format!("invalid events url {}", self.config.events_url))?;
+        if let Some(last_timestamp) = self.last_timestamp {
+            url.query_pairs_mut()
+                .append_pair("since", &last_timestamp.to_string());
+        }
+
+        let response = self.client.get(url).send()?.error_for_status()?;
+        let feed = response.json::<EventFeed>()?;
+        Ok(match feed {
+            EventFeed::Records(records) => records,
+            EventFeed::Envelope { records } => records,
+        })
+    }
+}

--- a/tooling/sanctifier-detector/src/webhook.rs
+++ b/tooling/sanctifier-detector/src/webhook.rs
@@ -1,0 +1,145 @@
+use crate::rules::{Alert, AlertSeverity};
+use anyhow::Result;
+use serde::Serialize;
+use tracing::warn;
+
+#[derive(Debug, Clone, Serialize)]
+struct AlertWebhookPayload {
+    event: &'static str,
+    generated_at_unix: String,
+    summary: AlertWebhookSummary,
+    alerts: Vec<Alert>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AlertWebhookSummary {
+    total_alerts: usize,
+    critical_alerts: usize,
+    high_alerts: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebhookProvider {
+    Discord,
+    Slack,
+    Teams,
+    Custom,
+}
+
+pub fn send_alert_webhooks(urls: &[String], alerts: &[Alert]) -> Result<()> {
+    if urls.is_empty() || alerts.is_empty() {
+        return Ok(());
+    }
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+
+    let payload = build_payload(alerts);
+    for url in urls {
+        let body = provider_payload(url, &payload);
+        match client.post(url).json(&body).send() {
+            Ok(resp) if resp.status().is_success() => {}
+            Ok(resp) => warn!(
+                target: "sanctifier-detector",
+                status = resp.status().as_u16(),
+                url = %url,
+                "Webhook delivery failed"
+            ),
+            Err(err) => {
+                warn!(target: "sanctifier-detector", error = %err, url = %url, "Webhook delivery error")
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn build_payload(alerts: &[Alert]) -> AlertWebhookPayload {
+    let critical_alerts = alerts
+        .iter()
+        .filter(|alert| alert.severity == AlertSeverity::Critical)
+        .count();
+    let high_alerts = alerts
+        .iter()
+        .filter(|alert| alert.severity == AlertSeverity::High)
+        .count();
+
+    AlertWebhookPayload {
+        event: "anomaly.alert",
+        generated_at_unix: chrono::Utc::now().timestamp().to_string(),
+        summary: AlertWebhookSummary {
+            total_alerts: alerts.len(),
+            critical_alerts,
+            high_alerts,
+        },
+        alerts: alerts.to_vec(),
+    }
+}
+
+fn provider_payload(url: &str, payload: &AlertWebhookPayload) -> serde_json::Value {
+    match classify_provider(url) {
+        WebhookProvider::Discord => serde_json::json!({
+            "content": summary_text(payload),
+        }),
+        WebhookProvider::Slack => serde_json::json!({
+            "text": summary_text(payload),
+            "attachments": [
+                {
+                    "color": slack_color(payload),
+                    "fields": payload.alerts.iter().map(|alert| serde_json::json!({
+                        "title": format!("{} / {}", alert.contract_id, alert.rule),
+                        "value": format!("{} - {}", alert.function, alert.summary),
+                        "short": false
+                    })).collect::<Vec<_>>()
+                }
+            ]
+        }),
+        WebhookProvider::Teams => serde_json::json!({
+            "text": summary_text(payload),
+        }),
+        WebhookProvider::Custom => serde_json::json!(payload),
+    }
+}
+
+fn summary_text(payload: &AlertWebhookPayload) -> String {
+    let mut message = format!(
+        "Sanctifier detector raised {} alert(s) at {}.",
+        payload.summary.total_alerts, payload.generated_at_unix
+    );
+    if payload.summary.critical_alerts > 0 {
+        message.push_str(&format!(" Critical: {}.", payload.summary.critical_alerts));
+    }
+    if payload.summary.high_alerts > 0 {
+        message.push_str(&format!(" High: {}.", payload.summary.high_alerts));
+    }
+    if let Some(first) = payload.alerts.first() {
+        message.push_str(&format!(
+            " First alert: {} on {}. {}",
+            first.rule, first.contract_id, first.summary
+        ));
+    }
+    message
+}
+
+fn slack_color(payload: &AlertWebhookPayload) -> &'static str {
+    if payload.summary.critical_alerts > 0 {
+        "#d92d20"
+    } else if payload.summary.high_alerts > 0 {
+        "#f79009"
+    } else {
+        "#17b26a"
+    }
+}
+
+fn classify_provider(url: &str) -> WebhookProvider {
+    if url.contains("discord") {
+        WebhookProvider::Discord
+    } else if url.contains("slack") {
+        WebhookProvider::Slack
+    } else if url.contains("teams") || url.contains("office.com/webhook") {
+        WebhookProvider::Teams
+    } else {
+        WebhookProvider::Custom
+    }
+}


### PR DESCRIPTION
Closes #744
Closes #751
Closes #747

Summary:
- Migrate the workflows to Node 24-compatible GitHub Action majors and set the Node 24 guard env.
- Add a PR corpus-replay job and tighten the fuzz smoke job to cover the unit harness.
- Add a new `sanctifier-detector` crate plus docs for off-chain anomaly detection and alerts.