### PR TITLE
feat(engine): detect env.ledger().timestamp() used as randomness entropy (S029)

### DIFF
--- a/contracts/fixtures/finding-codes/s029_timestamp_randomness.rs
+++ b/contracts/fixtures/finding-codes/s029_timestamp_randomness.rs
@@ -1,0 +1,55 @@
+//! S029 — Timestamp used as randomness entropy.
+//!
+//! Block timestamps are not secret entropy. Validators can nudge
+//! `env.ledger().timestamp()` within a window, making any randomness
+//! derived solely from it manipulable.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+
+#[contract]
+pub struct TimestampRandomnessBuggy;
+
+#[contract]
+pub struct TimestampRandomnessSafe;
+
+#[contractimpl]
+impl TimestampRandomnessBuggy {
+    // ❌ BAD: timestamp used as seed — flagged because function name contains "seed".
+    pub fn seed_prng(env: Env) -> u64 {
+        let seed = env.ledger().timestamp();
+        seed % 1000
+    }
+
+    // ❌ BAD: timestamp used as randomness — function name contains "rand".
+    pub fn rand_roll(env: Env) -> u64 {
+        env.ledger().timestamp() % 6 + 1
+    }
+
+    // ❌ BAD: timestamp selects winner — function name contains "pick".
+    pub fn pick_winner(env: Env, participants: Vec<Address>) -> Address {
+        let idx = env.ledger().timestamp() % participants.len() as u64;
+        participants.get(idx as u32).unwrap()
+    }
+
+    // ❌ BAD: timestamp stored into a variable named "winner".
+    pub fn draw(env: Env, total: u64) -> u64 {
+        let winner = env.ledger().timestamp() % total;
+        winner
+    }
+}
+
+#[contractimpl]
+impl TimestampRandomnessSafe {
+    // ✅ SAFE: timestamp used for expiry/time comparison only.
+    pub fn check_expiry(env: Env, deadline: u64) -> bool {
+        env.ledger().timestamp() > deadline
+    }
+
+    // ✅ SAFE: timestamp used for logging/record keeping, not as entropy.
+    pub fn record_time(env: Env) {
+        let ts = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("LAST_TS"), &ts);
+    }
+}

--- a/contracts/unsafe-prng-example/src/lib.rs
+++ b/contracts/unsafe-prng-example/src/lib.rs
@@ -46,6 +46,27 @@ impl UnsafePrngExample {
     pub fn set_value(env: Env, key: u32, value: u64) {
         env.storage().persistent().set(&key, &value);
     }
+
+    /// UNSAFE: Uses ledger timestamp as the sole source of randomness seed.
+    /// Flagged by the timestamp_randomness rule (S029).
+    pub fn pick_winner_by_timestamp(env: Env, participants: Vec<Address>) -> Address {
+        let seed = env.ledger().timestamp();
+        let idx = seed % participants.len() as u64;
+        participants.get(idx as u32).unwrap()
+    }
+
+    /// UNSAFE: Timestamp used directly to derive a rand value.
+    /// Flagged by the timestamp_randomness rule (S029).
+    pub fn rand_from_timestamp(env: Env) -> u64 {
+        let rand = env.ledger().timestamp() % 1000;
+        rand
+    }
+
+    /// SAFE: Timestamp used only for deadline/expiry checks.
+    /// This function will NOT be flagged.
+    pub fn is_expired(env: Env, deadline: u64) -> bool {
+        env.ledger().timestamp() > deadline
+    }
 }
 
 #[cfg(test)]

--- a/docs/rules/timestamp-randomness.md
+++ b/docs/rules/timestamp-randomness.md
@@ -1,0 +1,143 @@
+# Timestamp Randomness Rule (S029)
+
+## Overview
+
+The `timestamp_randomness` rule detects use of `env.ledger().timestamp()` as a source of randomness entropy. Block timestamps are **not** secret and can be nudged by validators within a small window, making any randomness derived solely from them manipulable.
+
+## Severity
+
+**High** — exploitable on-chain; a validator or a well-timed transaction can influence the outcome.
+
+## Detection Logic
+
+The rule fires when **all** of the following hold:
+
+1. `env.ledger().timestamp()` is called inside a function or expression.
+2. The context is randomness-related, identified by **name**:
+   - Function name contains `rand`, `seed`, `pick`, or `winner` (case-insensitive), **OR**
+   - A variable binding on the left-hand side of an assignment contains one of those keywords.
+
+Non-sensitive uses of `env.ledger().timestamp()` (deadline checks, expiry guards, audit logs) are **not** flagged.
+
+## Examples
+
+### ❌ Vulnerable — function named `pick_winner`
+
+```rust
+pub fn pick_winner(env: Env, participants: Vec<Address>) -> Address {
+    // UNSAFE: timestamp is predictable entropy
+    let idx = env.ledger().timestamp() % participants.len() as u64;
+    participants.get(idx as u32).unwrap()
+}
+```
+
+### ❌ Vulnerable — variable named `seed`
+
+```rust
+pub fn initialize_game(env: Env) {
+    // UNSAFE: 'seed' bound to timestamp
+    let seed = env.ledger().timestamp();
+    env.storage().persistent().set(&symbol_short!("seed"), &seed);
+}
+```
+
+### ❌ Vulnerable — variable named `rand`
+
+```rust
+pub fn roll_dice(env: Env) -> u64 {
+    let rand = env.ledger().timestamp() % 6 + 1;
+    rand
+}
+```
+
+### ✅ Safe — timestamp used for expiry only
+
+```rust
+pub fn check_expiry(env: Env, deadline: u64) -> bool {
+    // SAFE: not randomness — pure time comparison
+    env.ledger().timestamp() > deadline
+}
+```
+
+### ✅ Safe — timestamp for audit logging
+
+```rust
+pub fn record_action(env: Env) {
+    let ts = env.ledger().timestamp();
+    env.storage().persistent().set(&symbol_short!("LAST_TS"), &ts);
+}
+```
+
+## Why Timestamps Are Dangerous as Randomness
+
+Soroban ledger timestamps represent the UNIX timestamp of the ledger close. Validators have limited but real influence over this value:
+
+- A validator can delay or advance a ledger close within protocol bounds.
+- An attacker who can predict or influence the timestamp can reverse-engineer the outcome of any computation based solely on it.
+- For lottery/NFT draw/reward distribution use cases this translates to direct financial manipulation.
+
+## Mitigation
+
+### 1. Use a VRF Oracle (Recommended for High-Stakes)
+
+```rust
+pub fn pick_winner(
+    env: Env,
+    participants: Vec<Address>,
+    vrf_proof: BytesN<64>,
+) -> Address {
+    // Verify the VRF proof, then derive index from it
+    let idx = derive_index_from_vrf(&vrf_proof, participants.len() as u64);
+    participants.get(idx as u32).unwrap()
+}
+```
+
+### 2. Combine Multiple Entropy Sources
+
+```rust
+pub fn pick_winner(env: Env, participants: Vec<Address>) -> Address {
+    let mut prng = env.prng();
+    // Combine timestamp with ledger sequence and contract address hash
+    let entropy = env.ledger().timestamp()
+        ^ env.ledger().sequence() as u64
+        ^ env.current_contract_address().to_string().len() as u64;
+    prng.reseed(entropy);
+    let idx = prng.gen_range(0..participants.len() as u64);
+    participants.get(idx as u32).unwrap()
+}
+```
+
+### 3. Commit-Reveal Scheme
+
+Have participants commit a secret hash off-chain; reveal it on-chain before the draw. The XOR of all revealed secrets becomes the seed. This eliminates any single party's ability to manipulate the outcome.
+
+## Related Rules
+
+- **S018 — Unsafe PRNG** (`unsafe_prng`): flags `env.prng()` used in state-critical code without reseeding. See [unsafe-prng.md](unsafe-prng.md).
+- **S006 — Unsafe Pattern** (`UNSAFE_PATTERN`): generic unsafe runtime patterns.
+
+## References
+
+- [Soroban Ledger API](https://docs.rs/soroban-sdk/latest/soroban_sdk/ledger/struct.Ledger.html)
+- [OWASP: Insufficient Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
+- [CWE-338: Use of Cryptographically Weak PRNG](https://cwe.mitre.org/data/definitions/338.html)
+- [SWC-120: Weak Sources of Randomness](https://swcregistry.io/docs/SWC-120)
+
+## Testing
+
+```bash
+# Run the rule unit tests
+cargo test -p sanctifier-core timestamp_randomness
+
+# Test against the fixture contract
+cargo test -p sanctifier-core -- timestamp_randomness
+```
+
+## Configuration
+
+The rule is enabled by default. To disable it selectively in `.sanctify.toml`:
+
+```toml
+[rules]
+timestamp_randomness = "off"
+```

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -79,6 +79,8 @@ pub const TAINT_PROPAGATION: &str = "S026";
 pub const STATIC_REENTRANCY: &str = "S027";
 /// Usage of storage/deployment APIs that were removed or renamed in Soroban SDK v22.
 pub const DEPRECATED_SDK_USAGE: &str = "S028";
+/// Use of env.ledger().timestamp() as entropy for randomness.
+pub const TIMESTAMP_RANDOMNESS: &str = "S029";
 
 /// A single finding-code entry with machine-readable code, category, and
 /// human-readable description.
@@ -365,6 +367,15 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             remediation: "Migrate bump() to extend_ttl(), replace RawVal with Val, and use new deploy patterns from the Environment",
             doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/error-codes.md",
         },
+        FindingCode {
+            code: TIMESTAMP_RANDOMNESS,
+            category: "randomness",
+            description: "Block timestamp (env.ledger().timestamp()) used as entropy for randomness — validators can manipulate timestamps within bounds",
+            title: "Timestamp Used as Randomness",
+            severity: FindingSeverity::High,
+            remediation: "Never use env.ledger().timestamp() as a sole source of randomness. Use a VRF oracle or combine multiple unpredictable entropy sources",
+            doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/unsafe-prng.md",
+        },
     ]
 }
 
@@ -406,5 +417,6 @@ mod tests {
         assert!(codes.iter().any(|c| c.code == TAINT_PROPAGATION));
         assert!(codes.iter().any(|c| c.code == STATIC_REENTRANCY));
         assert!(codes.iter().any(|c| c.code == DEPRECATED_SDK_USAGE));
+        assert!(codes.iter().any(|c| c.code == TIMESTAMP_RANDOMNESS));
     }
 }

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -50,6 +50,8 @@ pub mod taint_propagation;
 pub mod static_reentrancy;
 /// Soroban SDK v22 deprecated storage/deployment API patterns.
 pub mod deprecated_sdk_usage;
+/// Detect env.ledger().timestamp() used as entropy for randomness.
+pub mod timestamp_randomness;
 use serde::Serialize;
 use std::any::Any;
 
@@ -218,6 +220,7 @@ impl RuleRegistry {
         registry.register(taint_propagation::TaintPropagationRule::new());
         registry.register(static_reentrancy::StaticReentrancyRule::new());
         registry.register(deprecated_sdk_usage::DeprecatedSdkUsageRule::new());
+        registry.register(timestamp_randomness::TimestampRandomnessRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/src/rules/timestamp_randomness.rs
+++ b/tooling/sanctifier-core/src/rules/timestamp_randomness.rs
@@ -1,0 +1,395 @@
+//! Rule S029 — timestamp used as randomness source.
+//!
+//! Block timestamps are not secret entropy. Validators can nudge
+//! `env.ledger().timestamp()` within a small window, making any
+//! randomness derived from it manipulable.
+//!
+//! This rule fires when `env.ledger().timestamp()` appears inside:
+//! - a function whose name contains `rand`, `seed`, `pick`, or `winner`, OR
+//! - a variable binding whose name contains `rand`, `seed`, `pick`, or `winner`.
+
+use super::{Rule, RuleViolation, Severity};
+use syn::spanned::Spanned;
+use syn::{parse_str, File, Item, Pat};
+
+const SENSITIVE_NAMES: &[&str] = &["rand", "seed", "pick", "winner"];
+
+pub struct TimestampRandomnessRule;
+
+impl TimestampRandomnessRule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TimestampRandomnessRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for TimestampRandomnessRule {
+    fn name(&self) -> &str {
+        "timestamp_randomness"
+    }
+
+    fn description(&self) -> &str {
+        "Detects env.ledger().timestamp() used as entropy for randomness in rand/seed/pick/winner expressions"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+
+        for item in &file.items {
+            if let Item::Impl(impl_block) = item {
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(f) = impl_item {
+                        let fn_name = f.sig.ident.to_string();
+                        let fn_name_lower = fn_name.to_lowercase();
+                        let fn_is_sensitive = SENSITIVE_NAMES
+                            .iter()
+                            .any(|kw| fn_name_lower.contains(kw));
+
+                        let mut findings: Vec<(String, String)> = Vec::new();
+                        scan_block(
+                            &f.block,
+                            &fn_name,
+                            fn_is_sensitive,
+                            &mut findings,
+                        );
+
+                        for (location, context) in findings {
+                            violations.push(
+                                RuleViolation::new(
+                                    self.name(),
+                                    Severity::Error,
+                                    format!(
+                                        "'{context}' uses `env.ledger().timestamp()` as randomness entropy. \
+                                        Block timestamps are manipulable by validators and must not be used as a sole source of randomness.",
+                                    ),
+                                    location,
+                                )
+                                .with_suggestion(
+                                    "Replace timestamp-based entropy with a VRF oracle or a combination \
+                                    of unpredictable sources (e.g. transaction hash + sequence number). \
+                                    See docs/rules/unsafe-prng.md (S029) for guidance."
+                                        .to_string(),
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Walk a block and collect (location, context_label) for every
+/// `env.ledger().timestamp()` call that appears in a sensitive context.
+fn scan_block(
+    block: &syn::Block,
+    fn_name: &str,
+    fn_is_sensitive: bool,
+    findings: &mut Vec<(String, String)>,
+) {
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Local(local) => {
+                // Check if the bound variable name is sensitive.
+                let var_is_sensitive = binding_name_is_sensitive(&local.pat);
+
+                if let Some(init) = &local.init {
+                    let sensitive = fn_is_sensitive || var_is_sensitive;
+                    scan_expr(
+                        &init.expr,
+                        fn_name,
+                        sensitive,
+                        findings,
+                    );
+                }
+            }
+            syn::Stmt::Expr(expr, _) => {
+                scan_expr(expr, fn_name, fn_is_sensitive, findings);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Return true if any identifier in the pattern contains a sensitive keyword.
+fn binding_name_is_sensitive(pat: &Pat) -> bool {
+    match pat {
+        Pat::Ident(p) => {
+            let name = p.ident.to_string().to_lowercase();
+            SENSITIVE_NAMES.iter().any(|kw| name.contains(kw))
+        }
+        Pat::Type(p) => binding_name_is_sensitive(&p.pat),
+        Pat::Tuple(t) => t.elems.iter().any(binding_name_is_sensitive),
+        Pat::TupleStruct(ts) => ts.elems.iter().any(binding_name_is_sensitive),
+        _ => false,
+    }
+}
+
+/// Recursively scan an expression for `env.ledger().timestamp()` calls
+/// when in a sensitive context.
+fn scan_expr(
+    expr: &syn::Expr,
+    fn_name: &str,
+    sensitive: bool,
+    findings: &mut Vec<(String, String)>,
+) {
+    match expr {
+        syn::Expr::MethodCall(m) => {
+            let method = m.method.to_string();
+
+            if method == "timestamp" && is_ledger_receiver(&m.receiver) {
+                if sensitive {
+                    let span = m.span();
+                    findings.push((
+                        format!("{}:line {}", fn_name, span.start().line),
+                        fn_name.to_string(),
+                    ));
+                }
+                // No need to recurse into the receiver — we've matched.
+                return;
+            }
+
+            // Propagate sensitivity for method chains: if the call itself has
+            // a sensitive name, the arguments inherit that sensitivity.
+            let call_is_sensitive = sensitive
+                || SENSITIVE_NAMES
+                    .iter()
+                    .any(|kw| method.to_lowercase().contains(kw));
+
+            scan_expr(&m.receiver, fn_name, call_is_sensitive, findings);
+            for arg in &m.args {
+                scan_expr(arg, fn_name, call_is_sensitive, findings);
+            }
+        }
+        syn::Expr::Call(c) => {
+            // Check for path-style calls whose name is sensitive.
+            let call_is_sensitive = sensitive || call_path_is_sensitive(&c.func);
+            for arg in &c.args {
+                scan_expr(arg, fn_name, call_is_sensitive, findings);
+            }
+            scan_expr(&c.func, fn_name, call_is_sensitive, findings);
+        }
+        syn::Expr::Assign(a) => {
+            // Check if the left-hand side is a sensitive name.
+            let lhs_sensitive = expr_ident_is_sensitive(&a.left);
+            scan_expr(&a.right, fn_name, sensitive || lhs_sensitive, findings);
+        }
+        syn::Expr::Binary(b) => {
+            scan_expr(&b.left, fn_name, sensitive, findings);
+            scan_expr(&b.right, fn_name, sensitive, findings);
+        }
+        syn::Expr::Cast(c) => {
+            scan_expr(&c.expr, fn_name, sensitive, findings);
+        }
+        syn::Expr::Unary(u) => {
+            scan_expr(&u.expr, fn_name, sensitive, findings);
+        }
+        syn::Expr::Paren(p) => {
+            scan_expr(&p.expr, fn_name, sensitive, findings);
+        }
+        syn::Expr::Block(b) => {
+            scan_block(&b.block, fn_name, sensitive, findings);
+        }
+        syn::Expr::If(i) => {
+            scan_expr(&i.cond, fn_name, sensitive, findings);
+            scan_block(&i.then_branch, fn_name, sensitive, findings);
+            if let Some((_, else_expr)) = &i.else_branch {
+                scan_expr(else_expr, fn_name, sensitive, findings);
+            }
+        }
+        syn::Expr::Match(m) => {
+            scan_expr(&m.expr, fn_name, sensitive, findings);
+            for arm in &m.arms {
+                scan_expr(&arm.body, fn_name, sensitive, findings);
+            }
+        }
+        syn::Expr::ForLoop(f) => {
+            scan_expr(&f.expr, fn_name, sensitive, findings);
+            scan_block(&f.body, fn_name, sensitive, findings);
+        }
+        syn::Expr::While(w) => {
+            scan_expr(&w.cond, fn_name, sensitive, findings);
+            scan_block(&w.body, fn_name, sensitive, findings);
+        }
+        syn::Expr::Loop(l) => {
+            scan_block(&l.body, fn_name, sensitive, findings);
+        }
+        syn::Expr::Return(r) => {
+            if let Some(ret) = &r.expr {
+                scan_expr(ret, fn_name, sensitive, findings);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Returns true when the expression looks like `<x>.ledger()`.
+fn is_ledger_receiver(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::MethodCall(m) => m.method == "ledger",
+        syn::Expr::Paren(p) => is_ledger_receiver(&p.expr),
+        _ => false,
+    }
+}
+
+/// Returns true when a call's function path contains a sensitive keyword.
+fn call_path_is_sensitive(func: &syn::Expr) -> bool {
+    if let syn::Expr::Path(p) = func {
+        if let Some(seg) = p.path.segments.last() {
+            let name = seg.ident.to_string().to_lowercase();
+            return SENSITIVE_NAMES.iter().any(|kw| name.contains(kw));
+        }
+    }
+    false
+}
+
+/// Returns true when the expression is an identifier with a sensitive name.
+fn expr_ident_is_sensitive(expr: &syn::Expr) -> bool {
+    if let syn::Expr::Path(p) = expr {
+        if let Some(seg) = p.path.segments.last() {
+            let name = seg.ident.to_string().to_lowercase();
+            return SENSITIVE_NAMES.iter().any(|kw| name.contains(kw));
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_timestamp_in_rand_function() {
+        let rule = TimestampRandomnessRule::new();
+        let source = r#"
+            impl LotteryContract {
+                pub fn pick_winner(env: Env, participants: Vec<Address>) -> Address {
+                    let idx = env.ledger().timestamp() % participants.len() as u64;
+                    participants.get(idx as u32).unwrap()
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty(), "timestamp in pick_winner must be flagged");
+        assert!(violations[0].message.contains("pick_winner"));
+    }
+
+    #[test]
+    fn flags_timestamp_assigned_to_seed_variable() {
+        let rule = TimestampRandomnessRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn initialize(env: Env) {
+                    let seed = env.ledger().timestamp();
+                    env.storage().persistent().set(&symbol_short!("seed"), &seed);
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty(), "timestamp assigned to 'seed' must be flagged");
+    }
+
+    #[test]
+    fn flags_timestamp_assigned_to_rand_variable() {
+        let rule = TimestampRandomnessRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn roll(env: Env) -> u64 {
+                    let rand = env.ledger().timestamp() % 6 + 1;
+                    rand
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty(), "timestamp assigned to 'rand' must be flagged");
+    }
+
+    #[test]
+    fn flags_timestamp_in_winner_function() {
+        let rule = TimestampRandomnessRule::new();
+        let source = r#"
+            impl Lottery {
+                pub fn draw_winner(env: Env) -> u64 {
+                    env.ledger().timestamp() % 100
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty(), "timestamp in draw_winner must be flagged");
+    }
+
+    #[test]
+    fn no_flag_for_timestamp_in_non_sensitive_function() {
+        let rule = TimestampRandomnessRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn check_expiry(env: Env, deadline: u64) -> bool {
+                    env.ledger().timestamp() > deadline
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(violations.is_empty(), "timestamp for time comparison must not be flagged");
+    }
+
+    #[test]
+    fn no_flag_when_no_timestamp_call() {
+        let rule = TimestampRandomnessRule::new();
+        let source = r#"
+            impl MyContract {
+                pub fn pick_winner(env: Env) -> u64 {
+                    env.prng().gen_range(0..100)
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(violations.is_empty(), "no timestamp means no flag");
+    }
+
+    #[test]
+    fn empty_source_produces_no_findings() {
+        let rule = TimestampRandomnessRule::new();
+        assert!(rule.check("").is_empty());
+    }
+
+    #[test]
+    fn invalid_source_produces_no_panic() {
+        let rule = TimestampRandomnessRule::new();
+        assert!(rule.check("not valid rust {{{{").is_empty());
+    }
+
+    #[test]
+    fn finding_has_suggestion_linking_to_unsafe_prng_doc() {
+        let rule = TimestampRandomnessRule::new();
+        let source = r#"
+            impl Raffle {
+                pub fn pick_winner(env: Env) -> u32 {
+                    (env.ledger().timestamp() % 10) as u32
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(!violations.is_empty());
+        let suggestion = violations[0].suggestion.as_deref().unwrap_or("");
+        assert!(
+            suggestion.contains("unsafe-prng.md") || suggestion.contains("S029"),
+            "suggestion must link to unsafe-prng.md or S029"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds rule `timestamp_randomness` (S029) to detect `env.ledger().timestamp()` used as entropy for randomness
- Fires when timestamp appears in functions or variable bindings named `rand`, `seed`, `pick`, or `winner`
- Emits an **Error**-severity finding with a suggestion linking to `docs/rules/unsafe-prng.md`
- Adds finding code constant `S029` (`TIMESTAMP_RANDOMNESS`) to the catalogue
- Adds fixture contract `s029_timestamp_randomness.rs` and rule documentation `docs/rules/timestamp-randomness.md`
- Extends `contracts/unsafe-prng-example` with timestamp-based randomness examples

## Detection logic

| Context | Detected? |
|---|---|
| `pick_winner` uses `env.ledger().timestamp()` | ✅ Yes — function name contains `pick`/`winner` |
| `let seed = env.ledger().timestamp()` | ✅ Yes — variable name contains `seed` |
| `let rand = env.ledger().timestamp() % 6` | ✅ Yes — variable name contains `rand` |
| `env.ledger().timestamp() > deadline` | ❌ No — non-sensitive comparison context |

## Test plan

- [ ] `cargo test -p sanctifier-core -- timestamp_randomness` passes (all 9 unit tests)
- [ ] Fixture contract `s029_timestamp_randomness.rs` reviewed for correctness
- [ ] `docs/rules/timestamp-randomness.md` documents detection logic, examples, and mitigations

Closes #804
Closes #805
Closes #809
Closes #810