### PR TITLE
ci: add testnet health monitor

### DIFF
--- a/.github/scripts/testnet-monitor.js
+++ b/.github/scripts/testnet-monitor.js
@@ -1,0 +1,148 @@
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+const liveTestnetPath = path.join(workspace, "LIVE_TESTNET.md");
+const monitorDir = path.join(workspace, "monitor");
+
+function parseContracts(markdown) {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => {
+      const match = line.match(
+        /^\|\s*\*\*(?<name>[^*]+)\*\*(?<suffix>[^|]*)\|\s*`(?<id>C[A-Z0-9]+)`\s*\|/,
+      );
+
+      if (!match?.groups) {
+        return null;
+      }
+
+      const suffix = match.groups.suffix.replace(/\s+/g, " ").trim();
+
+      return {
+        name: `${match.groups.name}${suffix ? ` ${suffix}` : ""}`.trim(),
+        id: match.groups.id,
+      };
+    })
+    .filter(Boolean);
+}
+
+function runHealthCheck(contract) {
+  const startedAt = new Date().toISOString();
+  const result = spawnSync(
+    "stellar",
+    [
+      "contract",
+      "invoke",
+      "--id",
+      contract.id,
+      "--source",
+      "testnet-monitor",
+      "--network",
+      "testnet",
+      "--",
+      "health_check",
+    ],
+    { encoding: "utf8" },
+  );
+
+  const stdout = result.stdout.trim();
+  const stderr = result.stderr.trim();
+  const output = [stdout, stderr].filter(Boolean).join("\n");
+  const returnedTrue = /\btrue\b/i.test(output);
+
+  return {
+    ...contract,
+    checkedAt: startedAt,
+    healthy: result.status === 0 && returnedTrue,
+    exitCode: result.status,
+    output,
+  };
+}
+
+function writeGitHubOutput(results) {
+  const githubOutput = process.env.GITHUB_OUTPUT;
+
+  if (!githubOutput) {
+    return;
+  }
+
+  const failures = results.filter((result) => !result.healthy);
+  fs.appendFileSync(githubOutput, `healthy=${failures.length === 0}\n`);
+  fs.appendFileSync(githubOutput, `failures=${failures.length}\n`);
+  fs.appendFileSync(githubOutput, `total=${results.length}\n`);
+}
+
+function writeSummary(results, badge) {
+  const githubStepSummary = process.env.GITHUB_STEP_SUMMARY;
+
+  if (!githubStepSummary) {
+    return;
+  }
+
+  const lines = [
+    "## Testnet health monitor",
+    "",
+    `Badge: ${badge.message}`,
+    "",
+    "| Contract | Address | Result |",
+    "|---|---|---|",
+    ...results.map((result) => {
+      const status = result.healthy ? "healthy" : "failed";
+      return `| ${result.name} | \`${result.id}\` | ${status} |`;
+    }),
+    "",
+  ];
+
+  fs.appendFileSync(githubStepSummary, lines.join("\n"));
+}
+
+const markdown = fs.readFileSync(liveTestnetPath, "utf8");
+const contracts = parseContracts(markdown);
+
+if (contracts.length === 0) {
+  throw new Error("No contract IDs were found in LIVE_TESTNET.md");
+}
+
+fs.mkdirSync(monitorDir, { recursive: true });
+
+const results = contracts.map(runHealthCheck);
+const failures = results.filter((result) => !result.healthy);
+const badge = {
+  schemaVersion: 1,
+  label: "testnet monitor",
+  message:
+    failures.length === 0
+      ? `${results.length}/${results.length} healthy`
+      : `${results.length - failures.length}/${results.length} healthy`,
+  color: failures.length === 0 ? "brightgreen" : "red",
+};
+
+fs.writeFileSync(
+  path.join(monitorDir, "results.json"),
+  JSON.stringify(
+    { checkedAt: new Date().toISOString(), contracts: results },
+    null,
+    2,
+  ),
+);
+fs.writeFileSync(
+  path.join(monitorDir, "failures.json"),
+  JSON.stringify(failures, null, 2),
+);
+fs.writeFileSync(
+  path.join(monitorDir, "status.json"),
+  JSON.stringify(badge, null, 2),
+);
+
+writeGitHubOutput(results);
+writeSummary(results, badge);
+
+for (const result of results) {
+  const status = result.healthy ? "healthy" : "failed";
+  console.log(`${result.name} (${result.id}): ${status}`);
+  if (!result.healthy && result.output) {
+    console.log(result.output);
+  }
+}

--- a/.github/workflows/testnet-monitor.yml
+++ b/.github/workflows/testnet-monitor.yml
@@ -1,0 +1,115 @@
+name: Testnet Health Monitor
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  monitor:
+    name: Check deployed testnet contracts
+    runs-on: ubuntu-latest
+    env:
+      XDG_CONFIG_HOME: /tmp/stellar-xdg
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Stellar CLI
+        uses: stellar/stellar-cli@v23.0.1
+
+      - name: Create funded testnet monitor identity
+        run: |
+          stellar keys generate testnet-monitor --network testnet --fund --overwrite
+          stellar keys public-key testnet-monitor
+
+      - name: Run contract health checks
+        id: health
+        run: node .github/scripts/testnet-monitor.js
+
+      - name: Open tracking issues for failures
+        if: steps.health.outputs.healthy != 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require("node:fs");
+            const failures = JSON.parse(fs.readFileSync("monitor/failures.json", "utf8"));
+
+            for (const failure of failures) {
+              const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:testnet label:bug "${failure.id}"`;
+              const existing = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 1 });
+              const title = `Testnet health check failed: ${failure.name}`;
+              const body = [
+                "The scheduled testnet health monitor could not verify a deployed contract.",
+                "",
+                `- Contract: ${failure.name}`,
+                `- Address: \`${failure.id}\``,
+                `- Checked at: ${failure.checkedAt}`,
+                `- Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                "",
+                "```text",
+                failure.output || `stellar exited with ${failure.exitCode}`,
+                "```",
+              ].join("\n");
+
+              if (existing.data.items.length === 0) {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: ["testnet", "bug"],
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.data.items[0].number,
+                  body,
+                });
+              }
+            }
+
+      - name: Publish status badge JSON
+        if: always() && steps.health.outputs.total != ''
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          worktree="$(mktemp -d)"
+          if git ls-remote --exit-code --heads origin monitor >/dev/null 2>&1; then
+            git fetch origin monitor
+            git worktree add "$worktree" origin/monitor
+          else
+            git worktree add --detach "$worktree"
+            git -C "$worktree" checkout --orphan monitor
+            git -C "$worktree" rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p "$worktree/badges"
+          cp monitor/status.json "$worktree/badges/testnet-monitor.json"
+
+          git -C "$worktree" add badges/testnet-monitor.json
+          if git -C "$worktree" diff --cached --quiet; then
+            echo "Badge JSON already up to date."
+            exit 0
+          fi
+
+          git -C "$worktree" commit -m "chore: update testnet monitor badge"
+          git -C "$worktree" push origin HEAD:monitor
+
+      - name: Fail when any contract is unhealthy
+        if: steps.health.outputs.healthy != 'true'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   [![Codecov](https://codecov.io/gh/HyperSafeD/Sanctifier/graph/badge.svg)](https://codecov.io/gh/HyperSafeD/Sanctifier)
   [![crates.io](https://img.shields.io/crates/v/sanctifier-cli.svg)](https://crates.io/crates/sanctifier-cli)
   [![Soroban Testnet](https://img.shields.io/badge/Soroban%20Testnet-Live-2dd4bf?style=flat-square&logo=stellar)](LIVE_TESTNET.md)
+  [![Testnet Monitor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/HyperSafeD/Sanctifier/monitor/badges/testnet-monitor.json)](LIVE_TESTNET.md)
   [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 </div>
 


### PR DESCRIPTION
Fixes #739.

## Summary
- adds `.github/workflows/testnet-monitor.yml` on the requested 6-hour schedule plus manual dispatch
- parses contract names/addresses from `LIVE_TESTNET.md` and runs `stellar contract invoke ... health_check` for each one
- opens/de-duplicates `testnet` + `bug` tracking issues for failed contracts and includes the failed contract address/output
- publishes a shields.io endpoint JSON file to the `monitor` branch and adds the README badge under the Soroban Testnet badge

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/testnet-monitor.yml`
- `npx --yes prettier@3.5.3 --check .github/scripts/testnet-monitor.js .github/workflows/testnet-monitor.yml`
- `PATH=<fake-stellar> GITHUB_WORKSPACE=$PWD GITHUB_OUTPUT=.monitor-test-output GITHUB_STEP_SUMMARY=.monitor-test-summary node .github/scripts/testnet-monitor.js`
- `git diff --check`

## Notes
The local script test stubs the `stellar` binary and verifies parsing/output generation for all three `LIVE_TESTNET.md` contracts. The real health-check invocation runs in GitHub Actions after merge or manual dispatch.