### PR TITLE
fix(action): harden sarif-output validation + warn on upload-sarif misconfiguration

### DIFF
--- a/scripts/action_inputs.py
+++ b/scripts/action_inputs.py
@@ -73,12 +73,19 @@ def validate_inputs(
         allowed = ", ".join(sorted(_ALLOWED_SEVERITIES))
         raise ValueError(f"min-severity must be one of {allowed}, got {min_severity!r}")
 
+    validated_sarif_output = _validate_path(sarif_output, name="sarif-output", allow_missing=True)
+    if fmt == "sarif" and not validated_sarif_output.lower().endswith(".sarif"):
+        raise ValueError(
+            f"sarif-output must use a '.sarif' file extension when format is 'sarif' "
+            f"(GitHub Code Scanning rejects other extensions); got {validated_sarif_output!r}"
+        )
+
     return ActionInputs(
         path=_validate_path(path, name="path", allow_missing=False),
         min_severity=severity,
         format=fmt,
         upload_sarif=_normalise_bool(upload_sarif, name="upload-sarif"),
-        sarif_output=_validate_path(sarif_output, name="sarif-output", allow_missing=True),
+        sarif_output=validated_sarif_output,
         debug=_normalise_bool(debug, name="debug"),
     )
 
@@ -123,6 +130,15 @@ def main() -> int:
     except ValueError as exc:
         print(f"::error title=Invalid Input::Sanctifier action input error: {exc}", file=sys.stderr)
         return 2
+
+    if inputs.upload_sarif == "true" and inputs.format != "sarif":
+        print(
+            "::warning title=SARIF Upload Skipped::"
+            "upload-sarif is 'true' but format is not 'sarif'; "
+            "the Upload SARIF step will be skipped automatically. "
+            "Set format to 'sarif' or set upload-sarif to 'false' to silence this warning.",
+            file=sys.stderr,
+        )
 
     if inputs.debug == "true":
         print(

--- a/tests/action/test_action_inputs.py
+++ b/tests/action/test_action_inputs.py
@@ -115,6 +115,104 @@ class ActionInputTests(unittest.TestCase):
             stderr.getvalue(),
         )
 
+    # ── SARIF upload correctness ──────────────────────────────────────────────
+
+    def test_rejects_sarif_output_without_sarif_extension_when_format_is_sarif(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        with self.assertRaisesRegex(ValueError, r"\.sarif"):
+            validate_inputs(
+                path=".",
+                min_severity="high",
+                format="sarif",
+                upload_sarif="true",
+                sarif_output="results.json",
+                debug="false",
+            )
+
+    def test_accepts_sarif_output_without_sarif_extension_when_format_is_text(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        got = validate_inputs(
+            path=".",
+            min_severity="high",
+            format="text",
+            upload_sarif="false",
+            sarif_output="results.txt",
+            debug="false",
+        )
+        self.assertEqual(got.sarif_output, "results.txt")
+
+    def test_accepts_sarif_output_without_sarif_extension_when_format_is_json(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        got = validate_inputs(
+            path=".",
+            min_severity="high",
+            format="json",
+            upload_sarif="false",
+            sarif_output="results.json",
+            debug="false",
+        )
+        self.assertEqual(got.sarif_output, "results.json")
+
+    def test_rejects_absolute_sarif_output_path(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        with self.assertRaisesRegex(ValueError, "must be relative"):
+            validate_inputs(
+                path=".",
+                min_severity="high",
+                format="sarif",
+                upload_sarif="true",
+                sarif_output="/tmp/results.sarif",
+                debug="false",
+            )
+
+    def test_rejects_sarif_output_with_path_traversal(self) -> None:
+        from scripts.action_inputs import validate_inputs
+
+        with self.assertRaisesRegex(ValueError, "path traversal"):
+            validate_inputs(
+                path=".",
+                min_severity="high",
+                format="sarif",
+                upload_sarif="true",
+                sarif_output="../results.sarif",
+                debug="false",
+            )
+
+    def test_main_emits_warning_when_upload_sarif_true_but_format_is_not_sarif(self) -> None:
+        from scripts.action_inputs import main
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output = pathlib.Path(tmp) / "env"
+            stderr = StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "action_inputs.py",
+                    "--path",
+                    ".",
+                    "--min-severity",
+                    "high",
+                    "--format",
+                    "json",
+                    "--upload-sarif",
+                    "true",
+                    "--sarif-output",
+                    "results.json",
+                    "--debug",
+                    "false",
+                    "--output",
+                    str(output),
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("::warning title=SARIF Upload Skipped::", stderr.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `.sarif` extension enforcement on `sarif-output` when `format` is `sarif` — GitHub Code Scanning rejects SARIF files with non-`.sarif` extensions, so we now catch this at input validation time with a clear error.
- Emits a `::warning` GitHub annotation when `upload-sarif: true` is set but `format` is not `sarif`, making the otherwise-silent upload skip visible in the Actions log.
- Adds 6 new unit tests to `tests/action/test_action_inputs.py` covering all new validation paths (extension rejection, absolute-path rejection, path-traversal rejection on `sarif-output`, and the misconfiguration warning).

## Test plan

- [x] All 20 action unit tests pass locally (`python3 -m unittest discover -s tests/action`)
- [x] Existing tests unchanged — no regressions
- [x] New tests cover: `.sarif` extension enforcement, non-sarif format bypass, absolute path rejection, path-traversal rejection, and warning annotation emission

Closes #628
Closes #615
Closes #617
Closes #608