### PR TITLE
ci: pin action deps to SHA and add integration test coverage

### DIFF
--- a/.github/workflows/e2e-coverage.yml
+++ b/.github/workflows/e2e-coverage.yml
@@ -15,15 +15,15 @@ jobs:
     name: Run Tests and Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master (stable)
         with:
           toolchain: stable
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -47,7 +47,21 @@ jobs:
         run: cargo tarpaulin --package sanctifier-cli --package sanctifier-core --package amm-pool --out Xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           file: cobertura.xml
           fail_ci_if_error: false
+
+  action-tests:
+    name: Action Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.x"
+
+      - name: Run action integration tests
+        run: python -m unittest discover -s tests/action -p "test_*.py" -v

--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,6 @@ runs:
         ${{ env.SANCTIFIER_ACTION_FORMAT == 'sarif'
           && env.SANCTIFIER_ACTION_UPLOAD_SARIF == 'true'
           && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       with:
         sarif_file: ${{ env.SANCTIFIER_ACTION_SARIF_OUTPUT }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions dependencies in `action.yml` and `.github/workflows/e2e-coverage.yml` to immutable commit SHAs, preventing supply-chain attacks via mutable tags
- Add `action-tests` job to the E2E workflow to provide integration/e2e coverage for the action scripts under `tests/action/`
- Add inline `# <tag>` comments on every pinned ref so the human-readable version is preserved

## Changes

**`action.yml`**
- `github/codeql-action/upload-sarif@v3` → pinned to `dd903d2e4f5405488e5ef1422510ee31c8b32357`

**`.github/workflows/e2e-coverage.yml`**
- `actions/checkout@v6` → `df4cb1c069e1874edd31b4311f1884172cec0e10`
- `dtolnay/rust-toolchain@master` → `67ef31d5b988238dd797d409d6f9574278e20537`
- `actions/cache@v5` → `27d5ce7f107fe9357f9df03efb73ab90386fccae`
- `codecov/codecov-action@v3` → `ab904c41d6ece82784817410c45d8b8c02684457`
- New `action-tests` job: runs `python -m unittest discover -s tests/action -p "test_*.py"` with pinned `actions/checkout` and `actions/setup-python@v5`

## Test plan

- [ ] E2E Tests & Coverage job passes (cargo build, cargo test, tarpaulin, codecov upload)
- [ ] Action Integration Tests job passes (all tests under `tests/action/` discovered and passing)
- [ ] All action dependency refs are SHA-pinned (no mutable tags)

Closes #605
Closes #619
Closes #910
Closes #627