### PR TITLE
feat: vscode module boundaries, unit tests, CI coverage + CLI verify-deployment

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -118,6 +118,17 @@
 - Integration examples
 - Troubleshooting
 
+### VS Code Extension
+
+**Location:** [`vscode-extension/`](vscode-extension/)
+
+- **API stability** — `activate()` returns a typed `SanctifierExtensionApi` (`version`, `getFindings(uri)`) that other extensions can consume via `vscode.extensions.getExtension(...).exports`
+- **`sanctifier.minSeverity`** — filter in-editor diagnostics to `error`, `warning` (default), or `information`
+- **`sanctifier.toggleEnable`** — toggle the extension on/off from the command palette or status bar click
+- **`sanctifier.showOutput`** — reveal the persistent output channel
+- **`sanctifier.analyzeWorkspace`** — run the CLI and stream results to the output channel (respects `minSeverity`)
+- Status bar item shows live finding count; click to toggle
+
 ### Sanctifier CLI Deploy Command
 
 **Location:** `tooling/sanctifier-cli/src/commands/deploy.rs`

--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod suppress;
 pub mod update;
 pub mod upgrade;
 pub mod verify;
+pub mod verify_deployment;
 pub mod watch;
 pub mod webhook;
 pub mod workspace;

--- a/tooling/sanctifier-cli/src/commands/verify_deployment.rs
+++ b/tooling/sanctifier-cli/src/commands/verify_deployment.rs
@@ -1,0 +1,299 @@
+#![allow(dead_code)]
+
+use crate::commands::color as c;
+use anyhow::{bail, Context};
+use clap::Args;
+use serde::Serialize;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Args, Debug)]
+pub struct VerifyDeploymentArgs {
+    /// On-chain contract ID to verify
+    #[arg(long)]
+    pub contract_id: String,
+
+    /// Stellar network alias or passphrase (e.g. "testnet", "mainnet")
+    #[arg(long, default_value = "testnet")]
+    pub network: String,
+
+    /// Path to local contract source to build and compare (defaults to current dir)
+    #[arg(long, default_value = ".")]
+    pub source: PathBuf,
+
+    /// Skip local build; compare against this pre-computed SHA-256 hex digest
+    #[arg(long)]
+    pub expected_hash: Option<String>,
+
+    /// Output format: text (default) or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Serialize)]
+struct VerifyDeploymentReport {
+    contract_id: String,
+    network: String,
+    local_hash: String,
+    remote_hash: String,
+    match_result: bool,
+}
+
+pub fn exec(args: VerifyDeploymentArgs) -> anyhow::Result<()> {
+    let is_json = args.format == "json";
+
+    if !is_json {
+        println!("{}", c::bold("sanctifier verify-deployment"));
+        println!("  Contract : {}", args.contract_id);
+        println!("  Network  : {}", args.network);
+        println!();
+    }
+
+    let local_hash = match &args.expected_hash {
+        Some(h) => {
+            if !is_json {
+                println!("  Using supplied expected hash (skipping local build).");
+            }
+            h.clone()
+        }
+        None => {
+            if !is_json {
+                println!("  Building local WASM …");
+            }
+            build_and_hash(&args.source)?
+        }
+    };
+
+    if !is_json {
+        println!("  Fetching remote WASM hash for {} …", args.contract_id);
+    }
+    let remote_hash = fetch_remote_hash(&args.contract_id, &args.network)?;
+
+    let matched = local_hash == remote_hash;
+
+    if is_json {
+        let report = VerifyDeploymentReport {
+            contract_id: args.contract_id.clone(),
+            network: args.network.clone(),
+            local_hash,
+            remote_hash,
+            match_result: matched,
+        };
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        if !matched {
+            bail!("deployment verification failed for contract {}", args.contract_id);
+        }
+        return Ok(());
+    }
+
+    println!("  Local  sha256: {}", local_hash);
+    println!("  Remote sha256: {}", remote_hash);
+    println!();
+
+    if matched {
+        println!(
+            "{} Deployment verified — on-chain WASM matches local source.",
+            c::green_bold("✓")
+        );
+        Ok(())
+    } else {
+        println!(
+            "{} MISMATCH — deployed WASM does NOT match local source.",
+            c::red_bold("✗")
+        );
+        bail!(
+            "deployment verification failed: hash mismatch for contract {}",
+            args.contract_id
+        );
+    }
+}
+
+fn build_and_hash(source: &std::path::Path) -> anyhow::Result<String> {
+    let stellar_status = Command::new("stellar")
+        .args(["contract", "build"])
+        .current_dir(source)
+        .status();
+
+    let built = match stellar_status {
+        Ok(s) if s.success() => true,
+        _ => {
+            let status = Command::new("cargo")
+                .args([
+                    "build",
+                    "--release",
+                    "--target",
+                    "wasm32v1-none",
+                    "--manifest-path",
+                ])
+                .arg(source.join("Cargo.toml"))
+                .status()
+                .context("failed to invoke `cargo build`")?;
+            status.success()
+        }
+    };
+
+    if !built {
+        bail!("contract build failed — check the source for errors");
+    }
+
+    let wasm = find_wasm(source)?;
+    let bytes = std::fs::read(&wasm)
+        .with_context(|| format!("failed to read WASM artifact: {}", wasm.display()))?;
+    Ok(sha256_hex(&bytes))
+}
+
+fn find_wasm(source: &std::path::Path) -> anyhow::Result<PathBuf> {
+    for target_triple in &["wasm32v1-none", "wasm32-unknown-unknown"] {
+        let dir = source.join(format!("target/{}/release", target_triple));
+        if !dir.exists() {
+            continue;
+        }
+        let entries: Vec<_> = std::fs::read_dir(&dir)
+            .with_context(|| format!("cannot read {}", dir.display()))?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map(|x| x == "wasm").unwrap_or(false))
+            .collect();
+        if !entries.is_empty() {
+            let best = entries
+                .iter()
+                .max_by_key(|e| e.metadata().map(|m| m.len()).unwrap_or(0))
+                .unwrap();
+            return Ok(best.path());
+        }
+    }
+    bail!("no .wasm artifact found under {}/target/*/release/", source.display());
+}
+
+fn fetch_remote_hash(contract_id: &str, network: &str) -> anyhow::Result<String> {
+    let out_path = std::env::temp_dir().join(format!("sanctifier-{contract_id}.wasm"));
+
+    for cli in &["stellar", "soroban"] {
+        let status = Command::new(cli)
+            .args([
+                "contract",
+                "fetch",
+                "--id",
+                contract_id,
+                "--network",
+                network,
+                "--output-file",
+            ])
+            .arg(&out_path)
+            .status();
+
+        if let Ok(s) = status {
+            if s.success() {
+                let bytes = std::fs::read(&out_path).with_context(|| {
+                    format!("failed to read fetched WASM: {}", out_path.display())
+                })?;
+                let _ = std::fs::remove_file(&out_path);
+                return Ok(sha256_hex(&bytes));
+            }
+        }
+    }
+
+    bail!(
+        "could not fetch on-chain WASM — ensure `stellar` or `soroban` CLI is installed \
+         and authenticated to the '{}' network",
+        network
+    );
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use std::num::Wrapping as W;
+
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+
+    let mut h: [W<u32>; 8] = [
+        W(0x6a09e667),
+        W(0xbb67ae85),
+        W(0x3c6ef372),
+        W(0xa54ff53a),
+        W(0x510e527f),
+        W(0x9b05688c),
+        W(0x1f83d9ab),
+        W(0x5be0cd19),
+    ];
+
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+    let mut msg = data.to_vec();
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in msg.chunks(64) {
+        let mut w = [W(0u32); 64];
+        for i in 0..16 {
+            w[i] = W(u32::from_be_bytes(chunk[i * 4..i * 4 + 4].try_into().unwrap()));
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].0.rotate_right(7)
+                ^ w[i - 15].0.rotate_right(18)
+                ^ (w[i - 15].0 >> 3);
+            let s1 =
+                w[i - 2].0.rotate_right(17) ^ w[i - 2].0.rotate_right(19) ^ (w[i - 2].0 >> 10);
+            w[i] = w[i - 16] + W(s0) + w[i - 7] + W(s1);
+        }
+
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
+        for i in 0..64 {
+            let s1 = e.0.rotate_right(6) ^ e.0.rotate_right(11) ^ e.0.rotate_right(25);
+            let ch = (e.0 & f.0) ^ ((!e.0) & g.0);
+            let temp1 = hh + W(s1) + W(ch) + W(K[i]) + w[i];
+            let s0 = a.0.rotate_right(2) ^ a.0.rotate_right(13) ^ a.0.rotate_right(22);
+            let maj = (a.0 & b.0) ^ (a.0 & c.0) ^ (b.0 & c.0);
+            let temp2 = W(s0) + W(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d + temp1;
+            d = c;
+            c = b;
+            b = a;
+            a = temp1 + temp2;
+        }
+        h[0] += a;
+        h[1] += b;
+        h[2] += c;
+        h[3] += d;
+        h[4] += e;
+        h[5] += f;
+        h[6] += g;
+        h[7] += hh;
+    }
+
+    h.iter()
+        .flat_map(|w| w.0.to_be_bytes())
+        .map(|b| format!("{:02x}", b))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_known_vector() {
+        let hex = sha256_hex(b"abc");
+        assert!(hex.starts_with("ba7816bf"), "got: {hex}");
+    }
+
+    #[test]
+    fn sha256_empty() {
+        let hex = sha256_hex(b"");
+        assert!(hex.starts_with("e3b0c442"), "got: {hex}");
+    }
+}

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -54,6 +54,8 @@ pub enum Commands {
     Reentrancy(commands::reentrancy::ReentrancyArgs),
     /// Verify local source against on-chain bytecode
     Verify(commands::verify::VerifyArgs),
+    /// Verify an on-chain deployment matches expected local source or a pinned hash
+    VerifyDeployment(commands::verify_deployment::VerifyDeploymentArgs),
     /// Analyze an entire Cargo workspace (multiple contracts/libs)
     Workspace(commands::workspace::WorkspaceArgs),
     /// Watch for file changes and auto-rerun analysis
@@ -120,6 +122,7 @@ fn run() -> anyhow::Result<()> {
         Commands::Upgrade(args) => commands::upgrade::exec(args),
         Commands::Reentrancy(args) => commands::reentrancy::exec(args),
         Commands::Verify(args) => commands::verify::exec(args),
+        Commands::VerifyDeployment(args) => commands::verify_deployment::exec(args),
         Commands::Workspace(args) => commands::workspace::exec(args),
         Commands::Watch(args) => commands::watch::exec(args),
         Commands::Completions { shell } => {

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -4,3 +4,4 @@ tsconfig.json
 .gitignore
 **/node_modules/**
 *.vsix
+out/test/**

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -48,6 +48,17 @@
           "type": "boolean",
           "default": true,
           "description": "If true, only activate in workspaces whose Cargo.toml references soroban-sdk."
+        },
+        "sanctifier.minSeverity": {
+          "type": "string",
+          "enum": ["error", "warning", "information"],
+          "enumDescriptions": [
+            "Show only errors.",
+            "Show warnings and errors (recommended).",
+            "Show all findings including informational hints."
+          ],
+          "default": "warning",
+          "description": "Minimum severity level to surface in the editor. Findings below this threshold are silently suppressed."
         }
       }
     },
@@ -55,13 +66,23 @@
       {
         "command": "sanctifier.analyzeWorkspace",
         "title": "Sanctifier: Analyze workspace with CLI (JSON)"
+      },
+      {
+        "command": "sanctifier.toggleEnable",
+        "title": "Sanctifier: Toggle enable/disable"
+      },
+      {
+        "command": "sanctifier.showOutput",
+        "title": "Sanctifier: Show output channel"
       }
     ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "test": "npm run compile && node --test out/test/analyzer.test.js",
+    "lint": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/vscode-extension/src/analyzer.ts
+++ b/vscode-extension/src/analyzer.ts
@@ -204,6 +204,22 @@ function analyzeArithmeticHeuristic(lines: string[], findings: EditorFinding[]):
   }
 }
 
+/** Numeric rank for severity comparison (higher = more severe). */
+export const SEVERITY_ORDER: Record<Severity, number> = {
+  information: 0,
+  warning: 1,
+  error: 2,
+};
+
+/**
+ * Returns only findings whose severity is >= minSeverity.
+ * Useful for the in-editor view and the workspace-scan command.
+ */
+export function filterBySeverity(findings: EditorFinding[], minSeverity: Severity): EditorFinding[] {
+  const threshold = SEVERITY_ORDER[minSeverity];
+  return findings.filter((f) => SEVERITY_ORDER[f.severity] >= threshold);
+}
+
 export function looksLikeSorobanSource(text: string): boolean {
   return (
     /#\s*\[\s*contractimpl\b/.test(text) ||

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,34 +1,22 @@
 import * as vscode from 'vscode';
-import { analyzeSorobanSource, looksLikeSorobanSource, type EditorFinding } from './analyzer';
+import { analyzeSorobanSource, looksLikeSorobanSource, filterBySeverity, type Severity } from './analyzer';
+import { type EditorFinding, type SanctifierExtensionApi } from './types';
+import { folderLooksLikeSorobanProject, invalidateWorkspaceCache } from './workspace';
 import { spawn } from 'child_process';
+import { existsSync } from 'fs';
 
 const SOURCE = 'sanctifier';
-
-let sorobanWorkspaceCache: boolean | null = null;
+const EXTENSION_VERSION: string = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return (require('../package.json') as { version: string }).version;
+  } catch {
+    return '0.0.0';
+  }
+})();
 
 function getConfig() {
   return vscode.workspace.getConfiguration('sanctifier');
-}
-
-async function workspaceLooksLikeSorobanProject(): Promise<boolean> {
-  if (sorobanWorkspaceCache !== null) {
-    return sorobanWorkspaceCache;
-  }
-  const files = await vscode.workspace.findFiles('**/Cargo.toml', '**/target/**', 40);
-  for (const uri of files) {
-    try {
-      const doc = await vscode.workspace.openTextDocument(uri);
-      const t = doc.getText();
-      if (/soroban-sdk|soroban_sdk/.test(t)) {
-        sorobanWorkspaceCache = true;
-        return true;
-      }
-    } catch {
-      /* skip */
-    }
-  }
-  sorobanWorkspaceCache = false;
-  return false;
 }
 
 function findingToDiagnostic(doc: vscode.TextDocument, f: EditorFinding): vscode.Diagnostic {
@@ -57,8 +45,34 @@ function findingToDiagnostic(doc: vscode.TextDocument, f: EditorFinding): vscode
   return d;
 }
 
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
+export async function activate(context: vscode.ExtensionContext): Promise<SanctifierExtensionApi> {
   const collection = vscode.languages.createDiagnosticCollection(SOURCE);
+  const outputChannel = vscode.window.createOutputChannel('Sanctifier');
+
+  /** Live snapshot of findings keyed by document URI string. */
+  const findingsCache = new Map<string, EditorFinding[]>();
+  /** Last-seen text per document — skip re-analysis when content is unchanged. */
+  const contentCache = new Map<string, string>();
+
+  const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
+  statusBar.command = 'sanctifier.toggleEnable';
+  statusBar.tooltip = 'Sanctifier — click to toggle';
+  context.subscriptions.push(statusBar, collection, outputChannel);
+
+  function updateStatusBar(): void {
+    const enabled = getConfig().get<boolean>('enable') ?? true;
+    if (!enabled) {
+      statusBar.text = '$(shield) Sanctifier: off';
+      statusBar.show();
+      return;
+    }
+    let total = 0;
+    for (const findings of findingsCache.values()) {
+      total += findings.length;
+    }
+    statusBar.text = total > 0 ? `$(shield) Sanctifier: ${total}` : '$(shield) Sanctifier';
+    statusBar.show();
+  }
 
   const debouncers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -69,24 +83,44 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const cfg = getConfig();
     if (!cfg.get<boolean>('enable')) {
       collection.delete(doc.uri);
+      findingsCache.delete(doc.uri.toString());
+      updateStatusBar();
       return;
     }
     const text = doc.getText();
     if (!looksLikeSorobanSource(text)) {
       collection.delete(doc.uri);
+      findingsCache.delete(doc.uri.toString());
+      updateStatusBar();
       return;
     }
 
-    const findings = analyzeSorobanSource(text);
+    const key = doc.uri.toString();
+    if (contentCache.get(key) === text) {
+      return;
+    }
+    contentCache.set(key, text);
+
+    const minSeverity = (cfg.get<string>('minSeverity') ?? 'warning') as Severity;
+    const allFindings = analyzeSorobanSource(text);
+    const findings = filterBySeverity(allFindings, minSeverity);
+
+    findingsCache.set(doc.uri.toString(), findings);
     const diags = findings.map((f) => findingToDiagnostic(doc, f));
     collection.set(doc.uri, diags);
+    updateStatusBar();
   };
 
   const schedule = (doc: vscode.TextDocument) => {
     const onlySorobanWs = getConfig().get<boolean>('onlyInSorobanWorkspace');
-    if (onlySorobanWs && !vscode.workspace.workspaceFolders?.length) {
-      collection.delete(doc.uri);
-      return;
+    if (onlySorobanWs) {
+      const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+      if (!folder) {
+        collection.delete(doc.uri);
+        findingsCache.delete(doc.uri.toString());
+        updateStatusBar();
+        return;
+      }
     }
     const ms = getConfig().get<number>('debounceMs') ?? 400;
     const key = doc.uri.toString();
@@ -100,9 +134,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         debouncers.delete(key);
         const requireSoroban = getConfig().get<boolean>('onlyInSorobanWorkspace');
         if (requireSoroban) {
-          const ok = await workspaceLooksLikeSorobanProject();
+          const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+          if (!folder) {
+            collection.delete(doc.uri);
+            findingsCache.delete(doc.uri.toString());
+            updateStatusBar();
+            return;
+          }
+          const ok = await folderLooksLikeSorobanProject(folder);
           if (!ok) {
             collection.delete(doc.uri);
+            findingsCache.delete(doc.uri.toString());
+            updateStatusBar();
             return;
           }
         }
@@ -112,16 +155,29 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   };
 
   context.subscriptions.push(
-    collection,
     vscode.workspace.onDidChangeTextDocument((e) => schedule(e.document)),
     vscode.workspace.onDidOpenTextDocument((d) => schedule(d)),
     vscode.workspace.onDidCloseTextDocument((d) => {
+      const k = d.uri.toString();
       collection.delete(d.uri);
-      debouncers.delete(d.uri.toString());
+      findingsCache.delete(k);
+      contentCache.delete(k);
+      debouncers.delete(k);
+      updateStatusBar();
+    }),
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      invalidateWorkspaceCache();
+      contentCache.clear();
+      findingsCache.clear();
+      for (const doc of vscode.workspace.textDocuments) {
+        schedule(doc);
+      }
     }),
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration('sanctifier')) {
-        sorobanWorkspaceCache = null;
+        invalidateWorkspaceCache();
+        contentCache.clear();
+        findingsCache.clear();
         for (const doc of vscode.workspace.textDocuments) {
           schedule(doc);
         }
@@ -132,6 +188,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   for (const doc of vscode.workspace.textDocuments) {
     schedule(doc);
   }
+
+  // ── Commands ────────────────────────────────────────────────────────────────
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('sanctifier.toggleEnable', async () => {
+      const cfg = getConfig();
+      const current = cfg.get<boolean>('enable') ?? true;
+      await cfg.update('enable', !current, vscode.ConfigurationTarget.Global);
+      vscode.window.showInformationMessage(
+        `Sanctifier is now ${!current ? 'enabled' : 'disabled'}.`
+      );
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('sanctifier.showOutput', () => {
+      outputChannel.show(true);
+    })
+  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand('sanctifier.analyzeWorkspace', async () => {
@@ -147,30 +222,84 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.window.showErrorMessage('Open a folder to analyze.');
         return;
       }
-      const token = await new Promise<string | undefined>((resolve) => {
-        const p = spawn(exe, ['analyze', folder.uri.fsPath, '--format', 'json'], {
-          cwd: folder.uri.fsPath,
-        });
-        let out = '';
-        let err = '';
-        p.stdout.on('data', (b) => (out += b.toString()));
-        p.stderr.on('data', (b) => (err += b.toString()));
-        p.on('close', () => resolve(out || undefined));
-        p.on('error', () => resolve(undefined));
-      });
-      if (!token) {
-        vscode.window.showErrorMessage('sanctifier CLI failed or produced no output. Check sanctifierPath.');
+
+      // Remote workspaces (SSH, Codespaces, WSL) use non-file URIs; the CLI
+      // must run on the same machine as the source files.
+      if (folder.uri.scheme !== 'file') {
+        vscode.window.showErrorMessage(
+          'Sanctifier workspace analysis requires a local folder. ' +
+          'Remote workspaces (SSH / Codespaces / WSL) are not yet supported — ' +
+          'install the CLI on the remote host and run it from the integrated terminal.'
+        );
         return;
       }
-      const doc = await vscode.workspace.openTextDocument({
-        content: token,
-        language: 'json',
+
+      if (!existsSync(exe)) {
+        vscode.window.showErrorMessage(
+          `sanctifier CLI not found at "${exe}". ` +
+          'Check the sanctifier.sanctifierPath setting and ensure the binary is installed.'
+        );
+        return;
+      }
+
+      outputChannel.clear();
+      outputChannel.show(true);
+      outputChannel.appendLine(`[sanctifier] Scanning ${folder.uri.fsPath} …`);
+
+      const minSeverity = (getConfig().get<string>('minSeverity') ?? 'warning') as Severity;
+
+      const output = await new Promise<string | undefined>((resolve) => {
+        const p = spawn(
+          exe,
+          ['analyze', folder.uri.fsPath, '--format', 'json', '--min-severity', minSeverity],
+          { cwd: folder.uri.fsPath }
+        );
+        let out = '';
+        let err = '';
+        p.stdout.on('data', (b: Buffer) => (out += b.toString()));
+        p.stderr.on('data', (b: Buffer) => (err += b.toString()));
+        p.on('close', (code) => {
+          if (err) {
+            outputChannel.appendLine(`[sanctifier][stderr] ${err.trim()}`);
+          }
+          if (code !== 0 && !out) {
+            outputChannel.appendLine(`[sanctifier] CLI exited with code ${code}.`);
+            resolve(undefined);
+          } else {
+            resolve(out || undefined);
+          }
+        });
+        p.on('error', (e) => {
+          outputChannel.appendLine(`[sanctifier][error] ${e.message}`);
+          resolve(undefined);
+        });
       });
-      await vscode.window.showTextDocument(doc, { preview: true });
+
+      if (!output) {
+        vscode.window.showErrorMessage(
+          'sanctifier CLI produced no output. Check sanctifierPath and the output channel.'
+        );
+        return;
+      }
+
+      outputChannel.appendLine(output);
+      outputChannel.appendLine('[sanctifier] Scan complete.');
     })
   );
+
+  updateStatusBar();
+
+  // ── Public API (stable) ──────────────────────────────────────────────────────
+  const api: SanctifierExtensionApi = {
+    version: EXTENSION_VERSION,
+    getFindings(documentUri: string): EditorFinding[] {
+      return findingsCache.get(documentUri) ?? [];
+    },
+  };
+
+  return api;
 }
 
 export function deactivate(): void {
-  sorobanWorkspaceCache = null;
+  invalidateWorkspaceCache();
 }

--- a/vscode-extension/src/test/analyzer.test.ts
+++ b/vscode-extension/src/test/analyzer.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as path from 'path';
+import { analyzeSorobanSource, looksLikeSorobanSource, CODES, filterBySeverity, SEVERITY_ORDER } from '../analyzer';
+
+// Fixtures live in src/test/fixtures; resolve from compiled output location
+const fixturesDir = path.join(__dirname, '..', '..', 'src', 'test', 'fixtures');
+
+function fixture(name: string): string {
+  return fs.readFileSync(path.join(fixturesDir, name), 'utf8');
+}
+
+describe('looksLikeSorobanSource', () => {
+  it('detects #[contractimpl] attribute', () => {
+    assert.ok(looksLikeSorobanSource('#[contractimpl]\nimpl Foo {}'));
+  });
+
+  it('detects soroban_sdk crate usage', () => {
+    assert.ok(looksLikeSorobanSource('use soroban_sdk::Env;'));
+  });
+
+  it('detects #[contract] attribute', () => {
+    assert.ok(looksLikeSorobanSource('#[contract]\nstruct Foo;'));
+  });
+
+  it('returns false for plain Rust with no Soroban markers', () => {
+    assert.ok(!looksLikeSorobanSource('fn main() {\n  println!("hello");\n}'));
+  });
+});
+
+describe('analyzeSorobanSource — auth gap (S001)', () => {
+  it('flags a privileged fn missing require_auth', () => {
+    const src = fixture('auth_gap.rs');
+    const findings = analyzeSorobanSource(src);
+    assert.ok(
+      findings.some((f) => f.code === CODES.AUTH_GAP),
+      `expected S001 finding; got: ${JSON.stringify(findings)}`
+    );
+  });
+
+  it('does not flag when require_auth is present', () => {
+    const src = fixture('safe_contract.rs');
+    const findings = analyzeSorobanSource(src);
+    assert.ok(
+      !findings.some((f) => f.code === CODES.AUTH_GAP),
+      `unexpected S001 finding; got: ${JSON.stringify(findings)}`
+    );
+  });
+});
+
+describe('analyzeSorobanSource — unsafe patterns (S002 / S006)', () => {
+  it('flags panic! with S002', () => {
+    const src = fixture('panic_contract.rs');
+    const findings = analyzeSorobanSource(src);
+    assert.ok(
+      findings.some((f) => f.code === CODES.PANIC_USAGE),
+      `expected S002; got: ${JSON.stringify(findings)}`
+    );
+  });
+
+  it('flags .unwrap() with S006', () => {
+    const src = fixture('panic_contract.rs');
+    const findings = analyzeSorobanSource(src);
+    assert.ok(
+      findings.some((f) => f.code === CODES.UNSAFE_PATTERN),
+      `expected S006; got: ${JSON.stringify(findings)}`
+    );
+  });
+
+  it('does not flag commented-out unwrap', () => {
+    const src = '// let x = val.unwrap();\nfn safe() {}';
+    const findings = analyzeSorobanSource(src);
+    assert.ok(!findings.some((f) => f.code === CODES.UNSAFE_PATTERN));
+  });
+});
+
+describe('analyzeSorobanSource — arithmetic overflow (S003)', () => {
+  it('flags unchecked arithmetic inside contractimpl', () => {
+    const src = fixture('overflow_contract.rs');
+    const findings = analyzeSorobanSource(src);
+    assert.ok(
+      findings.some((f) => f.code === CODES.ARITHMETIC_OVERFLOW),
+      `expected S003; got: ${JSON.stringify(findings)}`
+    );
+  });
+
+  it('does not flag checked_add', () => {
+    const src = fixture('overflow_contract.rs');
+    const findings = analyzeSorobanSource(src);
+    const overflowFindings = findings.filter((f) => f.code === CODES.ARITHMETIC_OVERFLOW);
+    const lines = src.split('\n');
+    for (const f of overflowFindings) {
+      const lineText = lines[f.line - 1] ?? '';
+      assert.ok(
+        !lineText.includes('checked_'),
+        `S003 should not fire on a line containing checked_: "${lineText}"`
+      );
+    }
+  });
+
+  it('does not flag arithmetic outside contractimpl', () => {
+    const src = 'fn helper(a: i128, b: i128) -> i128 { a + b }';
+    const findings = analyzeSorobanSource(src);
+    assert.ok(!findings.some((f) => f.code === CODES.ARITHMETIC_OVERFLOW));
+  });
+});
+
+describe('analyzeSorobanSource — deduplication', () => {
+  it('does not emit duplicate findings for the same line and code', () => {
+    const src = [
+      'use soroban_sdk::contractimpl;',
+      'struct C;',
+      '#[contractimpl]',
+      'impl C {',
+      '  pub fn bad(a: i128, b: i128) -> i128 { a + b }',
+      '}',
+    ].join('\n');
+    const findings = analyzeSorobanSource(src);
+    const keys = findings.map((f) => `${f.line}:${f.code}:${f.message.slice(0, 40)}`);
+    const unique = new Set(keys);
+    assert.strictEqual(keys.length, unique.size, 'duplicate findings detected');
+  });
+});
+
+describe('SEVERITY_ORDER', () => {
+  it('ranks information < warning < error', () => {
+    assert.ok(SEVERITY_ORDER.information < SEVERITY_ORDER.warning);
+    assert.ok(SEVERITY_ORDER.warning < SEVERITY_ORDER.error);
+  });
+});
+
+describe('filterBySeverity', () => {
+  const mixed = [
+    { line: 1, code: 'S002', severity: 'error' as const, message: 'panic' },
+    { line: 2, code: 'S001', severity: 'warning' as const, message: 'auth gap' },
+    { line: 3, code: 'S003', severity: 'information' as const, message: 'hint' },
+  ];
+
+  it('passes all findings when minSeverity is information', () => {
+    assert.strictEqual(filterBySeverity(mixed, 'information').length, 3);
+  });
+
+  it('drops information-level findings when minSeverity is warning', () => {
+    const result = filterBySeverity(mixed, 'warning');
+    assert.strictEqual(result.length, 2);
+    assert.ok(result.every((f) => f.severity !== 'information'));
+  });
+
+  it('keeps only errors when minSeverity is error', () => {
+    const result = filterBySeverity(mixed, 'error');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].code, 'S002');
+  });
+
+  it('returns empty array when no findings meet threshold', () => {
+    const infoOnly = [{ line: 1, code: 'S003', severity: 'information' as const, message: 'hint' }];
+    assert.deepStrictEqual(filterBySeverity(infoOnly, 'error'), []);
+  });
+
+  it('returns empty array for empty input', () => {
+    assert.deepStrictEqual(filterBySeverity([], 'warning'), []);
+  });
+});

--- a/vscode-extension/src/test/fixtures/auth_gap.rs
+++ b/vscode-extension/src/test/fixtures/auth_gap.rs
@@ -1,0 +1,10 @@
+use soroban_sdk::{contractimpl, Env};
+
+struct MyContract;
+
+#[contractimpl]
+impl MyContract {
+    pub fn transfer(env: Env) {
+        env.storage().persistent().set(&"balance", &100i128);
+    }
+}

--- a/vscode-extension/src/test/fixtures/overflow_contract.rs
+++ b/vscode-extension/src/test/fixtures/overflow_contract.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contractimpl, Env};
+
+struct MyContract;
+
+#[contractimpl]
+impl MyContract {
+    pub fn add(env: Env, a: i128, b: i128) -> i128 {
+        a + b
+    }
+
+    pub fn safe_add(env: Env, a: i128, b: i128) -> Option<i128> {
+        a.checked_add(b)
+    }
+}

--- a/vscode-extension/src/test/fixtures/panic_contract.rs
+++ b/vscode-extension/src/test/fixtures/panic_contract.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::{contractimpl, Env};
+
+struct MyContract;
+
+#[contractimpl]
+impl MyContract {
+    pub fn divide(env: Env, a: i128, b: i128) -> i128 {
+        if b == 0 {
+            panic!("division by zero");
+        }
+        a / b
+    }
+
+    pub fn unwrap_val(env: Env) -> i128 {
+        let val: Option<i128> = None;
+        val.unwrap()
+    }
+}

--- a/vscode-extension/src/test/fixtures/safe_contract.rs
+++ b/vscode-extension/src/test/fixtures/safe_contract.rs
@@ -1,0 +1,11 @@
+use soroban_sdk::{contractimpl, Address, Env};
+
+struct MyContract;
+
+#[contractimpl]
+impl MyContract {
+    pub fn transfer(env: Env, from: Address) {
+        from.require_auth();
+        env.storage().persistent().set(&"balance", &100i128);
+    }
+}

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1,0 +1,16 @@
+export { CODES, SEVERITY_ORDER, type Severity, type EditorFinding, filterBySeverity } from './analyzer';
+
+/**
+ * Stable public API vended by the extension's activate() return value.
+ * Other extensions can consume it via:
+ *   const api = vscode.extensions.getExtension<SanctifierExtensionApi>('sanctifier.sanctifier-soroban')?.exports;
+ */
+export interface SanctifierExtensionApi {
+  /** Extension version from package.json. */
+  readonly version: string;
+  /**
+   * Returns the current in-editor findings for a document URI string.
+   * Returns an empty array if the document is not tracked or the extension is disabled.
+   */
+  getFindings(documentUri: string): import('./analyzer').EditorFinding[];
+}

--- a/vscode-extension/src/workspace.ts
+++ b/vscode-extension/src/workspace.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+
+const folderCache = new Map<string, boolean>();
+
+export function invalidateWorkspaceCache(): void {
+  folderCache.clear();
+}
+
+export async function folderLooksLikeSorobanProject(
+  folder: vscode.WorkspaceFolder
+): Promise<boolean> {
+  const key = folder.uri.toString();
+  const cached = folderCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const pattern = new vscode.RelativePattern(folder, '**/Cargo.toml');
+  const files = await vscode.workspace.findFiles(pattern, '**/target/**', 40);
+  for (const uri of files) {
+    try {
+      const doc = await vscode.workspace.openTextDocument(uri);
+      if (/soroban-sdk|soroban_sdk/.test(doc.getText())) {
+        folderCache.set(key, true);
+        return true;
+      }
+    } catch {
+      /* skip unreadable files */
+    }
+  }
+  folderCache.set(key, false);
+  return false;
+}


### PR DESCRIPTION
## Summary

- **#616** – Refactored vscode-extension for clearer module boundaries: extracted shared types/utilities to `src/types.ts` and per-folder workspace detection to `src/workspace.ts`; replaced global boolean cache with per-folder `Map<string, boolean>` for proper multi-root workspace support
- **#613** – Added unit tests (`src/test/analyzer.test.ts`) using Node's built-in `node:test` runner with `.rs` fixture files covering S001 auth-gap, S002 panic, S006 unwrap, S003 arithmetic overflow, deduplication, and severity filtering (19 tests, all passing)
- **#623** – Wired `test` and `lint` scripts in `package.json` so the existing CI workflow (`vscode-extension-ci.yml`) now runs tests and type-checks on ubuntu/windows/macos with Node 24
- **#738** – Added `sanctifier verify-deployment` CLI subcommand: hashes local WASM (via `stellar contract build` or cargo fallback) and compares against on-chain WASM fetched with `stellar`/`soroban` CLI; supports `--expected-hash` to skip local build and `--format json` for machine-readable output

## Test plan

- [ ] `cd vscode-extension && npm ci && npm run compile && npm test` — 19 unit tests pass
- [ ] `npm run lint` — no TypeScript errors
- [ ] `cargo check -p sanctifier-cli` — compiles without errors
- [ ] `cargo test -p sanctifier-cli` — sha256 unit tests pass
- [ ] CI green on ubuntu-latest, windows-latest, macos-latest

Closes #616, Closes #623, Closes #613, Closes #738