### PR TITLE
fix(cli): Resolve issues 530, 531, 532, 533

### DIFF
--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -586,8 +586,12 @@ pub(crate) fn load_config(path: &Path) -> SanctifyConfig {
         let config_path = current.join(".sanctify.toml");
         if config_path.exists() {
             if let Ok(content) = fs::read_to_string(&config_path) {
-                if let Ok(config) = toml::from_str(&content) {
-                    return config;
+                match toml::from_str(&content) {
+                    Ok(config) => return config,
+                    Err(e) => {
+                        eprintln!("Error: Invalid configuration file at {}\n{}", config_path.display(), e);
+                        std::process::exit(1);
+                    }
                 }
             }
         }

--- a/tooling/sanctifier-cli/src/commands/benchmark.rs
+++ b/tooling/sanctifier-cli/src/commands/benchmark.rs
@@ -31,6 +31,14 @@ pub struct BenchmarkArgs {
     /// Save the raw timing data as JSON to this path for future `--baseline` use.
     #[arg(short, long)]
     pub output: Option<PathBuf>,
+
+    /// Fail if any rule's p95 exceeds this budget in milliseconds.
+    #[arg(long)]
+    pub budget_ms: Option<f64>,
+
+    /// Opt-in to anonymous telemetry reporting for this benchmark run
+    #[arg(long)]
+    pub telemetry: bool,
 }
 
 /// Per-rule timing data stored in the JSON snapshot.
@@ -137,11 +145,34 @@ pub fn exec(args: BenchmarkArgs) -> anyhow::Result<()> {
             generated_at,
             corpus_path: args.corpus.display().to_string(),
             iterations,
-            rules: timings,
+            rules: timings.clone(),
         };
         let json = serde_json::to_string_pretty(&snapshot)?;
         fs::write(out_path, json)?;
         eprintln!("Saved benchmark snapshot to {}", out_path.display());
+    }
+
+    if args.telemetry {
+        let total_mean: f64 = timings.iter().map(|t| t.mean_ms).sum();
+        let payload = crate::telemetry::AnalysisTelemetry {
+            tool_version: crate::telemetry::sanitize_version(env!("CARGO_PKG_VERSION")),
+            duration_ms: total_mean.round() as u64,
+            rule_ids: timings.iter().map(|t| t.rule.clone()).collect(),
+        };
+        if let Err(e) = crate::telemetry::emit_analysis_telemetry(&payload) {
+            eprintln!("Warning: Failed to submit telemetry: {}", e);
+        }
+    }
+
+    if let Some(budget) = args.budget_ms {
+        let exceeded: Vec<_> = timings.iter().filter(|t| t.p95_ms > budget).collect();
+        if !exceeded.is_empty() {
+            eprintln!("\nError: The following rules exceeded the p95 budget of {:.2}ms:", budget);
+            for t in exceeded {
+                eprintln!("  - {}: {:.2}ms", t.rule, t.p95_ms);
+            }
+            std::process::exit(1);
+        }
     }
 
     Ok(())

--- a/tooling/sanctifier-cli/src/commands/storage.rs
+++ b/tooling/sanctifier-cli/src/commands/storage.rs
@@ -162,11 +162,15 @@ fn load_config(path: &Path) -> anyhow::Result<SanctifyConfig> {
     loop {
         let config_path = current.join(".sanctify.toml");
         if config_path.exists() {
-            let content = fs::read_to_string(&config_path)
-                .with_context(|| format!("failed to read {}", config_path.display()))?;
-            let config = toml::from_str(&content)
-                .map_err(|error| anyhow!("failed to parse {}: {}", config_path.display(), error))?;
-            return Ok(config);
+            if let Ok(content) = fs::read_to_string(&config_path) {
+                match toml::from_str(&content) {
+                    Ok(config) => return Ok(config),
+                    Err(e) => {
+                        eprintln!("Error: Invalid configuration file at {}\n{}", config_path.display(), e);
+                        std::process::exit(1);
+                    }
+                }
+            }
         }
 
         if !current.pop() {

--- a/tooling/sanctifier-cli/src/commands/workspace.rs
+++ b/tooling/sanctifier-cli/src/commands/workspace.rs
@@ -367,8 +367,12 @@ fn load_config_for(path: &Path) -> SanctifyConfig {
         let config_path = current.join(".sanctify.toml");
         if config_path.exists() {
             if let Ok(content) = fs::read_to_string(&config_path) {
-                if let Ok(config) = toml::from_str(&content) {
-                    return config;
+                match toml::from_str(&content) {
+                    Ok(config) => return config,
+                    Err(e) => {
+                        eprintln!("Error: Invalid configuration file at {}\n{}", config_path.display(), e);
+                        std::process::exit(1);
+                    }
                 }
             }
         }

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -18,7 +18,11 @@ pub mod vulndb;
 struct Cli {
     /// Disable coloured output (also respects NO_COLOR env var)
     #[arg(long, global = true)]
-    no_color: bool,
+    pub no_color: bool,
+
+    /// Opt-in to anonymous telemetry reporting for this invocation
+    #[arg(long, global = true)]
+    pub telemetry: bool,
 
     #[command(subcommand)]
     command: Commands,

--- a/tooling/sanctifier-cli/tests/cli_tests.rs
+++ b/tooling/sanctifier-cli/tests/cli_tests.rs
@@ -958,3 +958,43 @@ impl VulnerableContract {
         "Should mention 3 Address parameters"
     );
 }
+
+#[test]
+fn test_analyze_with_invalid_config_fails() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".sanctify.toml");
+    fs::write(&config_path, "invalid_toml = [").unwrap();
+
+    let mut cmd = Command::cargo_bin("sanctifier").unwrap();
+    cmd.current_dir(dir.path())
+        .arg("analyze")
+        .arg("some_file.rs")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Invalid configuration file"));
+}
+
+#[test]
+fn test_benchmark_budget_exceeded() {
+    let dir = tempdir().unwrap();
+    let src_path = dir.path().join("lib.rs");
+    fs::write(&src_path, "pub fn foo() {}").unwrap();
+
+    let mut cmd = Command::cargo_bin("sanctifier").unwrap();
+    cmd.arg("benchmark")
+        .arg(dir.path())
+        .arg("--budget-ms")
+        .arg("0.0000001") // guaranteed to fail
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("exceeded the p95 budget"));
+}
+
+#[test]
+fn test_telemetry_flag_parses() {
+    let mut cmd = Command::cargo_bin("sanctifier").unwrap();
+    cmd.arg("--telemetry")
+        .arg("--help")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
# Fix CLI UX/DX, Security Hardening, and Telemetry

This PR groups several improvements to the `sanctifier-cli` component to harden the CLI, improve diagnostics, and stabilize behavior.

## Changes Included
- **Config Validation (Line/Column errors) (#531)**: `.sanctify.toml` parse errors no longer fall back silently. They now emit line and column details to `stderr` and safely exit with a non-zero status code across `analyze`, `workspace`, and `storage` commands.
- **Benchmarks & Budgeting (#533 & #530)**: Added a `--budget-ms` flag to the `benchmark` command that causes the CLI to exit with an error if the 95th percentile duration of any rule exceeds the threshold. Also integrated the `--telemetry` flag to allow opting into telemetry submissions on demand.
- **Integration Tests (#532)**: Added test cases targeting the invalid TOML config failures, benchmark budgets, and global CLI argument parsing.

Closes #530
Closes #531
Closes #532
Closes #533
