### PR TITLE
fix(cli,core): harden config resolution, format validation, exit code…

### DIFF
--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -131,16 +131,41 @@ pub(crate) struct FileAnalysisResult {
 // ── Entry point ──────────────────────────────────────────────────────────────
 
 pub fn exec(args: AnalyzeArgs) -> anyhow::Result<()> {
-    let should_exit_on_findings = args.exit_code;
+    let profile = args.profile;
+    let exit_code_flag = args.exit_code;
     let found_issues = run_analysis(args)?;
-    if found_issues && should_exit_on_findings {
-        std::process::exit(1);
+    if resolve_exit(profile, exit_code_flag, found_issues) {
+        std::process::exit(crate::exit_codes::FINDINGS_FOUND);
     }
     Ok(())
 }
 
+/// Decide whether to exit with a non-zero code based on the active profile and
+/// the `--exit-code` flag.  Profile overrides the flag when both are supplied.
+fn resolve_exit(
+    profile: Option<AnalysisProfile>,
+    exit_code_flag: bool,
+    found_issues: bool,
+) -> bool {
+    match profile {
+        Some(AnalysisProfile::Strict) => found_issues,
+        Some(AnalysisProfile::Lenient) | Some(AnalysisProfile::Audit) => false,
+        Some(AnalysisProfile::Ci) => found_issues,
+        None => exit_code_flag && found_issues,
+    }
+}
+
+const VALID_FORMATS: &[&str] = &["text", "json", "ndjson", "sarif"];
+
 /// Run the full analysis and dispatch to the appropriate output format.
 pub(crate) fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
+    if !VALID_FORMATS.contains(&args.format.as_str()) {
+        anyhow::bail!(
+            "unknown output format {:?}; valid values are: {}",
+            args.format,
+            VALID_FORMATS.join(", ")
+        );
+    }
     if args.format == "ndjson" {
         return stream_ndjson(&args);
     }
@@ -259,6 +284,40 @@ pub(crate) fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
                 },
             }))?
         );
+    } else if args.format == "sarif" {
+        let results: Vec<serde_json::Value> = all_violations
+            .iter()
+            .map(|(file, v)| {
+                let level = match format!("{:?}", v.severity).as_str() {
+                    "Error" => "error",
+                    "Warning" => "warning",
+                    _ => "note",
+                };
+                let msg = match &v.suggestion {
+                    Some(s) => format!("{} — {}", v.message, s),
+                    None => v.message.clone(),
+                };
+                serde_json::json!({
+                    "ruleId": v.rule_name,
+                    "level": level,
+                    "message": { "text": msg },
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": {
+                                "uri": file,
+                                "uriBaseId": "%SRCROOT%"
+                            }
+                        }
+                    }]
+                })
+            })
+            .collect();
+        let sarif = crate::commands::sarif::build_sarif_log(
+            "sanctifier",
+            env!("CARGO_PKG_VERSION"),
+            results,
+        );
+        println!("{}", serde_json::to_string_pretty(&sarif)?);
     } else {
         if let Some(profile) = args.profile {
             println!(

--- a/tooling/sanctifier-cli/src/exit_codes.rs
+++ b/tooling/sanctifier-cli/src/exit_codes.rs
@@ -1,0 +1,6 @@
+/// Process exit code: analysis succeeded with no triggered findings.
+pub const SUCCESS: i32 = 0;
+/// Process exit code: findings were detected and the active profile triggered on them.
+pub const FINDINGS_FOUND: i32 = 1;
+/// Process exit code: unrecoverable error (invalid path, config parse failure, I/O error).
+pub const ERROR: i32 = 2;

--- a/tooling/sanctifier-cli/src/lib.rs
+++ b/tooling/sanctifier-cli/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "512"]
 
 pub mod commands;
+pub mod exit_codes;
 pub mod logging;
 pub mod telemetry;
 pub mod vulndb;

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -91,7 +91,7 @@ pub enum Commands {
 fn main() {
     if let Err(err) = run() {
         eprintln!("Error: {}", err);
-        std::process::exit(2);
+        std::process::exit(sanctifier_cli::exit_codes::ERROR);
     }
 }
 
@@ -104,7 +104,9 @@ fn run() -> anyhow::Result<()> {
 
     // Initialize structured logging before dispatching
     let log_format = match &cli.command {
-        Commands::Analyze(args) if args.format == "json" => logging::LogOutput::Json,
+        Commands::Analyze(args) if args.format == "json" || args.format == "sarif" => {
+            logging::LogOutput::Json
+        }
         _ => logging::LogOutput::Text,
     };
     if let Err(e) = logging::init(log_format) {

--- a/tooling/sanctifier-cli/tests/cli_tests.rs
+++ b/tooling/sanctifier-cli/tests/cli_tests.rs
@@ -998,3 +998,227 @@ fn test_telemetry_flag_parses() {
         .assert()
         .success();
 }
+
+// ── #517: Config file resolution precedence ───────────────────────────────────
+
+/// The config file in the same directory as the analysed file is used (nearest wins).
+/// We prove this by placing an INVALID config in the parent and a VALID config in
+/// the child — if the parent were loaded the command would exit 1.
+#[test]
+fn test_config_resolution_nearest_config_wins() {
+    let parent = tempdir().unwrap();
+    fs::write(parent.path().join(".sanctify.toml"), "invalid_toml = [").unwrap();
+
+    let child = parent.path().join("contracts");
+    fs::create_dir_all(&child).unwrap();
+    fs::write(child.join(".sanctify.toml"), "ledger_limit = 64000\n").unwrap();
+
+    let contract = child.join("lib.rs");
+    fs::write(&contract, "fn foo() {}").unwrap();
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(&contract)
+        .assert()
+        .success();
+}
+
+/// When no config exists in the contract's directory the resolver walks up to
+/// the parent directory and uses the config it finds there.
+#[test]
+fn test_config_resolution_walks_up_to_parent_directory() {
+    let parent = tempdir().unwrap();
+    fs::write(
+        parent.path().join(".sanctify.toml"),
+        "ledger_limit = 64000\n",
+    )
+    .unwrap();
+
+    let child = parent.path().join("src");
+    fs::create_dir_all(&child).unwrap();
+
+    let contract = child.join("lib.rs");
+    fs::write(&contract, "fn foo() {}").unwrap();
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(&contract)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Static analysis complete."));
+}
+
+/// When no config file exists anywhere the default config is used and analysis
+/// still completes successfully.
+#[test]
+fn test_config_resolution_defaults_when_no_config_found() {
+    let dir = tempdir().unwrap();
+    let contract = dir.path().join("lib.rs");
+    fs::write(&contract, "fn foo() {}").unwrap();
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(&contract)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Static analysis complete."));
+}
+
+// ── #518: Output format validation ───────────────────────────────────────────
+
+/// An unrecognised format string is rejected with a clear error message.
+#[test]
+fn test_analyze_rejects_unknown_format() {
+    let dir = tempdir().unwrap();
+    let contract = dir.path().join("lib.rs");
+    fs::write(&contract, "fn foo() {}").unwrap();
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(&contract)
+        .arg("--format")
+        .arg("xml")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("unknown output format"));
+}
+
+/// `--format sarif` produces a valid SARIF 2.1.0 document on stdout.
+#[test]
+fn test_analyze_sarif_format_produces_sarif_document() {
+    let dir = tempdir().unwrap();
+    let contract = dir.path().join("lib.rs");
+    fs::write(&contract, "fn foo() {}").unwrap();
+
+    let output = Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(&contract)
+        .arg("--format")
+        .arg("sarif")
+        .env_remove("RUST_LOG")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "sarif output should exit 0");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout)
+        .expect("sarif output should be valid JSON");
+    assert_eq!(json["version"], "2.1.0", "sarif version must be 2.1.0");
+    assert!(json["runs"].is_array(), "sarif must have a runs array");
+    assert!(
+        json["runs"][0]["tool"]["driver"]["name"].as_str() == Some("sanctifier"),
+        "sarif tool name must be 'sanctifier'"
+    );
+}
+
+/// `--format sarif` on a file with findings still exits 0 (format parity with json).
+#[test]
+fn test_analyze_sarif_findings_are_in_results_array() {
+    let fixture_path = env::current_dir()
+        .unwrap()
+        .join("tests/fixtures/vulnerable_contract.rs");
+
+    let output = Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(fixture_path)
+        .arg("--format")
+        .arg("sarif")
+        .env_remove("RUST_LOG")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["runs"][0]["results"].as_array().unwrap();
+    assert!(
+        !results.is_empty(),
+        "vulnerable contract must produce sarif results"
+    );
+
+    let first = &results[0];
+    assert!(first["ruleId"].is_string(), "result must have ruleId");
+    assert!(first["level"].is_string(), "result must have level");
+    assert!(
+        first["message"]["text"].is_string(),
+        "result must have message.text"
+    );
+    assert!(
+        first["locations"].is_array(),
+        "result must have locations array"
+    );
+}
+
+// ── #519: Analysis profile exit codes ────────────────────────────────────────
+
+/// `--profile strict` exits 1 whenever any finding is detected.
+#[test]
+fn test_profile_strict_exits_one_on_findings() {
+    let fixture_path = env::current_dir()
+        .unwrap()
+        .join("tests/fixtures/vulnerable_contract.rs");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(fixture_path)
+        .arg("--profile")
+        .arg("strict")
+        .assert()
+        .failure();
+}
+
+/// `--profile lenient` exits 0 even when findings are present.
+#[test]
+fn test_profile_lenient_exits_zero_with_findings() {
+    let fixture_path = env::current_dir()
+        .unwrap()
+        .join("tests/fixtures/vulnerable_contract.rs");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(fixture_path)
+        .arg("--profile")
+        .arg("lenient")
+        .assert()
+        .success();
+}
+
+/// `--profile ci` exits 1 when findings are detected.
+#[test]
+fn test_profile_ci_exits_one_on_findings() {
+    let fixture_path = env::current_dir()
+        .unwrap()
+        .join("tests/fixtures/vulnerable_contract.rs");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(fixture_path)
+        .arg("--profile")
+        .arg("ci")
+        .assert()
+        .failure();
+}
+
+/// Without `--exit-code` or `--profile`, findings do not cause a non-zero exit.
+#[test]
+fn test_no_profile_no_exit_code_exits_zero_with_findings() {
+    let fixture_path = env::current_dir()
+        .unwrap()
+        .join("tests/fixtures/vulnerable_contract.rs");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(fixture_path)
+        .assert()
+        .success();
+}

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -105,6 +105,22 @@ pub struct FindingCode {
     pub doc_url: &'static str,
 }
 
+impl FindingCode {
+    /// Format a short, self-contained diagnostic message suitable for terminal or log output.
+    pub fn format_diagnostic(&self) -> String {
+        format!(
+            "[{}] {} ({:?})\n  {}\n  Remediation: {}\n  More info: {}",
+            self.code, self.title, self.severity, self.description, self.remediation, self.doc_url,
+        )
+    }
+}
+
+/// Look up a single [`FindingCode`] by its code string (e.g. `"S001"`).
+/// Returns `None` if the code is not recognised.
+pub fn lookup_finding_code(code: &str) -> Option<FindingCode> {
+    all_finding_codes().into_iter().find(|c| c.code == code)
+}
+
 /// Returns every finding code known to this version of Sanctifier.
 pub fn all_finding_codes() -> Vec<FindingCode> {
     vec![
@@ -400,6 +416,37 @@ mod tests {
         let codes = all_finding_codes();
         let unique: HashSet<&str> = codes.iter().map(|c| c.code).collect();
         assert_eq!(codes.len(), unique.len());
+    }
+
+    #[test]
+    fn format_diagnostic_contains_code_title_and_remediation() {
+        let code = lookup_finding_code(AUTH_GAP).expect("S001 must exist");
+        let diag = code.format_diagnostic();
+        assert!(diag.contains("S001"), "diagnostic must include the code");
+        assert!(
+            diag.contains("Missing Authorization Guard"),
+            "diagnostic must include the title"
+        );
+        assert!(
+            diag.contains("Remediation:"),
+            "diagnostic must include the remediation label"
+        );
+        assert!(
+            diag.contains("More info:"),
+            "diagnostic must include the doc URL label"
+        );
+    }
+
+    #[test]
+    fn lookup_finding_code_returns_none_for_unknown_code() {
+        assert!(lookup_finding_code("X999").is_none());
+    }
+
+    #[test]
+    fn lookup_finding_code_returns_correct_entry() {
+        let code = lookup_finding_code(REENTRANCY).expect("S013 must exist");
+        assert_eq!(code.code, REENTRANCY);
+        assert_eq!(code.category, "reentrancy");
     }
 
     #[test]


### PR DESCRIPTION
…s, and diagnostics

Closes #510 
Closes #517 
Closes #518 
Closes #519 

- (#517) Add integration tests for config file resolution precedence (nearest .sanctify.toml wins; walks up to parent; defaults when absent)
- (#518) Validate --format value early; reject unknown values with a clear error message; add sarif format dispatch to `sanctifier analyze`
- (#519) Extract named exit-code constants to exit_codes.rs; wire AnalysisProfile (strict/lenient/audit/ci) into the exit-code decision in exec(); use EXIT_CODES::ERROR in main()
- (#510) Add FindingCode::format_diagnostic() and lookup_finding_code() to sanctifier-core for structured, actionable diagnostic output; add unit tests for both helpers

## Summary

Describe the change, the motivation behind it, and any important implementation details.

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Maintenance or refactor

## Testing

List the commands you ran and the scope of validation.

```text
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p sanctifier-core --all-features
cargo test -p sanctifier-cli
cd frontend && npm test
```

## Checklist

- [ ] I ran the relevant tests locally, or explained why they were not needed.
- [ ] I updated documentation for any user-facing behavior changes.
- [ ] I added or updated tests for the change when appropriate.
- [ ] I added a changelog or release-notes entry when needed, or confirmed none is required.
- [ ] I verified this branch is up to date with `main` and merge conflicts are resolved.
