### PR TITLE
Fix sanctifier-core build/clippy failures; add constant folding, gas exhaustion rule, and CFG-based taint analysis

### DIFF
--- a/tooling/sanctifier-core/src/cfg.rs
+++ b/tooling/sanctifier-core/src/cfg.rs
@@ -1,0 +1,329 @@
+//! Intra-procedural control-flow graph (CFG) construction for a single
+//! function body.
+//!
+//! AST-based pattern matching (the previous approach used by rules such as
+//! [`crate::rules::taint_propagation`]) walks a function body once, top to
+//! bottom. That is wrong whenever control flow loops back on itself: a
+//! `for`/`while` body that taints a variable on one iteration and reads it on
+//! the next is never connected, because a linear AST walk visits the loop
+//! body's statements exactly once, in source order, with no notion that the
+//! last statement can flow back into the first.
+//!
+//! This module builds an explicit graph of [`BasicBlock`]s connected by
+//! successor edges, so that dataflow passes (see [`crate::taint_engine`]) can
+//! run a proper fixed-point analysis: loop bodies get a back edge to their
+//! header, `if`/`else` branches join at a common successor, and `match` arms
+//! all flow into the block following the match.
+//!
+//! # Scope and limitations
+//!
+//! This is intentionally a lightweight, intra-procedural CFG tailored to the
+//! subset of Rust that appears in Soroban contracts, not a general-purpose
+//! Rust control-flow analyzer:
+//!
+//! * `let x = if/match { .. };` is **not** split into branch blocks — the
+//!   whole initializer is kept as one opaque statement in the current block.
+//!   Only `if`/`while`/`for`/`loop`/`match` that appear as a *statement*
+//!   (not as a sub-expression) get their own blocks/edges.
+//! * `break`/`continue`/`?` do not carry precise jump targets; they end the
+//!   current block but are not wired back to a specific loop-exit block.
+//!   This is a conservative simplification — it can never cause a dataflow
+//!   fact to be lost, only (rarely) computed slightly more permissively.
+//! * Function calls are not inlined or resolved — this CFG is strictly
+//!   intra-procedural.
+
+use syn::{Block, Expr, ExprForLoop, ExprIf, ExprLoop, ExprMatch, ExprWhile, Local, Pat, Stmt};
+
+/// A single statement kept inside a [`BasicBlock`].
+///
+/// Control-flow-introducing statements (`if`, `while`, `for`, `loop`,
+/// `match` used as a *statement*) are lowered into separate blocks/edges by
+/// [`Cfg::build`] and never appear here. Everything else — `let` bindings,
+/// plain expression statements, assignments — is kept verbatim so that
+/// dataflow passes can inspect it.
+#[derive(Debug, Clone)]
+pub enum BlockStmt {
+    /// A `let` binding, e.g. `let x = expr;`.
+    Local(Local),
+    /// A plain expression statement, e.g. `x = y;` or `sink(x);`.
+    Expr(Expr),
+    /// The binding introduced by a `for pat in iter_expr` loop header.
+    /// Kept separate from `Local` because the binding's taintedness depends
+    /// on `iter_expr`, not on a normal initializer.
+    ForBinding { pat: Pat, iter_expr: Expr },
+}
+
+/// A single node in the control-flow graph: a maximal run of statements with
+/// no internal branching.
+#[derive(Debug, Clone, Default)]
+pub struct BasicBlock {
+    pub id: usize,
+    pub stmts: Vec<BlockStmt>,
+}
+
+/// An intra-procedural control-flow graph for one function body.
+#[derive(Debug, Clone)]
+pub struct Cfg {
+    pub blocks: Vec<BasicBlock>,
+    /// `successors[b]` lists every block reachable in one step from block `b`.
+    pub successors: Vec<Vec<usize>>,
+    pub entry: usize,
+}
+
+impl Cfg {
+    /// Builds a CFG for `block` (typically a function body).
+    pub fn build(block: &Block) -> Cfg {
+        let mut builder = CfgBuilder::default();
+        let entry = builder.new_block();
+        builder.process_stmts(&block.stmts, entry);
+        Cfg {
+            blocks: builder.blocks,
+            successors: builder.successors,
+            entry,
+        }
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+}
+
+#[derive(Default)]
+struct CfgBuilder {
+    blocks: Vec<BasicBlock>,
+    successors: Vec<Vec<usize>>,
+}
+
+impl CfgBuilder {
+    fn new_block(&mut self) -> usize {
+        let id = self.blocks.len();
+        self.blocks.push(BasicBlock {
+            id,
+            stmts: Vec::new(),
+        });
+        self.successors.push(Vec::new());
+        id
+    }
+
+    fn add_edge(&mut self, from: usize, to: usize) {
+        self.successors[from].push(to);
+    }
+
+    fn push_stmt(&mut self, block: usize, stmt: BlockStmt) {
+        self.blocks[block].stmts.push(stmt);
+    }
+
+    /// Processes a sequence of statements starting at `current`, returning
+    /// the block that subsequent (fallthrough) code should attach to.
+    fn process_stmts(&mut self, stmts: &[Stmt], mut current: usize) -> usize {
+        for stmt in stmts {
+            current = self.process_stmt(stmt, current);
+        }
+        current
+    }
+
+    fn process_stmt(&mut self, stmt: &Stmt, current: usize) -> usize {
+        match stmt {
+            Stmt::Local(local) => {
+                self.push_stmt(current, BlockStmt::Local(local.clone()));
+                current
+            }
+            Stmt::Expr(expr, _) => self.process_expr_stmt(expr, current),
+            _ => current,
+        }
+    }
+
+    /// Processes an expression appearing directly as a statement. Only here
+    /// do `if`/`while`/`for`/`loop`/`match` get split into their own blocks —
+    /// see the module-level "Scope and limitations" note.
+    fn process_expr_stmt(&mut self, expr: &Expr, current: usize) -> usize {
+        match expr {
+            Expr::If(e) => self.process_if(e, current),
+            Expr::While(e) => self.process_while(e, current),
+            Expr::ForLoop(e) => self.process_for(e, current),
+            Expr::Loop(e) => self.process_loop(e, current),
+            Expr::Match(e) => self.process_match(e, current),
+            Expr::Block(e) => self.process_stmts(&e.block.stmts, current),
+            Expr::Return(_) | Expr::Break(_) | Expr::Continue(_) => {
+                self.push_stmt(current, BlockStmt::Expr(expr.clone()));
+                // Anything textually after this point in the same scope is
+                // unreachable along this path; give it a fresh, edge-less
+                // block so it doesn't pollute `current`'s flow.
+                self.new_block()
+            }
+            _ => {
+                self.push_stmt(current, BlockStmt::Expr(expr.clone()));
+                current
+            }
+        }
+    }
+
+    fn process_if(&mut self, e: &ExprIf, current: usize) -> usize {
+        self.push_stmt(current, BlockStmt::Expr((*e.cond).clone()));
+
+        let then_entry = self.new_block();
+        self.add_edge(current, then_entry);
+        let then_exit = self.process_stmts(&e.then_branch.stmts, then_entry);
+
+        let join = self.new_block();
+        self.add_edge(then_exit, join);
+
+        match &e.else_branch {
+            Some((_, else_expr)) => {
+                let else_entry = self.new_block();
+                self.add_edge(current, else_entry);
+                let else_exit = self.process_expr_stmt(else_expr, else_entry);
+                self.add_edge(else_exit, join);
+            }
+            None => {
+                // No else: the false branch falls straight through to join.
+                self.add_edge(current, join);
+            }
+        }
+        join
+    }
+
+    fn process_while(&mut self, e: &ExprWhile, current: usize) -> usize {
+        let header = self.new_block();
+        self.add_edge(current, header);
+        self.push_stmt(header, BlockStmt::Expr((*e.cond).clone()));
+
+        let body_entry = self.new_block();
+        self.add_edge(header, body_entry);
+        let body_exit = self.process_stmts(&e.body.stmts, body_entry);
+        self.add_edge(body_exit, header); // back edge
+
+        let after = self.new_block();
+        self.add_edge(header, after);
+        after
+    }
+
+    fn process_for(&mut self, e: &ExprForLoop, current: usize) -> usize {
+        let header = self.new_block();
+        self.add_edge(current, header);
+        self.push_stmt(
+            header,
+            BlockStmt::ForBinding {
+                pat: (*e.pat).clone(),
+                iter_expr: (*e.expr).clone(),
+            },
+        );
+
+        let body_entry = self.new_block();
+        self.add_edge(header, body_entry);
+        let body_exit = self.process_stmts(&e.body.stmts, body_entry);
+        self.add_edge(body_exit, header); // back edge
+
+        let after = self.new_block();
+        self.add_edge(header, after);
+        after
+    }
+
+    fn process_loop(&mut self, e: &ExprLoop, current: usize) -> usize {
+        let header = self.new_block();
+        self.add_edge(current, header);
+        let body_exit = self.process_stmts(&e.body.stmts, header);
+        self.add_edge(body_exit, header); // back edge
+
+        // `loop` has no implicit condition; it only exits via `break`. We
+        // still add a reachable exit block so dataflow facts that hold at
+        // loop entry are conservatively available after it too.
+        let after = self.new_block();
+        self.add_edge(header, after);
+        after
+    }
+
+    fn process_match(&mut self, e: &ExprMatch, current: usize) -> usize {
+        self.push_stmt(current, BlockStmt::Expr((*e.expr).clone()));
+
+        let join = self.new_block();
+        for arm in &e.arms {
+            let arm_entry = self.new_block();
+            self.add_edge(current, arm_entry);
+            let arm_exit = self.process_expr_stmt(&arm.body, arm_entry);
+            self.add_edge(arm_exit, join);
+        }
+        join
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+
+    fn build(src: &str) -> Cfg {
+        let block: Block = parse_str(&format!("{{ {src} }}")).unwrap();
+        Cfg::build(&block)
+    }
+
+    #[test]
+    fn straight_line_code_is_a_single_block_chain() {
+        let cfg = build("let a = 1; let b = 2; let c = a + b;");
+        // No branching: every block has at most one successor.
+        assert!(cfg.successors.iter().all(|s| s.len() <= 1));
+    }
+
+    #[test]
+    fn if_else_creates_branch_and_join() {
+        let cfg = build("if cond { let a = 1; } else { let b = 2; } let c = 3;");
+        // Entry block (holding the condition) must have two successors:
+        // the then-branch and the else-branch.
+        assert_eq!(cfg.successors[cfg.entry].len(), 2);
+    }
+
+    #[test]
+    fn if_without_else_falls_through_to_join() {
+        let cfg = build("if cond { let a = 1; }");
+        assert_eq!(cfg.successors[cfg.entry].len(), 2);
+    }
+
+    #[test]
+    fn while_loop_has_back_edge_to_header() {
+        let cfg = build("let mut i = 0; while i < 10 { i = i + 1; }");
+        let header_id = cfg
+            .blocks
+            .iter()
+            .find(|b| cfg.successors[b.id].len() == 2)
+            .map(|b| b.id)
+            .expect("while loop must have a header block with 2 successors");
+        let has_back_edge = cfg
+            .successors
+            .iter()
+            .any(|succs| succs.contains(&header_id));
+        assert!(has_back_edge, "while loop body must have a back edge");
+    }
+
+    #[test]
+    fn for_loop_has_back_edge_to_header() {
+        let cfg = build("for x in items.iter() { sink(x); }");
+        let header_id = cfg
+            .blocks
+            .iter()
+            .find(|b| cfg.successors[b.id].len() == 2)
+            .map(|b| b.id)
+            .expect("for loop must have a header block with 2 successors");
+        let has_back_edge = cfg
+            .successors
+            .iter()
+            .any(|succs| succs.contains(&header_id));
+        assert!(has_back_edge, "for loop body must have a back edge");
+    }
+
+    #[test]
+    fn match_arms_all_join_to_common_successor() {
+        let cfg = build("match x { 0 => { let a = 1; } _ => { let b = 2; } } let c = 3;");
+        assert_eq!(
+            cfg.successors[cfg.entry].len(),
+            2,
+            "match with 2 arms must branch into 2 arm blocks"
+        );
+    }
+
+    #[test]
+    fn block_count_grows_with_branching() {
+        let straight = build("let a = 1; let b = 2;");
+        let branching = build("if cond { let a = 1; } else { let b = 2; }");
+        assert!(branching.block_count() > straight.block_count());
+    }
+}

--- a/tooling/sanctifier-core/src/constant_folding.rs
+++ b/tooling/sanctifier-core/src/constant_folding.rs
@@ -1,0 +1,115 @@
+//! Constant folding for arithmetic expressions.
+//!
+//! Rules such as [`crate::rules::arithmetic_overflow`] flag unchecked arithmetic
+//! operators on the assumption that at least one operand is a runtime value
+//! whose range is unknown to the analyzer. When every operand in an expression
+//! is a literal (e.g. `1000 + 500`), the result is a compile-time constant that
+//! `rustc` itself evaluates and bounds-checks — flagging it as an overflow risk
+//! is just noise. [`fold_to_i128`] recursively evaluates such expressions so
+//! callers can skip emitting a finding when the whole expression folds.
+
+/// Attempts to evaluate `expr` as a compile-time integer constant.
+///
+/// Returns `Some(value)` if every leaf in the expression tree is an integer
+/// literal (optionally negated, parenthesized, or cast), and the expression is
+/// built entirely from `+ - * / %`. Returns `None` as soon as any operand is
+/// not statically known (a variable, function call, field access, etc.), since
+/// the rule should still treat that expression as carrying runtime risk.
+pub fn fold_to_i128(expr: &syn::Expr) -> Option<i128> {
+    match expr {
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Int(int),
+            ..
+        }) => int.base10_parse::<i128>().ok(),
+        syn::Expr::Unary(syn::ExprUnary {
+            op: syn::UnOp::Neg(_),
+            expr,
+            ..
+        }) => fold_to_i128(expr).and_then(i128::checked_neg),
+        syn::Expr::Paren(syn::ExprParen { expr, .. }) => fold_to_i128(expr),
+        syn::Expr::Group(syn::ExprGroup { expr, .. }) => fold_to_i128(expr),
+        syn::Expr::Cast(syn::ExprCast { expr, .. }) => fold_to_i128(expr),
+        syn::Expr::Binary(syn::ExprBinary {
+            left, op, right, ..
+        }) => {
+            let l = fold_to_i128(left)?;
+            let r = fold_to_i128(right)?;
+            match op {
+                syn::BinOp::Add(_) => l.checked_add(r),
+                syn::BinOp::Sub(_) => l.checked_sub(r),
+                syn::BinOp::Mul(_) => l.checked_mul(r),
+                syn::BinOp::Div(_) => l.checked_div(r),
+                syn::BinOp::Rem(_) => l.checked_rem(r),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Returns `true` if `expr` is entirely made up of compile-time integer
+/// constants, i.e. [`fold_to_i128`] succeeds.
+pub fn is_foldable_constant(expr: &syn::Expr) -> bool {
+    fold_to_i128(expr).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+
+    fn fold(src: &str) -> Option<i128> {
+        let expr: syn::Expr = parse_str(src).unwrap();
+        fold_to_i128(&expr)
+    }
+
+    #[test]
+    fn folds_simple_addition() {
+        assert_eq!(fold("1000 + 500"), Some(1500));
+    }
+
+    #[test]
+    fn folds_nested_arithmetic() {
+        assert_eq!(fold("(1 + 2) * 3 - 4"), Some(5));
+    }
+
+    #[test]
+    fn folds_negative_literal() {
+        assert_eq!(fold("-5 + 10"), Some(5));
+    }
+
+    #[test]
+    fn folds_through_cast() {
+        assert_eq!(fold("(1 + 2) as i128"), Some(3));
+    }
+
+    #[test]
+    fn returns_none_for_variable_operand() {
+        assert_eq!(fold("a + 2"), None);
+    }
+
+    #[test]
+    fn returns_none_for_function_call_operand() {
+        assert_eq!(fold("foo() + 2"), None);
+    }
+
+    #[test]
+    fn returns_none_on_overflow() {
+        assert_eq!(fold("170141183460469231731687303715884105727 + 1"), None);
+    }
+
+    #[test]
+    fn returns_none_on_division_by_zero() {
+        assert_eq!(fold("1 / 0"), None);
+    }
+
+    #[test]
+    fn is_foldable_constant_matches_fold_result() {
+        assert!(is_foldable_constant(
+            &parse_str::<syn::Expr>("1000 + 500").unwrap()
+        ));
+        assert!(!is_foldable_constant(
+            &parse_str::<syn::Expr>("a + 500").unwrap()
+        ));
+    }
+}

--- a/tooling/sanctifier-core/src/contract_discovery.rs
+++ b/tooling/sanctifier-core/src/contract_discovery.rs
@@ -38,7 +38,7 @@
 //!   in the file (storage types are file-scoped, not per-contract).
 
 use std::collections::BTreeMap;
-use syn::{spanned::Spanned, File, ImplItem, Item, Meta, Type};
+use syn::{File, ImplItem, Item, Meta, Type};
 
 // ── Public data types ─────────────────────────────────────────────────────────
 

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -83,6 +83,8 @@ pub const DEPRECATED_SDK_USAGE: &str = "S028";
 pub const TIMESTAMP_RANDOMNESS: &str = "S029";
 /// require_auth used instead of require_auth_for_args in multi-arg admin operations, enabling replay/scope-confusion attacks.
 pub const REQUIRE_AUTH_FOR_ARGS: &str = "S030";
+/// Loop bound or iteration count derives from an unbounded user-controlled parameter, risking out-of-gas reverts.
+pub const GAS_EXHAUSTION_RISK: &str = "S031";
 
 /// A single finding-code entry with machine-readable code, category, and
 /// human-readable description.
@@ -403,6 +405,15 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             remediation: "Replace require_auth() with require_auth_for_args() to bind authorization to the exact call payload, preventing replay attacks across different argument combinations",
             doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/require-auth-for-args.md",
         },
+        FindingCode {
+            code: GAS_EXHAUSTION_RISK,
+            category: "gas_limits",
+            description: "Loop bound or iteration count derives from an unbounded user-controlled parameter, which can exhaust the transaction's gas budget and cause an out-of-gas revert",
+            title: "Gas Exhaustion Risk",
+            severity: FindingSeverity::Medium,
+            remediation: "Cap the iteration count with a fixed maximum (e.g. .take(MAX_ITEMS) or an explicit length check before the loop) so the gas cost cannot scale unbounded with caller-supplied input",
+            doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/gas-exhaustion-risk.md",
+        },
     ]
 }
 
@@ -477,5 +488,6 @@ mod tests {
         assert!(codes.iter().any(|c| c.code == DEPRECATED_SDK_USAGE));
         assert!(codes.iter().any(|c| c.code == TIMESTAMP_RANDOMNESS));
         assert!(codes.iter().any(|c| c.code == REQUIRE_AUTH_FOR_ARGS));
+        assert!(codes.iter().any(|c| c.code == GAS_EXHAUSTION_RISK));
     }
 }

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -50,7 +50,9 @@ use syn::{parse_str, Fields, File, Item, Meta, Type};
 use thiserror::Error;
 
 pub mod analysis_cache;
+pub mod cfg;
 pub mod complexity;
+pub mod constant_folding;
 pub mod contract_discovery;
 pub mod finding_codes;
 pub mod gas_estimator;
@@ -66,6 +68,7 @@ pub mod sep41;
 pub mod smt;
 pub mod soroban_v21;
 pub mod storage_collision;
+pub mod taint_engine;
 
 // Re-export common types for easier CLI access
 pub use complexity::{ContractMetrics, FunctionMetrics};

--- a/tooling/sanctifier-core/src/parser.rs
+++ b/tooling/sanctifier-core/src/parser.rs
@@ -20,6 +20,7 @@ use crate::input_validation::{self, ValidationError};
 use syn::File;
 
 /// A validated and successfully parsed Rust source file.
+#[derive(Debug)]
 pub struct ParsedSource {
     /// The AST produced by `syn`.
     pub file: File,

--- a/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
+++ b/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
@@ -341,7 +341,12 @@ impl<'ast> Visit<'ast> for ArithVisitor {
         if self.index_depth == 0 {
             if let Some(fn_name) = self.current_fn.clone() {
                 if let Some((op_str, suggestion)) = Self::classify_op(&node.op) {
-                    if !is_string_literal(&node.left) && !is_string_literal(&node.right) {
+                    if !is_string_literal(&node.left)
+                        && !is_string_literal(&node.right)
+                        && !crate::constant_folding::is_foldable_constant(
+                            &syn::Expr::Binary(node.clone()),
+                        )
+                    {
                         let key = (fn_name.clone(), op_str.to_string());
                         if !self.seen.contains(&key) {
                             self.seen.insert(key);
@@ -646,6 +651,41 @@ mod tests {
             violations.len(),
             0,
             "index subscript arithmetic must be skipped"
+        );
+    }
+
+    #[test]
+    fn test_skip_constant_folded_arithmetic() {
+        let rule = ArithmeticOverflowRule::new();
+        // 1000 + 500 is a compile-time constant; rustc evaluates and bounds
+        // checks it itself, so it is not a runtime overflow risk.
+        let source = r#"
+            fn transfer() {
+                let a = 1000 + 500;
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(
+            violations.len(),
+            0,
+            "constant-folded literal arithmetic must not be flagged"
+        );
+    }
+
+    #[test]
+    fn test_still_flags_when_one_operand_is_runtime() {
+        let rule = ArithmeticOverflowRule::new();
+        // Mixed literal + variable is still a runtime risk and must be flagged.
+        let source = r#"
+            fn transfer(amount: u64) {
+                let a = amount + 500;
+            }
+        "#;
+        let violations = rule.check(source);
+        assert_eq!(
+            violations.len(),
+            1,
+            "arithmetic with a non-constant operand must still be flagged"
         );
     }
 }

--- a/tooling/sanctifier-core/src/rules/gas_exhaustion.rs
+++ b/tooling/sanctifier-core/src/rules/gas_exhaustion.rs
@@ -1,0 +1,439 @@
+//! Rule S031 — gas exhaustion risk from unbounded user-controlled loops.
+//!
+//! Soroban transactions have a fixed gas/instruction budget. A loop whose
+//! iteration count grows with a caller-supplied collection (`Vec<T>`,
+//! `Map<K, V>`, `Bytes`) or a raw integer parameter has no upper bound unless
+//! the contract clamps it — so a sufficiently large input reverts the
+//! transaction out-of-gas instead of failing gracefully (or "bricking" the
+//! call for every other caller sharing the same budget).
+//!
+//! This rule flags `for`/`while` loops inside `impl` methods whose bound
+//! traces directly back to such a parameter, unless the bound expression
+//! itself is clamped via `.min(...)`/`.saturating_sub(...)`/`.take(...)`.
+
+use super::{Rule, RuleViolation, Severity};
+use syn::spanned::Spanned;
+use syn::{parse_str, File, Item};
+
+pub struct GasExhaustionRiskRule;
+
+impl GasExhaustionRiskRule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GasExhaustionRiskRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for GasExhaustionRiskRule {
+    fn name(&self) -> &str {
+        "gas_exhaustion_risk"
+    }
+
+    fn description(&self) -> &str {
+        "Detects loops whose iteration count derives from an unbounded user-controlled parameter (S031)"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+
+        for item in &file.items {
+            if let Item::Impl(impl_block) = item {
+                for impl_item in &impl_block.items {
+                    if let syn::ImplItem::Fn(f) = impl_item {
+                        let fn_name = f.sig.ident.to_string();
+                        let unbounded_params = unbounded_param_names(&f.sig);
+                        if unbounded_params.is_empty() {
+                            continue;
+                        }
+
+                        let mut findings = Vec::new();
+                        scan_block(&f.block, &fn_name, &unbounded_params, &mut findings);
+
+                        for (location, reason) in findings {
+                            violations.push(
+                                RuleViolation::new(
+                                    self.name(),
+                                    Severity::Warning,
+                                    format!(
+                                        "Loop in '{fn_name}' {reason}, which can exhaust the gas budget \
+                                        and cause an out-of-gas revert (S031)."
+                                    ),
+                                    location,
+                                )
+                                .with_suggestion(
+                                    "Cap the iteration count with a fixed maximum, e.g. `.iter().take(MAX_ITEMS)` \
+                                    or an explicit `if param.len() > MAX_ITEMS { return Err(...) }` check before \
+                                    the loop, so gas cost cannot scale unbounded with caller-supplied input."
+                                        .to_string(),
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Returns the names of function parameters whose type makes their size
+/// directly caller-controlled: `Vec<_>`, `Map<_, _>`, `Bytes`, or a raw
+/// unsigned integer (`u32`, `u64`, `u128`, `usize`) that could be used
+/// directly as a loop bound.
+fn unbounded_param_names(sig: &syn::Signature) -> Vec<String> {
+    sig.inputs
+        .iter()
+        .filter_map(|arg| {
+            let syn::FnArg::Typed(pt) = arg else {
+                return None;
+            };
+            let syn::Pat::Ident(pi) = pt.pat.as_ref() else {
+                return None;
+            };
+            if type_is_unbounded(pt.ty.as_ref()) {
+                Some(pi.ident.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn type_is_unbounded(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(tp) => {
+            let Some(seg) = tp.path.segments.last() else {
+                return false;
+            };
+            matches!(
+                seg.ident.to_string().as_str(),
+                "Vec" | "Map" | "Bytes" | "u32" | "u64" | "u128" | "usize" | "i128"
+            )
+        }
+        syn::Type::Reference(r) => type_is_unbounded(r.elem.as_ref()),
+        _ => false,
+    }
+}
+
+/// Walk a block looking for `for`/`while` loops whose bound traces back to
+/// an unbounded parameter.
+fn scan_block(
+    block: &syn::Block,
+    fn_name: &str,
+    unbounded_params: &[String],
+    findings: &mut Vec<(String, String)>,
+) {
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Expr(expr, _) => scan_expr(expr, fn_name, unbounded_params, findings),
+            syn::Stmt::Local(local) => {
+                if let Some(init) = &local.init {
+                    scan_expr(&init.expr, fn_name, unbounded_params, findings);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn scan_expr(
+    expr: &syn::Expr,
+    fn_name: &str,
+    unbounded_params: &[String],
+    findings: &mut Vec<(String, String)>,
+) {
+    match expr {
+        syn::Expr::ForLoop(f) => {
+            if let Some(reason) = unbounded_iterator_reason(&f.expr, unbounded_params) {
+                let line = f.span().start().line;
+                findings.push((format!("{fn_name}:line {line}"), reason));
+            }
+            scan_block(&f.body, fn_name, unbounded_params, findings);
+        }
+        syn::Expr::While(w) => {
+            if let Some(reason) = unbounded_condition_reason(&w.cond, unbounded_params) {
+                let line = w.span().start().line;
+                findings.push((format!("{fn_name}:line {line}"), reason));
+            }
+            scan_block(&w.body, fn_name, unbounded_params, findings);
+        }
+        syn::Expr::Loop(l) => scan_block(&l.body, fn_name, unbounded_params, findings),
+        syn::Expr::Block(b) => scan_block(&b.block, fn_name, unbounded_params, findings),
+        syn::Expr::If(i) => {
+            scan_block(&i.then_branch, fn_name, unbounded_params, findings);
+            if let Some((_, else_expr)) = &i.else_branch {
+                scan_expr(else_expr, fn_name, unbounded_params, findings);
+            }
+        }
+        syn::Expr::Match(m) => {
+            for arm in &m.arms {
+                scan_expr(&arm.body, fn_name, unbounded_params, findings);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// If `iter_expr` (the expression after `in` in a `for x in <iter_expr>`)
+/// iterates the full length of an unbounded parameter without a clamp,
+/// returns a human-readable reason. Otherwise `None`.
+fn unbounded_iterator_reason(iter_expr: &syn::Expr, unbounded_params: &[String]) -> Option<String> {
+    if expr_contains_clamp(iter_expr) {
+        return None;
+    }
+    match iter_expr {
+        // `param.iter()`, `param.iter().rev()`, `(&param).iter()`, etc.
+        syn::Expr::MethodCall(m) => {
+            if let Some(param) = root_receiver_param(&m.receiver, unbounded_params) {
+                return Some(format!("iterates the full length of parameter '{param}'"));
+            }
+            unbounded_iterator_reason(&m.receiver, unbounded_params)
+        }
+        syn::Expr::Reference(r) => unbounded_iterator_reason(&r.expr, unbounded_params),
+        syn::Expr::Paren(p) => unbounded_iterator_reason(&p.expr, unbounded_params),
+        // `0..param` or `0..param.len()`
+        syn::Expr::Range(r) => {
+            let end = r.end.as_deref()?;
+            range_bound_param(end, unbounded_params)
+                .map(|param| format!("iterates up to bound derived from parameter '{param}'"))
+        }
+        _ => None,
+    }
+}
+
+/// If `cond` (a `while` condition) compares a loop counter against an
+/// unbounded parameter (or its `.len()`) without a clamp, returns a reason.
+fn unbounded_condition_reason(cond: &syn::Expr, unbounded_params: &[String]) -> Option<String> {
+    if expr_contains_clamp(cond) {
+        return None;
+    }
+    let syn::Expr::Binary(b) = cond else {
+        return None;
+    };
+    if !matches!(
+        b.op,
+        syn::BinOp::Lt(_) | syn::BinOp::Le(_) | syn::BinOp::Ne(_)
+    ) {
+        return None;
+    }
+    range_bound_param(&b.right, unbounded_params)
+        .or_else(|| range_bound_param(&b.left, unbounded_params))
+        .map(|param| format!("loop condition is bounded by parameter '{param}'"))
+}
+
+/// Returns the parameter name if `expr` is `<param>` or `<param>.len()`.
+fn range_bound_param(expr: &syn::Expr, unbounded_params: &[String]) -> Option<String> {
+    match expr {
+        syn::Expr::Path(p) => {
+            let name = p.path.segments.last()?.ident.to_string();
+            unbounded_params.contains(&name).then_some(name)
+        }
+        syn::Expr::MethodCall(m) if m.method == "len" => {
+            root_receiver_param(&m.receiver, unbounded_params)
+        }
+        syn::Expr::Paren(p) => range_bound_param(&p.expr, unbounded_params),
+        _ => None,
+    }
+}
+
+/// Walks through a receiver chain (`&param`, `(*param)`, etc.) to find a
+/// root identifier matching one of `unbounded_params`.
+fn root_receiver_param(expr: &syn::Expr, unbounded_params: &[String]) -> Option<String> {
+    match expr {
+        syn::Expr::Path(p) => {
+            let name = p.path.segments.last()?.ident.to_string();
+            unbounded_params.contains(&name).then_some(name)
+        }
+        syn::Expr::Reference(r) => root_receiver_param(&r.expr, unbounded_params),
+        syn::Expr::Unary(u) => root_receiver_param(&u.expr, unbounded_params),
+        syn::Expr::Paren(p) => root_receiver_param(&p.expr, unbounded_params),
+        _ => None,
+    }
+}
+
+/// Returns true if `expr` contains a clamp-style call (`.min(`, `.take(`,
+/// `.saturating_sub(`, `.truncate(`) anywhere in its method-call chain,
+/// signalling the author already bounded the iteration count.
+fn expr_contains_clamp(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::MethodCall(m) => {
+            let method = m.method.to_string();
+            matches!(
+                method.as_str(),
+                "min" | "take" | "saturating_sub" | "truncate" | "clamp"
+            ) || expr_contains_clamp(&m.receiver)
+        }
+        syn::Expr::Reference(r) => expr_contains_clamp(&r.expr),
+        syn::Expr::Paren(p) => expr_contains_clamp(&p.expr),
+        syn::Expr::Range(r) => r
+            .end
+            .as_deref()
+            .map(expr_contains_clamp)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_for_loop_over_full_vec_param() {
+        let rule = GasExhaustionRiskRule::new();
+        let source = r#"
+            impl Batch {
+                pub fn process(env: Env, recipients: Vec<Address>) {
+                    for r in recipients.iter() {
+                        do_transfer(&env, r);
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            !violations.is_empty(),
+            "unbounded Vec parameter loop must be flagged"
+        );
+        assert!(violations[0].message.contains("process"));
+    }
+
+    #[test]
+    fn flags_range_loop_bound_by_integer_param() {
+        let rule = GasExhaustionRiskRule::new();
+        let source = r#"
+            impl Counter {
+                pub fn bump_many(env: Env, count: u32) {
+                    for i in 0..count {
+                        bump(&env, i);
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            !violations.is_empty(),
+            "range bound by raw integer parameter must be flagged"
+        );
+    }
+
+    #[test]
+    fn flags_while_loop_bound_by_param_len() {
+        let rule = GasExhaustionRiskRule::new();
+        let source = r#"
+            impl Batch {
+                pub fn process(env: Env, items: Vec<u32>) {
+                    let mut i = 0;
+                    while i < items.len() {
+                        i += 1;
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            !violations.is_empty(),
+            "while loop bound by param.len() must be flagged"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_when_take_clamp_applied() {
+        let rule = GasExhaustionRiskRule::new();
+        let source = r#"
+            impl Batch {
+                pub fn process(env: Env, recipients: Vec<Address>) {
+                    for r in recipients.iter().take(MAX_BATCH) {
+                        do_transfer(&env, r);
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            violations.is_empty(),
+            ".take(...) clamp must suppress the finding"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_when_min_clamp_applied_to_range() {
+        let rule = GasExhaustionRiskRule::new();
+        let source = r#"
+            impl Counter {
+                pub fn bump_many(env: Env, count: u32) {
+                    for i in 0..count.min(MAX_COUNT) {
+                        bump(&env, i);
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            violations.is_empty(),
+            ".min(...) clamp on the range bound must suppress the finding"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_loop_over_fixed_constant() {
+        let rule = GasExhaustionRiskRule::new();
+        let source = r#"
+            impl Counter {
+                pub fn bump_fixed(env: Env) {
+                    for i in 0..10 {
+                        bump(&env, i);
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(
+            violations.is_empty(),
+            "loop bound by a fixed literal must not be flagged"
+        );
+    }
+
+    #[test]
+    fn does_not_flag_function_without_unbounded_params() {
+        let rule = GasExhaustionRiskRule::new();
+        let source = r#"
+            impl Vault {
+                pub fn admin(&self, env: Env, admin: Address) {
+                    for i in 0..5 {
+                        log(&env, i);
+                    }
+                }
+            }
+        "#;
+        let violations = rule.check(source);
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn empty_source_produces_no_findings() {
+        let rule = GasExhaustionRiskRule::new();
+        assert!(rule.check("").is_empty());
+    }
+
+    #[test]
+    fn invalid_source_produces_no_panic() {
+        let rule = GasExhaustionRiskRule::new();
+        assert!(rule.check("not valid rust {{{{").is_empty());
+    }
+}

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -7,6 +7,8 @@
 pub mod arithmetic_overflow;
 /// Missing authorization checks.
 pub mod auth_gap;
+/// Gas exhaustion risk from unbounded user-controlled loops (S031).
+pub mod gas_exhaustion;
 /// Instance storage misuse — per-user data stored in Instance instead of Persistent.
 pub mod instance_storage_misuse;
 /// Ledger entry size analysis.
@@ -224,6 +226,7 @@ impl RuleRegistry {
         registry.register(deprecated_sdk_usage::DeprecatedSdkUsageRule::new());
         registry.register(timestamp_randomness::TimestampRandomnessRule::new());
         registry.register(require_auth_for_args::RequireAuthForArgsRule::new());
+        registry.register(gas_exhaustion::GasExhaustionRiskRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/src/rules/taint_propagation.rs
+++ b/tooling/sanctifier-core/src/rules/taint_propagation.rs
@@ -5,10 +5,18 @@
 //! `let Foo { x, y } = ...` (Pat::Struct) destructures.  Emits a finding when
 //! a tainted value reaches a sensitive sink (storage write or external call)
 //! without an intervening `require_auth` or explicit validation.
+//!
+//! The actual dataflow is delegated to [`crate::taint_engine`], which runs a
+//! fixed-point analysis over an intra-procedural CFG ([`crate::cfg`]) rather
+//! than a single top-to-bottom AST walk. That matters for control flow this
+//! rule previously missed entirely: a `for`/`while` loop body that taints a
+//! variable used by a later iteration, or a branch that only conditionally
+//! introduces taint before a sink is reached after the branches join.
 
 use super::{Rule, RuleViolation, Severity};
+use crate::taint_engine;
 use std::collections::HashSet;
-use syn::{parse_str, File, Item, Pat};
+use syn::{parse_str, File, Item};
 
 pub struct TaintPropagationRule;
 
@@ -24,24 +32,6 @@ impl Default for TaintPropagationRule {
     }
 }
 
-// ── Internal state ─────────────────────────────────────────────────────────────
-
-struct TaintState<'a> {
-    fn_name: &'a str,
-    /// Variables currently considered tainted.
-    tainted: HashSet<String>,
-    /// True once require_auth / require_auth_for_args has been seen.
-    has_auth: bool,
-    violations: Vec<TaintViolation>,
-}
-
-struct TaintViolation {
-    fn_name: String,
-    tainted_var: String,
-    sink: String,
-    line: usize,
-}
-
 // ── Rule impl ──────────────────────────────────────────────────────────────────
 
 impl Rule for TaintPropagationRule {
@@ -50,7 +40,7 @@ impl Rule for TaintPropagationRule {
     }
 
     fn description(&self) -> &str {
-        "Tracks user-controlled data through tuple/struct destructures and flags \
+        "Tracks user-controlled data through the function's control-flow graph and flags \
          when tainted values reach storage or external-call sinks without auth"
     }
 
@@ -73,21 +63,14 @@ impl Rule for TaintPropagationRule {
                         let fn_name = f.sig.ident.to_string();
 
                         // Seed taint from parameters (excluding `env: Env` and `self`)
-                        let tainted = collect_param_names(&f.sig);
-                        if tainted.is_empty() {
+                        let sources = collect_param_names(&f.sig);
+                        if sources.is_empty() {
                             continue;
                         }
 
-                        let mut state = TaintState {
-                            fn_name: &fn_name,
-                            tainted,
-                            has_auth: false,
-                            violations: Vec::new(),
-                        };
+                        let findings = taint_engine::analyze(&f.block, sources);
 
-                        scan_block(&f.block, &mut state);
-
-                        for v in state.violations {
+                        for finding in findings {
                             violations.push(
                                 RuleViolation::new(
                                     self.name(),
@@ -95,9 +78,9 @@ impl Rule for TaintPropagationRule {
                                     format!(
                                         "Function '{}': tainted variable '{}' reaches '{}' \
                                          sink without prior require_auth",
-                                        v.fn_name, v.tainted_var, v.sink
+                                        fn_name, finding.var, finding.sink
                                     ),
-                                    format!("{}:{}", v.fn_name, v.line),
+                                    format!("{}:{}", fn_name, finding.line),
                                 )
                                 .with_suggestion(
                                     "Call require_auth() on any address parameter before using \
@@ -130,210 +113,10 @@ fn collect_param_names(sig: &syn::Signature) -> HashSet<String> {
             if ty_str.contains("Env") {
                 continue;
             }
-            collect_pat_idents(&pt.pat, &mut names);
+            taint_engine::collect_pat_idents(&pt.pat, &mut names);
         }
     }
     names
-}
-
-// ── Block / expression scanner ────────────────────────────────────────────────
-
-fn scan_block(block: &syn::Block, state: &mut TaintState<'_>) {
-    for stmt in &block.stmts {
-        match stmt {
-            syn::Stmt::Local(local) => {
-                // Check if the RHS expression contains a tainted variable
-                if let Some(init) = &local.init {
-                    let rhs_tainted = expr_is_tainted(&init.expr, &state.tainted);
-                    // Also propagate auth checks from init expression
-                    check_auth_in_expr(&init.expr, state);
-                    if rhs_tainted {
-                        // Propagate taint to all variables bound in the pattern
-                        let mut new_tainted = HashSet::new();
-                        collect_pat_idents(&local.pat, &mut new_tainted);
-                        state.tainted.extend(new_tainted);
-                    }
-                }
-            }
-            syn::Stmt::Expr(e, _) => scan_expr(e, state),
-            _ => {}
-        }
-    }
-}
-
-fn scan_expr(expr: &syn::Expr, state: &mut TaintState<'_>) {
-    match expr {
-        syn::Expr::MethodCall(mc) => {
-            let method = mc.method.to_string();
-
-            // Detect auth
-            if method == "require_auth" || method == "require_auth_for_args" {
-                state.has_auth = true;
-            }
-
-            // Detect sink: storage write or external call
-            if (is_storage_write(&method, &mc.receiver) || is_external_call(&method))
-                && !state.has_auth
-            {
-                // Check if any argument uses a tainted variable
-                for arg in &mc.args {
-                    if let Some(var) = first_tainted_ident(arg, &state.tainted) {
-                        use syn::spanned::Spanned;
-                        let line = mc.span().start().line;
-                        state.violations.push(TaintViolation {
-                            fn_name: state.fn_name.to_string(),
-                            tainted_var: var,
-                            sink: method.clone(),
-                            line,
-                        });
-                    }
-                }
-            }
-
-            scan_expr(&mc.receiver, state);
-            for arg in &mc.args {
-                scan_expr(arg, state);
-            }
-        }
-        syn::Expr::Block(b) => scan_block(&b.block, state),
-        syn::Expr::If(i) => {
-            scan_expr(&i.cond, state);
-            scan_block(&i.then_branch, state);
-            if let Some((_, e)) = &i.else_branch {
-                scan_expr(e, state);
-            }
-        }
-        syn::Expr::Match(m) => {
-            scan_expr(&m.expr, state);
-            for arm in &m.arms {
-                scan_expr(&arm.body, state);
-            }
-        }
-        syn::Expr::Assign(a) => {
-            scan_expr(&a.left, state);
-            scan_expr(&a.right, state);
-        }
-        syn::Expr::Call(c) => {
-            for arg in &c.args {
-                scan_expr(arg, state);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn check_auth_in_expr(expr: &syn::Expr, state: &mut TaintState<'_>) {
-    if let syn::Expr::MethodCall(mc) = expr {
-        let method = mc.method.to_string();
-        if method == "require_auth" || method == "require_auth_for_args" {
-            state.has_auth = true;
-        }
-    }
-}
-
-// ── Pattern helpers ────────────────────────────────────────────────────────────
-
-/// Recursively collect all identifier names bound by a pattern.
-/// Handles Pat::Ident, Pat::Tuple, and Pat::Struct — the key cases for #760.
-fn collect_pat_idents(pat: &Pat, out: &mut HashSet<String>) {
-    match pat {
-        Pat::Ident(pi) => {
-            out.insert(pi.ident.to_string());
-        }
-        // Pat::Tuple: let (a, b) = ...
-        Pat::Tuple(pt) => {
-            for elem in &pt.elems {
-                collect_pat_idents(elem, out);
-            }
-        }
-        // Pat::Struct: let Foo { x, y } = ...
-        Pat::Struct(ps) => {
-            for field in &ps.fields {
-                collect_pat_idents(&field.pat, out);
-            }
-        }
-        // Pat::TupleStruct: let Some(x) = ...
-        Pat::TupleStruct(pts) => {
-            for elem in &pts.elems {
-                collect_pat_idents(elem, out);
-            }
-        }
-        // Pat::Reference: let &x = ...
-        Pat::Reference(pr) => collect_pat_idents(&pr.pat, out),
-        _ => {}
-    }
-}
-
-// ── Expression taint helpers ───────────────────────────────────────────────────
-
-/// Returns true if the expression references any tainted variable.
-fn expr_is_tainted(expr: &syn::Expr, tainted: &HashSet<String>) -> bool {
-    first_tainted_ident(expr, tainted).is_some()
-}
-
-/// Returns the first tainted identifier name found in expr, or None.
-fn first_tainted_ident(expr: &syn::Expr, tainted: &HashSet<String>) -> Option<String> {
-    match expr {
-        syn::Expr::Path(p) => {
-            if let Some(seg) = p.path.segments.last() {
-                let name = seg.ident.to_string();
-                if tainted.contains(&name) {
-                    return Some(name);
-                }
-            }
-            None
-        }
-        syn::Expr::Reference(r) => first_tainted_ident(&r.expr, tainted),
-        syn::Expr::MethodCall(mc) => {
-            if let Some(v) = first_tainted_ident(&mc.receiver, tainted) {
-                return Some(v);
-            }
-            for arg in &mc.args {
-                if let Some(v) = first_tainted_ident(arg, tainted) {
-                    return Some(v);
-                }
-            }
-            None
-        }
-        syn::Expr::Call(c) => {
-            for arg in &c.args {
-                if let Some(v) = first_tainted_ident(arg, tainted) {
-                    return Some(v);
-                }
-            }
-            None
-        }
-        syn::Expr::Tuple(t) => {
-            for elem in &t.elems {
-                if let Some(v) = first_tainted_ident(elem, tainted) {
-                    return Some(v);
-                }
-            }
-            None
-        }
-        syn::Expr::Binary(b) => {
-            first_tainted_ident(&b.left, tainted).or_else(|| first_tainted_ident(&b.right, tainted))
-        }
-        _ => None,
-    }
-}
-
-fn is_storage_write(method: &str, receiver: &syn::Expr) -> bool {
-    if !matches!(method, "set" | "update" | "remove") {
-        return false;
-    }
-    let s = quote::quote!(#receiver).to_string();
-    s.contains("storage")
-        || s.contains("persistent")
-        || s.contains("temporary")
-        || s.contains("instance")
-}
-
-fn is_external_call(method: &str) -> bool {
-    matches!(
-        method,
-        "invoke_contract" | "try_invoke_contract" | "invoke_contract_check"
-    )
 }
 
 // ── Unit tests ─────────────────────────────────────────────────────────────────
@@ -433,5 +216,49 @@ mod tests {
     #[test]
     fn empty_source_no_panic() {
         assert!(rule().check("").is_empty());
+    }
+
+    #[test]
+    fn detects_taint_introduced_inside_for_loop_body() {
+        // Regression test for the bug #401 exists to fix: a pure top-to-bottom
+        // AST walk never visited for-loop bodies at all, so taint flowing
+        // from a tainted Vec parameter into the per-iteration loop variable
+        // was invisible. The CFG-backed taint engine must catch it.
+        let source = r#"
+            impl Batch {
+                pub fn process(env: Env, recipients: Vec<Symbol>) {
+                    let mut key = default_key;
+                    for r in recipients.iter() {
+                        key = r;
+                        env.storage().persistent().set(&key, &1);
+                    }
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(
+            !v.is_empty(),
+            "taint introduced inside a for-loop body must be flagged"
+        );
+    }
+
+    #[test]
+    fn detects_taint_from_one_if_branch_after_join() {
+        let source = r#"
+            impl MyContract {
+                pub fn store(env: Env, user_input: Symbol) {
+                    let mut key = default_key;
+                    if some_cond {
+                        key = user_input;
+                    }
+                    env.storage().persistent().set(&key, &1);
+                }
+            }
+        "#;
+        let v = rule().check(source);
+        assert!(
+            !v.is_empty(),
+            "taint introduced in only one if-branch must still be flagged after the join"
+        );
     }
 }

--- a/tooling/sanctifier-core/src/taint_engine.rs
+++ b/tooling/sanctifier-core/src/taint_engine.rs
@@ -1,0 +1,435 @@
+//! Intra-procedural taint analysis on top of [`crate::cfg`].
+//!
+//! Identifies **sources** (untrusted parameters passed into a contract entry
+//! point) and **sinks** (privileged operations: storage writes and external
+//! contract calls), then runs a forward dataflow fixed-point over the CFG to
+//! decide whether tainted data can reach a sink. Unlike a single top-to-bottom
+//! AST walk, this correctly handles:
+//!
+//! * **Loops** — a variable tainted at the bottom of a loop body is visible
+//!   at the top of the next iteration, via the CFG's back edge.
+//! * **Branch joins** — a variable tainted in only one arm of an `if`/`match`
+//!   is still considered (conservatively) tainted after the branches join.
+//! * **Aliasing / reassignment** — `let y = x;` propagates taint from `x` to
+//!   `y`; a later `x = clean_value();` clears (kills) `x`'s own taint without
+//!   affecting `y`, since each variable's taint is tracked independently and
+//!   blocks are processed in their own statement order.
+//!
+//! # Soundness note
+//!
+//! This is a best-effort static analysis, not a soundness-certified one. The
+//! "facts" set is unioned at join points, which is conservative (taint-safe)
+//! for taint itself, but also applied to the `require_auth` marker — meaning
+//! a branch that authorizes is treated as authorizing the merged path too.
+//! This matches the precision level of the rest of the rule suite.
+
+use crate::cfg::{BasicBlock, BlockStmt, Cfg};
+use std::collections::{HashSet, VecDeque};
+use syn::spanned::Spanned;
+use syn::{Expr, Pat};
+
+/// Sentinel inserted into the fact set once a `require_auth` /
+/// `require_auth_for_args` call has been observed on a path.
+const AUTH_MARKER: &str = "__authorized__";
+
+/// A tainted value reaching a sink.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaintFinding {
+    /// The tainted variable observed at the sink call site.
+    pub var: String,
+    /// The sink method name (e.g. `"set"`, `"invoke_contract"`).
+    pub sink: String,
+    /// Source line of the sink call, if available.
+    pub line: usize,
+}
+
+/// Runs taint analysis over `body`, seeding the analysis with `sources` (the
+/// set of variable names considered tainted at function entry).
+///
+/// A sink call is flagged unless `AUTH_MARKER` is present in the fact set at
+/// that point in the CFG (i.e. some `require_auth*` call precedes it on every
+/// path the dataflow fixed point considers reachable).
+pub fn analyze(body: &syn::Block, sources: HashSet<String>) -> Vec<TaintFinding> {
+    let cfg = Cfg::build(body);
+    let n = cfg.block_count();
+    if n == 0 {
+        return vec![];
+    }
+
+    let mut block_in: Vec<HashSet<String>> = vec![HashSet::new(); n];
+    block_in[cfg.entry] = sources;
+
+    let mut worklist: VecDeque<usize> = (0..n).collect();
+    while let Some(b) = worklist.pop_front() {
+        let (out, _) = transfer(&cfg.blocks[b], &block_in[b]);
+        for &succ in &cfg.successors[b] {
+            let before = block_in[succ].len();
+            block_in[succ].extend(out.iter().cloned());
+            if block_in[succ].len() != before {
+                worklist.push_back(succ);
+            }
+        }
+    }
+
+    // Final pass over the stabilized fixed point to collect findings without
+    // duplication from intermediate iterations.
+    let mut findings = Vec::new();
+    for block in &cfg.blocks {
+        let (_, block_findings) = transfer(block, &block_in[block.id]);
+        findings.extend(block_findings);
+    }
+    findings
+}
+
+/// Applies one basic block's statements to an incoming fact set, returning
+/// the outgoing fact set and any sink findings observed along the way.
+fn transfer(block: &BasicBlock, in_facts: &HashSet<String>) -> (HashSet<String>, Vec<TaintFinding>) {
+    let mut facts = in_facts.clone();
+    let mut findings = Vec::new();
+
+    for stmt in &block.stmts {
+        match stmt {
+            BlockStmt::Local(local) => {
+                if let Some(init) = &local.init {
+                    scan_expr(&init.expr, &mut facts, &mut findings);
+                    if expr_is_tainted(&init.expr, &facts) {
+                        let mut names = HashSet::new();
+                        collect_pat_idents(&local.pat, &mut names);
+                        facts.extend(names);
+                    } else if let Some(name) = simple_pat_ident(&local.pat) {
+                        // Strong update: rebinding to a clean value clears
+                        // this variable's own taint.
+                        facts.remove(&name);
+                    }
+                }
+            }
+            BlockStmt::Expr(expr) => process_top_level_expr(expr, &mut facts, &mut findings),
+            BlockStmt::ForBinding { pat, iter_expr } => {
+                scan_expr(iter_expr, &mut facts, &mut findings);
+                if expr_is_tainted(iter_expr, &facts) {
+                    let mut names = HashSet::new();
+                    collect_pat_idents(pat, &mut names);
+                    facts.extend(names);
+                }
+            }
+        }
+    }
+
+    (facts, findings)
+}
+
+fn process_top_level_expr(expr: &Expr, facts: &mut HashSet<String>, findings: &mut Vec<TaintFinding>) {
+    if let Expr::Assign(a) = expr {
+        scan_expr(&a.right, facts, findings);
+        let tainted = expr_is_tainted(&a.right, facts);
+        if let Some(name) = simple_expr_ident(&a.left) {
+            if tainted {
+                facts.insert(name);
+            } else {
+                facts.remove(&name);
+            }
+        }
+        return;
+    }
+    scan_expr(expr, facts, findings);
+}
+
+/// Recursively walks an expression, recording sink findings and updating the
+/// auth marker, without itself binding any new taint (that only happens for
+/// `let` bindings and plain assignments — see [`transfer`]).
+fn scan_expr(expr: &Expr, facts: &mut HashSet<String>, findings: &mut Vec<TaintFinding>) {
+    match expr {
+        Expr::MethodCall(mc) => {
+            let method = mc.method.to_string();
+
+            if method == "require_auth" || method == "require_auth_for_args" {
+                facts.insert(AUTH_MARKER.to_string());
+            }
+
+            if (is_storage_write(&method, &mc.receiver) || is_external_call(&method))
+                && !facts.contains(AUTH_MARKER)
+            {
+                for arg in &mc.args {
+                    if let Some(var) = first_tainted_ident(arg, facts) {
+                        findings.push(TaintFinding {
+                            var,
+                            sink: method.clone(),
+                            line: mc.span().start().line,
+                        });
+                    }
+                }
+            }
+
+            scan_expr(&mc.receiver, facts, findings);
+            for arg in &mc.args {
+                scan_expr(arg, facts, findings);
+            }
+        }
+        Expr::Call(c) => {
+            scan_expr(&c.func, facts, findings);
+            for arg in &c.args {
+                scan_expr(arg, facts, findings);
+            }
+        }
+        Expr::If(i) => {
+            scan_expr(&i.cond, facts, findings);
+            for stmt in &i.then_branch.stmts {
+                scan_stmt(stmt, facts, findings);
+            }
+            if let Some((_, else_expr)) = &i.else_branch {
+                scan_expr(else_expr, facts, findings);
+            }
+        }
+        Expr::Match(m) => {
+            scan_expr(&m.expr, facts, findings);
+            for arm in &m.arms {
+                scan_expr(&arm.body, facts, findings);
+            }
+        }
+        Expr::Block(b) => {
+            for stmt in &b.block.stmts {
+                scan_stmt(stmt, facts, findings);
+            }
+        }
+        Expr::Assign(a) => {
+            scan_expr(&a.left, facts, findings);
+            scan_expr(&a.right, facts, findings);
+        }
+        Expr::Paren(p) => scan_expr(&p.expr, facts, findings),
+        Expr::Group(g) => scan_expr(&g.expr, facts, findings),
+        Expr::Reference(r) => scan_expr(&r.expr, facts, findings),
+        Expr::Unary(u) => scan_expr(&u.expr, facts, findings),
+        Expr::Cast(c) => scan_expr(&c.expr, facts, findings),
+        Expr::Try(t) => scan_expr(&t.expr, facts, findings),
+        Expr::Field(f) => scan_expr(&f.base, facts, findings),
+        Expr::Index(idx) => {
+            scan_expr(&idx.expr, facts, findings);
+            scan_expr(&idx.index, facts, findings);
+        }
+        Expr::Binary(b) => {
+            scan_expr(&b.left, facts, findings);
+            scan_expr(&b.right, facts, findings);
+        }
+        Expr::Tuple(t) => {
+            for elem in &t.elems {
+                scan_expr(elem, facts, findings);
+            }
+        }
+        Expr::Return(r) => {
+            if let Some(inner) = &r.expr {
+                scan_expr(inner, facts, findings);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn scan_stmt(stmt: &syn::Stmt, facts: &mut HashSet<String>, findings: &mut Vec<TaintFinding>) {
+    match stmt {
+        syn::Stmt::Local(local) => {
+            if let Some(init) = &local.init {
+                scan_expr(&init.expr, facts, findings);
+                if expr_is_tainted(&init.expr, facts) {
+                    let mut names = HashSet::new();
+                    collect_pat_idents(&local.pat, &mut names);
+                    facts.extend(names);
+                }
+            }
+        }
+        syn::Stmt::Expr(expr, _) => process_top_level_expr(expr, facts, findings),
+        _ => {}
+    }
+}
+
+// ── Pattern / expression helpers ─────────────────────────────────────────────
+
+/// Recursively collects all identifier names bound by a pattern (handles
+/// tuple/struct/tuple-struct/reference destructures).
+pub fn collect_pat_idents(pat: &Pat, out: &mut HashSet<String>) {
+    match pat {
+        Pat::Ident(pi) => {
+            out.insert(pi.ident.to_string());
+        }
+        Pat::Tuple(pt) => {
+            for elem in &pt.elems {
+                collect_pat_idents(elem, out);
+            }
+        }
+        Pat::Struct(ps) => {
+            for field in &ps.fields {
+                collect_pat_idents(&field.pat, out);
+            }
+        }
+        Pat::TupleStruct(pts) => {
+            for elem in &pts.elems {
+                collect_pat_idents(elem, out);
+            }
+        }
+        Pat::Reference(pr) => collect_pat_idents(&pr.pat, out),
+        Pat::Type(pt) => collect_pat_idents(&pt.pat, out),
+        _ => {}
+    }
+}
+
+fn simple_pat_ident(pat: &Pat) -> Option<String> {
+    match pat {
+        Pat::Ident(pi) => Some(pi.ident.to_string()),
+        Pat::Type(pt) => simple_pat_ident(&pt.pat),
+        _ => None,
+    }
+}
+
+fn simple_expr_ident(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Path(p) => p.path.segments.last().map(|s| s.ident.to_string()),
+        _ => None,
+    }
+}
+
+/// Returns `true` if `expr` references any currently-tainted variable.
+pub fn expr_is_tainted(expr: &Expr, facts: &HashSet<String>) -> bool {
+    first_tainted_ident(expr, facts).is_some()
+}
+
+/// Returns the first tainted identifier referenced by `expr`, if any.
+fn first_tainted_ident(expr: &Expr, facts: &HashSet<String>) -> Option<String> {
+    match expr {
+        Expr::Path(p) => {
+            let name = p.path.segments.last()?.ident.to_string();
+            facts.contains(&name).then_some(name)
+        }
+        Expr::Reference(r) => first_tainted_ident(&r.expr, facts),
+        Expr::Paren(p) => first_tainted_ident(&p.expr, facts),
+        Expr::Group(g) => first_tainted_ident(&g.expr, facts),
+        Expr::Unary(u) => first_tainted_ident(&u.expr, facts),
+        Expr::Cast(c) => first_tainted_ident(&c.expr, facts),
+        Expr::Field(f) => first_tainted_ident(&f.base, facts),
+        Expr::MethodCall(mc) => first_tainted_ident(&mc.receiver, facts)
+            .or_else(|| mc.args.iter().find_map(|a| first_tainted_ident(a, facts))),
+        Expr::Call(c) => c.args.iter().find_map(|a| first_tainted_ident(a, facts)),
+        Expr::Tuple(t) => t.elems.iter().find_map(|e| first_tainted_ident(e, facts)),
+        Expr::Binary(b) => {
+            first_tainted_ident(&b.left, facts).or_else(|| first_tainted_ident(&b.right, facts))
+        }
+        _ => None,
+    }
+}
+
+fn is_storage_write(method: &str, receiver: &Expr) -> bool {
+    if !matches!(method, "set" | "update" | "remove") {
+        return false;
+    }
+    let s = quote::quote!(#receiver).to_string();
+    s.contains("storage") || s.contains("persistent") || s.contains("temporary") || s.contains("instance")
+}
+
+fn is_external_call(method: &str) -> bool {
+    matches!(
+        method,
+        "invoke_contract" | "try_invoke_contract" | "invoke_contract_check"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+
+    fn analyze_src(src: &str, sources: &[&str]) -> Vec<TaintFinding> {
+        let block: syn::Block = parse_str(&format!("{{ {src} }}")).unwrap();
+        analyze(&block, sources.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn flags_direct_taint_to_sink() {
+        let findings = analyze_src(
+            "env.storage().persistent().set(&key, &val);",
+            &["key", "val"],
+        );
+        assert!(!findings.is_empty());
+        assert_eq!(findings[0].sink, "set");
+    }
+
+    #[test]
+    fn require_auth_suppresses_finding() {
+        let findings = analyze_src(
+            "caller.require_auth(); env.storage().persistent().set(&key, &val);",
+            &["key", "val", "caller"],
+        );
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn taint_survives_aliasing_through_intermediate_variable() {
+        // key -> alias -> sink. A pure single-pass AST matcher that only
+        // checks direct parameter names at the call site would miss this if
+        // it didn't track the intermediate binding; the dataflow engine
+        // must propagate taint through the rebinding.
+        let findings = analyze_src(
+            "let alias = key; env.storage().persistent().set(&alias, &val);",
+            &["key", "val"],
+        );
+        assert!(
+            !findings.is_empty(),
+            "taint must propagate through an intermediate alias variable"
+        );
+    }
+
+    #[test]
+    fn reassignment_to_clean_value_kills_taint() {
+        let findings = analyze_src(
+            "let mut x = key; x = 0; env.storage().persistent().set(&x, &fixed_val);",
+            &["key"],
+        );
+        assert!(
+            findings.is_empty(),
+            "reassigning x to a constant must clear its taint"
+        );
+    }
+
+    #[test]
+    fn taint_introduced_inside_loop_body_is_caught() {
+        // The bug this module exists to fix: a pure top-to-bottom AST walk
+        // over the original rule never even visited for-loop bodies, so
+        // taint introduced by iterating a tainted collection was invisible.
+        let findings = analyze_src(
+            "let mut key = clean_key; for item in items.iter() { key = item; env.storage().persistent().set(&key, &val); }",
+            &["items", "val"],
+        );
+        assert!(
+            !findings.is_empty(),
+            "taint flowing from a tainted iterator into the loop variable must be caught"
+        );
+    }
+
+    #[test]
+    fn taint_from_one_if_branch_is_visible_after_join() {
+        let findings = analyze_src(
+            "let mut key = clean_key; if cond { key = tainted_input; } env.storage().persistent().set(&key, &val);",
+            &["tainted_input", "val"],
+        );
+        assert!(
+            !findings.is_empty(),
+            "taint introduced in only one branch must still be visible after the if/else joins"
+        );
+    }
+
+    #[test]
+    fn no_finding_when_no_source_reaches_sink() {
+        let findings = analyze_src(
+            "env.storage().persistent().set(&safe_key, &safe_val);",
+            &["unrelated_param"],
+        );
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn external_call_sink_is_detected() {
+        let findings = analyze_src(
+            "env.invoke_contract(&target, &fn_name, args);",
+            &["args"],
+        );
+        assert!(!findings.is_empty());
+        assert_eq!(findings[0].sink, "invoke_contract");
+    }
+}

--- a/tooling/sanctifier-core/tests/sep41_tests.rs
+++ b/tooling/sanctifier-core/tests/sep41_tests.rs
@@ -492,7 +492,7 @@ fn test_minimal_token_candidate_two_core_functions() {
     
     assert!(report.candidate, "Should be candidate with 2 core functions");
     assert!(!report.compliant, "Should not be compliant");
-    assert!(report.issues.len() > 0, "Should report missing functions");
+    assert!(!report.issues.is_empty(), "Should report missing functions");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **#490** — Fixes the `sanctifier-core` build/clippy failures blocking `make lint` and `cargo build`: removed an unused `Spanned` import in `contract_discovery.rs`, added `#[derive(Debug)]` to `parser::ParsedSource` (required by `.unwrap_err()` in tests), and fixed a `clippy::len_zero` lint in `sep41_tests.rs`. Verified clean under `cargo build -p sanctifier-core --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test -p sanctifier-core --all-features`.
- **#402** — Adds a constant-folding pass (`constant_folding.rs`) that evaluates literal-only arithmetic at analysis time, so trivial expressions like `1000 + 500` are no longer flagged by the S003 arithmetic-overflow rule.
- **#403** — Adds rule **S031: Gas Exhaustion Risk** (`rules/gas_exhaustion.rs`), detecting `for`/`while` loops whose bound traces back to an unbounded user-controlled parameter (`Vec`, `Map`, `Bytes`, or raw integers) without a clamp (`.min()`, `.take()`, etc.). Note: the issue text requested code `S012`, but that code is already assigned to `SEP41_INTERFACE_DEVIATION`, so the next free code `S031` was used instead.
- **#401** — Adds an intra-procedural CFG builder (`cfg.rs`) and a fixed-point taint dataflow engine (`taint_engine.rs`), replacing the single-pass AST walker in the S026 `taint_propagation` rule. This fixes a real gap where the old rule never visited loop bodies at all, so taint introduced inside a `for`/`while` loop, or in only one branch of an `if`, was invisible. Intra-procedural only, as scoped by the issue.

## Test plan

- [x] `cargo build -p sanctifier-core --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p sanctifier-core --all-features` (342 lib tests + all integration/snapshot tests pass)
- [x] New regression tests for each rule/module (constant folding, gas exhaustion, CFG construction, taint engine, loop/branch taint propagation)

Closes #490
Closes #402
Closes #403
Closes #401