### PR TITLE
feat: add release checklist, winget/scoop manifests, status bar impro…

### DIFF
--- a/.github/workflows/winget-scoop.yml
+++ b/.github/workflows/winget-scoop.yml
@@ -1,0 +1,118 @@
+name: Update Winget & Scoop Manifests
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  update-manifests:
+    name: Update Winget and Scoop manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download Windows amd64 binary
+        run: |
+          curl -fsSL -o sanctifier-windows-amd64.exe \
+            "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/sanctifier-windows-amd64.exe"
+
+      - name: Compute SHA256 for Winget manifest
+        id: sha256
+        run: |
+          sha=$(sha256sum sanctifier-windows-amd64.exe | cut -d ' ' -f 1)
+          echo "sha256=${sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Update Winget installer manifest
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA="${{ steps.sha256.outputs.sha256 }}"
+          sed -i "s|PackageVersion: .*|PackageVersion: ${VERSION}|g" winget/manifests/h/HyperSafeD/Sanctifier/*/HyperSafeD.Sanctifier.installer.yaml
+          sed -i "s|PackageVersion: .*|PackageVersion: ${VERSION}|g" winget/manifests/h/HyperSafeD/Sanctifier/*/HyperSafeD.Sanctifier.locale.en-US.yaml
+          sed -i "s|PackageVersion: .*|PackageVersion: ${VERSION}|g" winget/manifests/h/HyperSafeD/Sanctifier/*/HyperSafeD.Sanctifier.yaml
+          sed -i "s|/download/v[^/]*/|/download/v${VERSION}/|g" winget/manifests/h/HyperSafeD/Sanctifier/*/HyperSafeD.Sanctifier.installer.yaml
+          sed -i "s|/download/v[^/]*/|/download/v${VERSION}/|g" winget/manifests/h/HyperSafeD/Sanctifier/*/HyperSafeD.Sanctifier.locale.en-US.yaml
+          sed -i "s|/releases/tag/v[^\"]*|/releases/tag/v${VERSION}|g" winget/manifests/h/HyperSafeD/Sanctifier/*/HyperSafeD.Sanctifier.locale.en-US.yaml
+          sed -i "s|InstallerSha256: .*|InstallerSha256: ${SHA}|g" winget/manifests/h/HyperSafeD/Sanctifier/*/HyperSafeD.Sanctifier.installer.yaml
+
+      - name: Update Scoop manifest
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA="${{ steps.sha256.outputs.sha256 }}"
+          cat > scoop/sanctifier.json << MANIFESTEOF
+          {
+            "version": "${VERSION}",
+            "description": "Security copilot for Stellar Soroban smart contracts",
+            "homepage": "https://github.com/HyperSafeD/Sanctifier",
+            "license": "MIT OR Apache-2.0",
+            "architecture": {
+              "64bit": {
+                "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/v${VERSION}/sanctifier-windows-amd64.exe",
+                "hash": "${SHA}"
+              },
+              "arm64": {
+                "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/v${VERSION}/sanctifier-windows-arm64.exe",
+                "hash": "${SHA}"
+              }
+            },
+            "bin": [
+              [
+                "sanctifier-windows-amd64.exe",
+                "sanctifier"
+              ]
+            ],
+            "checkver": {
+              "github": "https://github.com/HyperSafeD/Sanctifier"
+            },
+            "autoupdate": {
+              "architecture": {
+                "64bit": {
+                  "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/\$version/sanctifier-windows-amd64.exe",
+                  "hash": {
+                    "url": "\$baseurl/SHA256SUMS"
+                  }
+                },
+                "arm64": {
+                  "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/\$version/sanctifier-windows-arm64.exe",
+                  "hash": {
+                    "url": "\$baseurl/SHA256SUMS"
+                  }
+                }
+              }
+            }
+          }
+          MANIFESTEOF
+
+      - name: Create Winget PR to microsoft/winget-pkgs
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.WINGET_PR_TOKEN }}
+          commit-message: "Update Sanctifier to v${{ steps.version.outputs.version }}"
+          title: "winget: Update HyperSafeD.Sanctifier to ${{ steps.version.outputs.version }}"
+          body: |
+            Auto-generated update for Sanctifier v${{ steps.version.outputs.version }}
+
+            Release: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+          branch: "winget/sanctifier-${{ steps.version.outputs.version }}"
+          base: "main"
+          path: "winget/manifests/h/HyperSafeD/Sanctifier/${{ steps.version.outputs.version }}"
+          labels: "automated,winget"
+        continue-on-error: true
+
+      - name: Commit updated manifest files to this repo
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update winget & scoop manifests for v${{ steps.version.outputs.version }}"
+          file_pattern: "winget/ scoop/"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,43 @@
+# Release Checklist
+
+This document describes the steps required to publish a new release of Sanctifier.
+
+## Pre-release
+
+- [ ] Ensure all CI checks pass on `main` (build, test, lint, coverage)
+- [ ] Update version in all `Cargo.toml` files to match the target release tag:
+  - `Cargo.toml` (workspace)
+  - `tooling/sanctifier-cli/Cargo.toml`
+  - `tooling/sanctifier-core/Cargo.toml`
+  - `tooling/sanctifier-detector/Cargo.toml`
+  - `tooling/sanctifier-wasm/Cargo.toml`
+- [ ] Update version in `vscode-extension/package.json`
+- [ ] Update `CHANGELOG.md` — move unreleased entries to a new version section
+- [ ] Run `cargo publish --dry-run -p sanctifier-core && cargo publish --dry-run -p sanctifier-cli` and fix any warnings
+- [ ] Run `cargo publish --dry-run -p sanctifier-detector` and fix any warnings
+- [ ] Verify all documentation links in `README.md` and `docs/` are valid
+- [ ] Check that `CARGO_REGISTRY_TOKEN` is set in GitHub Secrets
+
+## Release
+
+- [ ] Create and push an annotated tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`
+- [ ] Wait for the `Release` workflow to build and attach binaries
+- [ ] Wait for the `Publish to Crates.io` workflow to complete
+- [ ] Wait for the `Publish API Documentation` workflow to deploy docs
+- [ ] Wait for the `Release VS Code Extension` workflow to publish to VS Code Marketplace
+
+## Post-release
+
+- [ ] Verify `cargo install sanctifier-cli` installs the latest version
+- [ ] Verify the GitHub release page shows correct binaries and SHA256SUMS
+- [ ] Verify https://crates.io/crates/sanctifier-cli shows the new version
+- [ ] Verify `winget install HyperSafeD.Sanctifier` works
+- [ ] Verify `scoop install sanctifier` works
+- [ ] Verify VS Code extension updates in the marketplace
+- [ ] Verify https://docs.rs/sanctifier-cli shows the new version
+- [ ] Announce the release in relevant channels
+
+## Rollback (if needed)
+
+- [ ] Yank the crate: `cargo yank --vers X.Y.Z sanctifier-cli`
+- [ ] Delete the GitHub release and re-tag

--- a/scoop/sanctifier.json
+++ b/scoop/sanctifier.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.1.0",
+  "description": "Security copilot for Stellar Soroban smart contracts",
+  "homepage": "https://github.com/HyperSafeD/Sanctifier",
+  "license": "MIT OR Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/v0.1.0/sanctifier-windows-amd64.exe",
+      "hash": "PLACEHOLDER_SHA256"
+    },
+    "arm64": {
+      "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/v0.1.0/sanctifier-windows-arm64.exe",
+      "hash": "PLACEHOLDER_SHA256"
+    }
+  },
+  "bin": [
+    [
+      "sanctifier-windows-amd64.exe",
+      "sanctifier"
+    ]
+  ],
+  "checkver": {
+    "github": "https://github.com/HyperSafeD/Sanctifier"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/v$version/sanctifier-windows-amd64.exe",
+        "hash": {
+          "url": "$baseurl/SHA256SUMS"
+        }
+      },
+      "arm64": {
+        "url": "https://github.com/HyperSafeD/Sanctifier/releases/download/v$version/sanctifier-windows-arm64.exe",
+        "hash": {
+          "url": "$baseurl/SHA256SUMS"
+        }
+      }
+    }
+  }
+}

--- a/vscode-extension/PRIVACY.md
+++ b/vscode-extension/PRIVACY.md
@@ -1,0 +1,70 @@
+# Sanctifier VS Code Extension — Privacy Policy
+
+## Overview
+
+The Sanctifier VS Code extension may collect anonymous usage telemetry to help us understand how developers use the extension and prioritize improvements.
+
+**Telemetry is opt-in only** and is disabled by default. No data is sent unless you explicitly enable it.
+
+## What we collect
+
+When telemetry is enabled, the extension sends the following anonymous data:
+
+- **Scan count**: The number of times the analyzer has run
+- **Finding count by rule**: The number of findings per rule code (e.g., `S001: 5`, `S002: 3`)
+- **Extension version**: The version of the Sanctifier extension you are using
+- **VS Code version**: The version of VS Code you are using
+
+## What we NEVER collect
+
+We do not and will never collect:
+
+- Source code or file contents
+- File paths or workspace names
+- Contract names or addresses
+- Repository URLs
+- Personal information (names, emails, IP addresses)
+- Environment variables or secrets
+- Any other identifiable information
+
+## How we use the data
+
+The collected data helps us:
+
+- Understand which rules generate the most findings
+- Prioritize bug fixes and feature development
+- Understand VS Code version distribution for compatibility testing
+
+## Data storage and transmission
+
+- Data is sent via HTTPS to our analytics endpoint
+- No third-party analytics services are used
+- Data is aggregated and anonymized
+- No individual user or session identification is tracked
+
+## How to enable or disable telemetry
+
+You can enable or disable telemetry at any time in VS Code settings:
+
+1. Open Settings (`Cmd+,` or `Ctrl+,`)
+2. Search for `sanctifier.telemetry.enabled`
+3. Toggle the setting
+
+Or in `settings.json`:
+
+```json
+{
+  "sanctifier.telemetry.enabled": true
+}
+```
+
+When you first install the extension, you will be prompted to opt in. If you decline, no telemetry data will be sent.
+
+## Changes to this policy
+
+We may update this privacy policy from time to time. Changes will be reflected in this file and noted in the extension's changelog.
+
+## Contact
+
+For questions about this privacy policy, please open an issue at:
+https://github.com/HyperSafeD/Sanctifier/issues

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -64,6 +64,12 @@
           ],
           "default": "warning",
           "description": "Minimum severity level to surface in the editor. Findings below this threshold are silently suppressed."
+        },
+        "sanctifier.telemetry.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Send anonymous usage telemetry (scan count, finding count by rule, extension version, VS Code version). No source code or file paths are ever sent.",
+          "markdownDescription": "When enabled, Sanctifier sends anonymous usage data to help prioritize improvements. **No source code, file paths, or personal data is ever collected.** See the [privacy policy](https://github.com/HyperSafeD/Sanctifier/blob/main/vscode-extension/PRIVACY.md) for details."
         }
       }
     },

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -10,6 +10,7 @@ import { findingsToSarif, parseSarif, serialiseSarif, validateSarifShape, sarifT
 import { validateSarifContent, validateSarifResultCount, isPathWithinWorkspace, MAX_SARIF_BYTES } from './security';
 import { checkAndSuggestDevcontainer } from './devcontainer';
 import { SanctifierHoverProvider } from './hover';
+import { recordScan, sendTelemetry, promptTelemetryOptIn } from './telemetry';
 
 const SOURCE = 'sanctifier';
 const EXTENSION_VERSION: string = (() => {
@@ -74,9 +75,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
   const contentCache = new Map<string, string>();
 
   const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
-  statusBar.command = 'sanctifier.toggleEnable';
-  statusBar.tooltip = 'Sanctifier — click to toggle';
+  statusBar.command = 'workbench.actions.view.problems';
+  statusBar.tooltip = 'Sanctifier — click to open Problems panel';
   context.subscriptions.push(statusBar, collection, outputChannel);
+
+  let scanning = false;
 
   context.subscriptions.push(
     vscode.languages.registerHoverProvider(
@@ -89,14 +92,30 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
     const enabled = getConfig().get<boolean>('enable') ?? true;
     if (!enabled) {
       statusBar.text = '$(shield) Sanctifier: off';
+      statusBar.tooltip = 'Sanctifier is disabled — click to open Problems panel';
       statusBar.show();
       return;
     }
-    let total = 0;
-    for (const findings of findingsCache.values()) {
-      total += findings.length;
+    if (scanning) {
+      statusBar.text = '$(sync~spin) Sanctifier: scanning…';
+      statusBar.tooltip = 'Sanctifier is scanning…';
+      statusBar.show();
+      return;
     }
-    statusBar.text = total > 0 ? `$(shield) Sanctifier: ${total}` : '$(shield) Sanctifier';
+    const editor = vscode.window.activeTextEditor;
+    if (editor && editor.document.languageId === 'rust') {
+      const current = findingsCache.get(editor.document.uri.toString()) ?? [];
+      const count = current.length;
+      statusBar.text = count > 0
+        ? `$(warning) Sanctifier: ${count} finding${count !== 1 ? 's' : ''}`
+        : '$(shield) Sanctifier';
+      statusBar.tooltip = count > 0
+        ? `${count} finding${count !== 1 ? 's' : ''} — click to open Problems panel`
+        : 'Sanctifier — click to open Problems panel';
+    } else {
+      statusBar.text = '$(shield) Sanctifier';
+      statusBar.tooltip = 'Sanctifier — click to open Problems panel';
+    }
     statusBar.show();
   }
 
@@ -127,13 +146,24 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
     }
     contentCache.set(key, text);
 
+    scanning = true;
+    updateStatusBar();
+
     const minSeverity = (cfg.get<string>('minSeverity') ?? 'warning') as Severity;
     const allFindings = analyzeSorobanSource(text);
     const findings = filterBySeverity(allFindings, minSeverity);
 
+    const byRule: Record<string, number> = {};
+    for (const f of findings) {
+      byRule[f.code] = (byRule[f.code] ?? 0) + 1;
+    }
+    recordScan(byRule);
+
     findingsCache.set(doc.uri.toString(), findings);
     const diags = findings.map((f) => findingToDiagnostic(doc, f));
     collection.set(doc.uri, diags);
+
+    scanning = false;
     updateStatusBar();
   };
 
@@ -211,6 +241,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
           schedule(doc);
         }
       }
+    }),
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      updateStatusBar();
     })
   );
 
@@ -218,7 +251,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
     schedule(doc);
   }
 
-  // ── Commands ────────────────────────────────────────────────────────────────
+  // ── Telemetry opt-in prompt ──────────────────────────────────────────────────
 
   context.subscriptions.push(
     vscode.commands.registerCommand('sanctifier.toggleEnable', async () => {
@@ -273,8 +306,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
       outputChannel.clear();
       outputChannel.show(true);
       outputChannel.appendLine(`[sanctifier] Scanning ${folder.uri.fsPath} …`);
-
-      const minSeverity = (getConfig().get<string>('minSeverity') ?? 'warning') as Severity;
 
       // Security (#612): warn before executing binaries outside the workspace.
       const insideWorkspace = exe.startsWith(folder.uri.fsPath);
@@ -434,7 +465,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
         return;
       }
 
-      statusBar.text = '$(sync~spin) Sanctifier: generating SARIF…';
+      scanning = true;
+      updateStatusBar();
       try {
         const output = await new Promise<string | undefined>((resolve) => {
           const p = spawn(exe, ['analyze', folder.uri.fsPath, '--format', 'sarif'], {
@@ -448,7 +480,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
 
         if (!output) {
           vscode.window.showErrorMessage('Sanctifier CLI produced no SARIF output.');
-          statusBar.text = '$(shield) Sanctifier';
+          scanning = false;
+          updateStatusBar();
           return;
         }
 
@@ -466,7 +499,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
           `Failed to open SARIF report: ${e instanceof Error ? e.message : String(e)}`,
         );
       } finally {
-        statusBar.text = '$(shield) Sanctifier';
+        scanning = false;
+        updateStatusBar();
       }
     }),
 
@@ -479,6 +513,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
 
   // ── Devcontainer check ──────────────────────────────────────────────────────
   void checkAndSuggestDevcontainer();
+
+  // ── Telemetry ────────────────────────────────────────────────────────────────
+  void promptTelemetryOptIn(context);
 
   updateStatusBar();
 
@@ -495,4 +532,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<Sancti
 
 export function deactivate(): void {
   invalidateWorkspaceCache();
+  void sendTelemetry();
 }

--- a/vscode-extension/src/telemetry.ts
+++ b/vscode-extension/src/telemetry.ts
@@ -1,0 +1,107 @@
+import * as vscode from 'vscode';
+
+interface TelemetryPayload {
+  scan_count: number;
+  finding_count_by_rule: Record<string, number>;
+  extension_version: string;
+  vscode_version: string;
+}
+
+const TELEMETRY_ENDPOINT = 'https://telemetry.hypersafed.com/api/v1/ingest';
+
+const EXTENSION_VERSION: string = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return (require('../package.json') as { version: string }).version;
+  } catch {
+    return '0.0.0';
+  }
+})();
+
+let scanCount = 0;
+const findingCountByRule: Record<string, number> = {};
+
+export function recordScan(findingsByRule: Record<string, number>): void {
+  scanCount++;
+  for (const [rule, count] of Object.entries(findingsByRule)) {
+    findingCountByRule[rule] = (findingCountByRule[rule] ?? 0) + count;
+  }
+}
+
+export function buildPayload(): TelemetryPayload {
+  return {
+    scan_count: scanCount,
+    finding_count_by_rule: { ...findingCountByRule },
+    extension_version: EXTENSION_VERSION,
+    vscode_version: vscode.version,
+  };
+}
+
+export async function sendTelemetry(): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration('sanctifier');
+  if (!cfg.get<boolean>('telemetry.enabled')) {
+    return;
+  }
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    await fetch(TELEMETRY_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildPayload()),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  } catch {
+    /* silently drop telemetry errors */
+  }
+}
+
+export function resetTelemetry(): void {
+  scanCount = 0;
+  for (const key of Object.keys(findingCountByRule)) {
+    delete findingCountByRule[key];
+  }
+}
+
+export async function promptTelemetryOptIn(context: vscode.ExtensionContext): Promise<void> {
+  const key = 'sanctifier.telemetry.firstRunPrompted';
+  if (context.globalState.get<boolean>(key)) {
+    return;
+  }
+  await context.globalState.update(key, true);
+
+  const cfg = vscode.workspace.getConfiguration('sanctifier');
+  const alreadySet = cfg.inspect<boolean>('telemetry.enabled');
+  if (alreadySet?.globalValue !== undefined) {
+    return;
+  }
+
+  const choice = await vscode.window.showInformationMessage(
+    'Sanctifier: Help us improve by sharing anonymous usage telemetry? No source code or file paths are ever sent.',
+    { modal: false },
+    'Yes, enable telemetry',
+    'No, thanks',
+    'Read privacy policy',
+  );
+
+  if (choice === 'Yes, enable telemetry') {
+    await cfg.update('telemetry.enabled', true, vscode.ConfigurationTarget.Global);
+  } else if (choice === 'No, thanks') {
+    await cfg.update('telemetry.enabled', false, vscode.ConfigurationTarget.Global);
+  } else if (choice === 'Read privacy policy') {
+    await vscode.env.openExternal(
+      vscode.Uri.parse('https://github.com/HyperSafeD/Sanctifier/blob/main/vscode-extension/PRIVACY.md'),
+    );
+    const followUp = await vscode.window.showInformationMessage(
+      'Sanctifier: Enable anonymous usage telemetry?',
+      'Yes',
+      'No',
+    );
+    if (followUp === 'Yes') {
+      await cfg.update('telemetry.enabled', true, vscode.ConfigurationTarget.Global);
+    } else if (followUp === 'No') {
+      await cfg.update('telemetry.enabled', false, vscode.ConfigurationTarget.Global);
+    }
+  }
+}

--- a/winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/HyperSafeD.Sanctifier.installer.yaml
+++ b/winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/HyperSafeD.Sanctifier.installer.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: HyperSafeD.Sanctifier
+PackageVersion: 0.1.0
+InstallerLocale: en-US
+InstallerType: portable
+Commands:
+  - sanctifier
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/HyperSafeD/Sanctifier/releases/download/v0.1.0/sanctifier-windows-amd64.exe
+    InstallerSha256: PLACEHOLDER_SHA256
+    UpgradeBehavior: uninstallPrevious
+  - Architecture: arm64
+    InstallerUrl: https://github.com/HyperSafeD/Sanctifier/releases/download/v0.1.0/sanctifier-windows-arm64.exe
+    InstallerSha256: PLACEHOLDER_SHA256
+    UpgradeBehavior: uninstallPrevious
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/HyperSafeD.Sanctifier.locale.en-US.yaml
+++ b/winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/HyperSafeD.Sanctifier.locale.en-US.yaml
@@ -1,0 +1,26 @@
+PackageIdentifier: HyperSafeD.Sanctifier
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: HyperSafeD
+PublisherUrl: https://github.com/HyperSafeD
+PublisherSupportUrl: https://github.com/HyperSafeD/Sanctifier/issues
+PrivacyUrl: https://github.com/HyperSafeD/Sanctifier/blob/main/vscode-extension/PRIVACY.md
+Author: Sanctifier Contributors
+PackageName: Sanctifier
+PackageUrl: https://github.com/HyperSafeD/Sanctifier
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/HyperSafeD/Sanctifier/blob/main/LICENSE
+Copyright: Copyright (c) Sanctifier Contributors
+ShortDescription: Security copilot for Stellar Soroban smart contracts
+Description: Sanctifier is a static analysis and formal verification tool for Stellar Soroban smart contracts. It detects security vulnerabilities including auth gaps, unsafe unwraps, arithmetic overflow, and more.
+Tags:
+  - soroban
+  - stellar
+  - security
+  - static-analysis
+  - rust
+  - smart-contracts
+  - cli
+ReleaseNotesUrl: https://github.com/HyperSafeD/Sanctifier/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/HyperSafeD.Sanctifier.yaml
+++ b/winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/HyperSafeD.Sanctifier.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: HyperSafeD.Sanctifier
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
closes #1051 
closes #1053 
closes #1058 
closes #1060 
## Summary

This PR implements four open source contributions in a single changeset, covering release infrastructure, Windows package managers, VS Code extension UX improvements, and opt-in telemetry.

---

## Changes

### 1. Cargo publish & release workflow

- Added `RELEASE_CHECKLIST.md` — step-by-step guide covering pre-release version bumps, tag creation, CI verification, crates.io publish, VS Code Marketplace publish, Winget/Scoop updates, and rollback procedures
- Verified `cargo publish --dry-run -p sanctifier-core` and `-p sanctifier-detector` package cleanly (98 files / 879.9 KiB and 11 files / 65.8 KiB respectively)
- `sanctifier-cli` depends on `sanctifier-core` which must be published first — the existing `.github/workflows/publish.yml` already handles the correct ordering (publish core → wait for crates.io propagation → publish CLI)

### 2. Windows package manager manifests

- **Winget**: Created `winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/` with three manifest files:
  - `HyperSafeD.Sanctifier.installer.yaml` — portable installer for x64 and arm64
  - `HyperSafeD.Sanctifier.locale.en-US.yaml` — package metadata, tags, description
  - `HyperSafeD.Sanctifier.yaml` — version manifest

- **Scoop**: Created `scoop/sanctifier.json` with:
  - x64 and arm64 architecture support
  - `checkver` for automatic version detection
  - `autoupdate` to pull hashes from SHA256SUMS

- **CI automation**: Added `.github/workflows/winget-scoop.yml` that:
  - Triggers on `v*.*.*` tag pushes
  - Downloads the Windows binary and computes SHA256
  - Auto-updates both Winget and Scoop manifest files in-repo
  - Opens a PR against `microsoft/winget-pkgs` for review

### 3. VS Code status bar improvements

Refactored the status bar in `vscode-extension/src/extension.ts`:

- **Current-file count**: Status bar now shows the finding count for only the active Rust file (e.g. `⚠ Sanctifier: 3 findings`) instead of the total across all open files
- **Scanning spinner**: Displays `$(sync~spin) Sanctifier: scanning…` during active analysis
- **Problems panel**: Clicking the status bar opens the Problems panel (`workbench.actions.view.problems`) instead of toggling enable/disable
- **Active editor tracking**: Added `onDidChangeActiveTextEditor` listener to update the count immediately when switching editors
- **SARIF generation** also uses the scanning state for consistent UX

### 4. Opt-in telemetry

- **Configuration**: Added `sanctifier.telemetry.enabled` setting (default: `false`) to `package.json`

- **New module**: `vscode-extension/src/telemetry.ts` with:
  - `recordScan()` — increments scan count and aggregates findings by rule code
  - `sendTelemetry()` — sends JSON payload via HTTPS with 5s timeout, silently drops on failure
  - `promptTelemetryOptIn()` — first-run dialog with Yes / No / Read Privacy Policy options
  - `resetTelemetry()` / `buildPayload()` — state management

- **Integration**: Wired into `extension.ts`:
  - `recordScan()` called after every analysis with per-rule finding counts
  - `promptTelemetryOptIn()` called once on first activation
  - `sendTelemetry()` called on extension deactivation

- **What is tracked**:
  - Scan count
  - Finding count by rule (e.g. `{ "S001": 5, "S002": 3 }`)
  - Extension version
  - VS Code version

- **What is NEVER tracked**: source code, file paths, contract names, repository URLs, IP addresses, personal data, secrets

- **Privacy policy**: Added `vscode-extension/PRIVACY.md` with clear documentation of data collection, storage, and opt-out instructions

---

## Files changed

| File | Change |
|---|---|
| `RELEASE_CHECKLIST.md` | New — release process documentation |
| `.github/workflows/winget-scoop.yml` | New — CI automation for Winget/Scoop |
| `winget/manifests/h/HyperSafeD/Sanctifier/0.1.0/*.yaml` | New — Winget manifests (3 files) |
| `scoop/sanctifier.json` | New — Scoop bucket manifest |
| `vscode-extension/PRIVACY.md` | New — extension privacy policy |
| `vscode-extension/src/telemetry.ts` | New — telemetry module |
| `vscode-extension/package.json` | Modified — added `sanctifier.telemetry.enabled` config |
| `vscode-extension/src/extension.ts` | Modified — status bar refactor, telemetry integration |

---

## Verification

- [x] TypeScript compilation: `tsc -p ./ --noEmit` — zero errors
- [x] ESLint: `eslint src --ext .ts --max-warnings 0` — zero warnings
- [x] Jest: `117/117 tests passing`
- [x] `cargo publish --dry-run -p sanctifier-core` — packages successfully
- [x] `cargo publish --dry-run -p sanctifier-detector` — packages successfully
- [x] `sanctifier-cli` dry-run correctly fails on missing crates.io dependency (CI ordering handles this)
