### PR TITLE
feat: add Docker, npm, Homebrew distribution and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,13 @@ jobs:
         with:
           subject-path: ${{ matrix.artifact_name }}
 
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}
+          retention-days: 7
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
@@ -124,3 +131,162 @@ jobs:
           cd release
           sha256sum * > SHA256SUMS
           gh release upload "$TAG" SHA256SUMS --repo "$REPO" --clobber
+
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    needs: build-and-release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download musl binary artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: sanctifier-linux-amd64-musl
+          path: .
+
+      - name: Set image name
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=ghcr.io/${OWNER}/sanctifier" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ci
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build-and-release
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish @hypersafed/sanctifier-cli
+        working-directory: packages/sanctifier-cli-npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  homebrew-update:
+    name: Update Homebrew formula
+    runs-on: ubuntu-latest
+    needs: build-and-release
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download macOS binaries from release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          mkdir -p binaries
+          gh release download "$TAG" --repo "$REPO" --pattern 'sanctifier-macos-amd64' --dir binaries
+          gh release download "$TAG" --repo "$REPO" --pattern 'sanctifier-macos-arm64' --dir binaries
+
+      - name: Calculate SHA256 checksums
+        id: shas
+        run: |
+          echo "amd64=$(sha256sum binaries/sanctifier-macos-amd64 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "arm64=$(sha256sum binaries/sanctifier-macos-arm64 | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - name: Generate updated formula
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          AMD64_SHA="${{ steps.shas.outputs.amd64 }}"
+          ARM64_SHA="${{ steps.shas.outputs.arm64 }}"
+
+          python3 -c "
+          import re
+
+          with open('homebrew/sanctifier.rb', 'r') as f:
+              content = f.read()
+
+          content = re.sub(r'version \"[^\"]*\"', f'version \"{VERSION}\"', content)
+          content = re.sub(
+              r'url \"https://github\.com/HyperSafeD/Sanctifier/releases/download/v[^\"]*/sanctifier-macos-arm64\"',
+              f'url \"https://github.com/HyperSafeD/Sanctifier/releases/download/v{VERSION}/sanctifier-macos-arm64\"',
+              content
+          )
+          content = re.sub(
+              r'url \"https://github\.com/HyperSafeD/Sanctifier/releases/download/v[^\"]*/sanctifier-macos-amd64\"',
+              f'url \"https://github.com/HyperSafeD/Sanctifier/releases/download/v{VERSION}/sanctifier-macos-amd64\"',
+              content
+          )
+          content = re.sub(
+              r'url \"https://github\.com/HyperSafeD/Sanctifier/releases/download/v[^\"]*/sanctifier-linux-amd64-musl\"',
+              f'url \"https://github.com/HyperSafeD/Sanctifier/releases/download/v{VERSION}/sanctifier-linux-amd64-musl\"',
+              content
+          )
+          content = re.sub(r'sha256 \"[a-f0-9]{64}\"', f'sha256 \"{ARM64_SHA}\"', content, count=1)
+          content = re.sub(r'sha256 \"[a-f0-9]{64}\"', f'sha256 \"{AMD64_SHA}\"', content, count=1)
+
+          with open('homebrew/sanctifier.rb', 'w') as f:
+              f.write(content)
+          "
+
+          echo "Generated homebrew/sanctifier.rb:"
+          cat homebrew/sanctifier.rb
+
+      - name: Checkout Homebrew tap repo and push formula
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN is not set; skipping Homebrew tap push."
+            echo "Set up this secret to auto-update Homebrew formula on release."
+            exit 0
+          fi
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/HyperSafeD/homebrew-sanctifier.git" /tmp/homebrew-tap
+
+          cp homebrew/sanctifier.rb /tmp/homebrew-tap/
+
+          cd /tmp/homebrew-tap
+
+          if git diff --quiet sanctifier.rb; then
+            echo "Formula already up to date; nothing to push."
+          else
+            git add sanctifier.rb
+            git commit -m "Update sanctifier to ${TAG}"
+            git push origin main
+            echo "Pushed updated formula to HyperSafeD/homebrew-sanctifier"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Format Guidelines
+
+- Each version section starts with `## [X.Y.Z] - YYYY-MM-DD`
+- Sub-sections: `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`
+- Bullet points start with `-` and describe user-facing changes
+- Reference issue/PR numbers where applicable
+
 ## [Unreleased]
 
 ### Added
+
+- Docker image published to ghcr.io/hypersafed/sanctifier on each release
+- npm wrapper @hypersafed/sanctifier-cli for npx usage without Rust toolchain
+- Homebrew formula for macOS and Linux (brew install HyperSafeD/sanctifier/sanctifier)
+- `scripts/release.sh` to automate version bumps across all manifests
+- `action.yml` now supports `use-docker` input for containerized analysis
 
 - **S012 (SEP-41) Hardening**: Comprehensive improvements to SEP-41 token interface checks
   - Enhanced module-level documentation in `tooling/sanctifier-core/src/sep41.rs` with usage examples, safety considerations, and contribution guidelines

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,16 @@
-# Stage 1: Build the Sanctifier CLI
-FROM rust:1.75-slim AS builder
+ARG VERSION=0.1.0
+FROM alpine:3.20 AS fetcher
+RUN apk add --no-cache curl ca-certificates
+ARG VERSION
+RUN curl -fsSL -o /sanctifier \
+    "https://github.com/HyperSafeD/Sanctifier/releases/download/v${VERSION}/sanctifier-linux-amd64-musl" \
+    && chmod +x /sanctifier \
+    && curl -fsSL -o /sanctifier.sha256 \
+    "https://github.com/HyperSafeD/Sanctifier/releases/download/v${VERSION}/sanctifier-linux-amd64-musl.sha256" \
+    && cd / && sha256sum -c sanctifier.sha256
 
-RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /app
-
-# Copy workspace manifests first for better layer caching
-COPY Cargo.toml Cargo.lock ./
-COPY tooling/sanctifier-core/Cargo.toml tooling/sanctifier-core/
-COPY tooling/sanctifier-cli/Cargo.toml tooling/sanctifier-cli/
-COPY contracts/vulnerable-contract/Cargo.toml contracts/vulnerable-contract/
-COPY contracts/kani-poc/Cargo.toml contracts/kani-poc/
-COPY contracts/amm-pool/Cargo.toml contracts/amm-pool/
-
-# Create dummy source files for dependency caching
-RUN mkdir -p tooling/sanctifier-core/src && echo "pub fn dummy() {}" > tooling/sanctifier-core/src/lib.rs \
-    && mkdir -p tooling/sanctifier-cli/src && echo "fn main() {}" > tooling/sanctifier-cli/src/main.rs \
-    && mkdir -p contracts/vulnerable-contract/src && echo "#![no_std]" > contracts/vulnerable-contract/src/lib.rs \
-    && mkdir -p contracts/kani-poc/src && echo "#![no_std]" > contracts/kani-poc/src/lib.rs \
-    && mkdir -p contracts/amm-pool/src && echo "" > contracts/amm-pool/src/lib.rs
-
-# Build dependencies only (cached layer)
-RUN cargo build --release --package sanctifier-cli 2>/dev/null || true
-
-# Copy actual source code
-COPY tooling/ tooling/
-COPY contracts/ contracts/
-
-# Build the real binary
-RUN cargo build --release --package sanctifier-cli
-
-# Stage 2: Minimal runtime image
-FROM debian:bookworm-slim
-
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /app/target/release/sanctifier-cli /usr/local/bin/sanctifier
-
+FROM scratch
+COPY --from=fetcher /sanctifier /usr/local/bin/sanctifier
 WORKDIR /workspace
-
-ENTRYPOINT ["sanctifier"]
+ENTRYPOINT ["/usr/local/bin/sanctifier"]
 CMD ["--help"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,5 @@
+FROM scratch
+COPY sanctifier-linux-amd64-musl /usr/local/bin/sanctifier
+WORKDIR /workspace
+ENTRYPOINT ["/usr/local/bin/sanctifier"]
+CMD ["--help"]

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -5,32 +5,44 @@ This document describes the steps required to publish a new release of Sanctifie
 ## Pre-release
 
 - [ ] Ensure all CI checks pass on `main` (build, test, lint, coverage)
-- [ ] Update version in all `Cargo.toml` files to match the target release tag:
+- [ ] Run `scripts/release.sh X.Y.Z` to bump all version strings
   - `Cargo.toml` (workspace)
-  - `tooling/sanctifier-cli/Cargo.toml`
+  - `tooling/sanctifier-cli/Cargo.toml` (including sanctifier-core dep)
   - `tooling/sanctifier-core/Cargo.toml`
   - `tooling/sanctifier-detector/Cargo.toml`
   - `tooling/sanctifier-wasm/Cargo.toml`
-- [ ] Update version in `vscode-extension/package.json`
-- [ ] Update `CHANGELOG.md` — move unreleased entries to a new version section
+  - `vscode-extension/package.json`
+  - `packages/sanctifier-cli-npm/package.json`
+  - `homebrew/sanctifier.rb`
+- [ ] Update `CHANGELOG.md` — move Unreleased entries to a new `[X.Y.Z]` section
 - [ ] Run `cargo publish --dry-run -p sanctifier-core && cargo publish --dry-run -p sanctifier-cli` and fix any warnings
 - [ ] Run `cargo publish --dry-run -p sanctifier-detector` and fix any warnings
 - [ ] Verify all documentation links in `README.md` and `docs/` are valid
 - [ ] Check that `CARGO_REGISTRY_TOKEN` is set in GitHub Secrets
+- [ ] Check that `NPM_TOKEN` is set in GitHub Secrets (for @hypersafed/sanctifier-cli)
 
 ## Release
 
-- [ ] Create and push an annotated tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`
+- [ ] Commit version bump: `git commit -am "chore: bump version to X.Y.Z"`
+- [ ] Create and push an annotated tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin main && git push origin vX.Y.Z`
 - [ ] Wait for the `Release` workflow to build and attach binaries
 - [ ] Wait for the `Publish to Crates.io` workflow to complete
+- [ ] Wait for the `Publish to npm` workflow to publish @hypersafed/sanctifier-cli
+- [ ] Wait for the `Docker` workflow to push to ghcr.io/hypersafed/sanctifier
+- [ ] Wait for the `Homebrew` workflow to update HyperSafeD/homebrew-sanctifier
 - [ ] Wait for the `Publish API Documentation` workflow to deploy docs
 - [ ] Wait for the `Release VS Code Extension` workflow to publish to VS Code Marketplace
 
 ## Post-release
 
 - [ ] Verify `cargo install sanctifier-cli` installs the latest version
+- [ ] Verify `npx @hypersafed/sanctifier-cli analyze ./my-contract` works
+- [ ] Verify `docker run --rm -v $(pwd):/workspace ghcr.io/hypersafed/sanctifier analyze /workspace` works
+- [ ] Verify `brew install HyperSafeD/sanctifier/sanctifier` works
 - [ ] Verify the GitHub release page shows correct binaries and SHA256SUMS
 - [ ] Verify https://crates.io/crates/sanctifier-cli shows the new version
+- [ ] Verify https://www.npmjs.com/package/@hypersafed/sanctifier-cli shows the new version
+- [ ] Verify https://github.com/HyperSafeD/packages shows the Docker image
 - [ ] Verify `winget install HyperSafeD.Sanctifier` works
 - [ ] Verify `scoop install sanctifier` works
 - [ ] Verify VS Code extension updates in the marketplace
@@ -40,4 +52,5 @@ This document describes the steps required to publish a new release of Sanctifie
 ## Rollback (if needed)
 
 - [ ] Yank the crate: `cargo yank --vers X.Y.Z sanctifier-cli`
+- [ ] Unpublish the npm package: `npm unpublish @hypersafed/sanctifier-cli@X.Y.Z`
 - [ ] Delete the GitHub release and re-tag

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: Enable verbose debug logging for the action steps (safe-by-default; no secrets)
     required: false
     default: "false"
+  use-docker:
+    description: Run sanctifier via the ghcr.io/hypersafed/sanctifier Docker image instead of installing via cargo
+    required: false
+    default: "false"
 
 outputs:
   findings-count:
@@ -60,6 +64,7 @@ runs:
         cat "$RUNNER_TEMP/sanctifier_action_inputs" >> "$GITHUB_ENV"
 
     - name: Install Sanctifier CLI
+      if: ${{ inputs.use-docker != 'true' }}
       shell: bash
       run: |
         python "${{ github.action_path }}/scripts/resolve_action_version.py" \
@@ -79,7 +84,8 @@ runs:
           cargo install sanctifier-cli --locked
         fi
 
-    - name: Analyze project
+    - name: Analyze project (native)
+      if: ${{ inputs.use-docker != 'true' }}
       shell: bash
       run: |
         if [ "${SANCTIFIER_ACTION_DEBUG:-false}" = "true" ]; then
@@ -93,6 +99,42 @@ runs:
             --exit-code > "$SANCTIFIER_ACTION_SARIF_OUTPUT"
         else
           sanctifier analyze "$SANCTIFIER_ACTION_PATH" \
+            --format "$SANCTIFIER_ACTION_FORMAT" \
+            --min-severity "$SANCTIFIER_ACTION_MIN_SEVERITY" \
+            --exit-code
+        fi
+
+    - name: Analyze project (Docker)
+      if: ${{ inputs.use-docker == 'true' }}
+      shell: bash
+      run: |
+        DOCKER_TAG="${{ inputs.version }}"
+        if [ -z "$DOCKER_TAG" ]; then
+          DOCKER_TAG="latest"
+        fi
+
+        SCAN_ABS_PATH="$(realpath "$SANCTIFIER_ACTION_PATH" 2>/dev/null || cd "$SANCTIFIER_ACTION_PATH" && pwd)"
+        IMAGE_OWNER=$(echo "${{ github.action_repository }}" | cut -d'/' -f1 | tr '[:upper:]' '[:lower:]')
+        IMAGE="ghcr.io/${IMAGE_OWNER}/sanctifier:${DOCKER_TAG}"
+
+        if [ "${SANCTIFIER_ACTION_DEBUG:-false}" = "true" ]; then
+          echo "[sanctifier-action][debug] scan path=$SCAN_ABS_PATH format=$SANCTIFIER_ACTION_FORMAT min_severity=$SANCTIFIER_ACTION_MIN_SEVERITY docker_image=$IMAGE"
+        fi
+
+        if [ "$SANCTIFIER_ACTION_FORMAT" = "sarif" ]; then
+          mkdir -p "$(dirname "$SANCTIFIER_ACTION_SARIF_OUTPUT")"
+          docker run --rm \
+            -v "${SCAN_ABS_PATH}:/workspace" \
+            "${IMAGE}" \
+            analyze /workspace \
+            --format sarif \
+            --min-severity "$SANCTIFIER_ACTION_MIN_SEVERITY" \
+            --exit-code > "$SANCTIFIER_ACTION_SARIF_OUTPUT"
+        else
+          docker run --rm \
+            -v "${SCAN_ABS_PATH}:/workspace" \
+            "${IMAGE}" \
+            analyze /workspace \
             --format "$SANCTIFIER_ACTION_FORMAT" \
             --min-severity "$SANCTIFIER_ACTION_MIN_SEVERITY" \
             --exit-code

--- a/homebrew/sanctifier.rb
+++ b/homebrew/sanctifier.rb
@@ -1,0 +1,31 @@
+class Sanctifier < Formula
+  desc "Security copilot for Stellar Soroban smart contracts"
+  homepage "https://github.com/HyperSafeD/Sanctifier"
+  license "MIT OR Apache-2.0"
+  version "0.1.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/HyperSafeD/Sanctifier/releases/download/v#{version}/sanctifier-macos-arm64"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    else
+      url "https://github.com/HyperSafeD/Sanctifier/releases/download/v#{version}/sanctifier-macos-amd64"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  on_linux do
+    url "https://github.com/HyperSafeD/Sanctifier/releases/download/v#{version}/sanctifier-linux-amd64-musl"
+    sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  end
+
+  def install
+    bin.install "sanctifier-macos-arm64" => "sanctifier" if OS.mac? && Hardware::CPU.arm?
+    bin.install "sanctifier-macos-amd64" => "sanctifier" if OS.mac? && Hardware::CPU.intel?
+    bin.install "sanctifier-linux-amd64-musl" => "sanctifier" if OS.linux?
+  end
+
+  test do
+    system "#{bin}/sanctifier", "--version"
+  end
+end

--- a/packages/sanctifier-cli-npm/bin/sanctifier.js
+++ b/packages/sanctifier-cli-npm/bin/sanctifier.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+const { existsSync, mkdirSync, chmodSync, writeFileSync, unlinkSync } = require("fs");
+const path = require("path");
+const os = require("os");
+
+const BINARY_NAME = "sanctifier";
+const REPO = "HyperSafeD/Sanctifier";
+const CACHE_DIR = path.join(os.homedir(), ".sanctifier", "bin");
+const GITHUB_API = "https://api.github.com";
+
+function getPlatform() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  if (platform === "linux" && arch === "x64") return "linux-amd64-musl";
+  if (platform === "darwin" && arch === "x64") return "macos-amd64";
+  if (platform === "darwin" && arch === "arm64") return "macos-arm64";
+  if (platform === "win32" && arch === "x64") return "windows-amd64";
+
+  throw new Error(
+    `Unsupported platform: ${platform}/${arch}. Sanctifier currently supports macOS (x64/arm64) and Linux (x64).`
+  );
+}
+
+function getBinaryName(platform) {
+  if (platform.startsWith("windows")) return `${BINARY_NAME}-${platform}.exe`;
+  return `${BINARY_NAME}-${platform}`;
+}
+
+async function fetchLatestVersion() {
+  const url = `${GITHUB_API}/repos/${REPO}/releases/latest`;
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "@hypersafed/sanctifier-cli" },
+    });
+    if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+    const data = await res.json();
+    return data.tag_name.replace(/^v/, "");
+  } catch (err) {
+    const result = spawnSync("curl", ["-fsSL", url], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status !== 0)
+      throw new Error(
+        `Failed to fetch latest version. ${result.stderr || err.message}`
+      );
+    const data = JSON.parse(result.stdout);
+    return data.tag_name.replace(/^v/, "");
+  }
+}
+
+async function downloadBinary(version, platform, dest) {
+  const binaryName = getBinaryName(platform);
+  const downloadUrl = `https://github.com/${REPO}/releases/download/v${version}/${binaryName}`;
+
+  const res = await fetch(downloadUrl, {
+    headers: { "User-Agent": "@hypersafed/sanctifier-cli" },
+    redirect: "follow",
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to download binary: HTTP ${res.status} from ${downloadUrl}`
+    );
+  }
+
+  if (!existsSync(path.dirname(dest))) {
+    mkdirSync(path.dirname(dest), { recursive: true });
+  }
+
+  const buffer = Buffer.from(await res.arrayBuffer());
+  writeFileSync(dest, buffer);
+  chmodSync(dest, 0o755);
+}
+
+async function ensureBinary() {
+  const platform = getPlatform();
+  const binaryName =
+    os.platform() === "win32"
+      ? `${BINARY_NAME}.exe`
+      : BINARY_NAME;
+  const cachedBinary = path.join(CACHE_DIR, binaryName);
+
+  if (existsSync(cachedBinary)) return cachedBinary;
+
+  const version = await fetchLatestVersion();
+  await downloadBinary(version, platform, cachedBinary);
+  return cachedBinary;
+}
+
+async function main() {
+  let binaryPath;
+  try {
+    binaryPath = await ensureBinary();
+  } catch (err) {
+    console.error(
+      `sanctifier: failed to download binary. ${err.message}`
+    );
+    console.error("Install via cargo: cargo install sanctifier-cli");
+    console.error("Install via brew:  brew install HyperSafeD/sanctifier/sanctifier");
+    process.exit(1);
+  }
+
+  const args = process.argv.slice(2);
+  const result = spawnSync(binaryPath, args, { stdio: "inherit" });
+
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      console.error(
+        `sanctifier: binary not found at ${binaryPath}. Cache may be corrupt.`
+      );
+      try {
+        unlinkSync(binaryPath);
+      } catch (_) {}
+      process.exit(1);
+    }
+    console.error(`sanctifier: failed to run binary. ${result.error.message}`);
+    process.exit(1);
+  }
+
+  process.exit(result.status || 0);
+}
+
+main().catch((err) => {
+  console.error(`sanctifier: unexpected error. ${err.message}`);
+  process.exit(1);
+});

--- a/packages/sanctifier-cli-npm/package.json
+++ b/packages/sanctifier-cli-npm/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@hypersafed/sanctifier-cli",
+  "version": "0.1.0",
+  "description": "CLI wrapper for Sanctifier — Stellar Soroban Security Suite. Downloads the pre-built binary on first run.",
+  "license": "MIT OR Apache-2.0",
+  "homepage": "https://github.com/HyperSafeD/Sanctifier",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HyperSafeD/Sanctifier.git",
+    "directory": "packages/sanctifier-cli-npm"
+  },
+  "bin": {
+    "sanctifier": "bin/sanctifier.js"
+  },
+  "files": [
+    "bin/sanctifier.js",
+    "package.json"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "keywords": [
+    "soroban",
+    "stellar",
+    "security",
+    "static-analysis",
+    "smart-contracts",
+    "sanctifier"
+  ]
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.2.0"
+  exit 1
+fi
+
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  echo "Error: version must be in semver format (e.g. 0.2.0, 0.2.0-rc1)"
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "Bumping version to $VERSION"
+
+prev_version=$(grep -E '^version\s*=' tooling/sanctifier-cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+echo "  Current version: $prev_version"
+
+bump_cargo_toml() {
+  local file="$1"
+  if grep -q '^version = ' "$file"; then
+    sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" "$file" && rm -f "$file.bak"
+    echo "  Updated $file"
+  fi
+}
+
+bump_cargo_dep_version() {
+  local file="$1"
+  local dep="$2"
+  if grep -q "$dep" "$file"; then
+    sed -i.bak "s/\\($dep.*version = \"\\)[^\"]*\"/\\1$VERSION\"/" "$file" && rm -f "$file.bak"
+    echo "  Updated $dep dependency in $file"
+  fi
+}
+
+bump_package_json() {
+  local file="$1"
+  if grep -q '"version"' "$file"; then
+    sed -i.bak 's/"version": "[^"]*"/"version": "'"$VERSION"'"/' "$file" && rm -f "$file.bak"
+    echo "  Updated $file"
+  fi
+}
+
+bump_homebrew_formula() {
+  local file="$1"
+  sed -i.bak "s/version \"[^\"]*\"/version \"$VERSION\"/" "$file" && rm -f "$file.bak"
+  echo "  Updated $file"
+}
+
+bump_cargo_toml "Cargo.toml"
+bump_cargo_toml "tooling/sanctifier-cli/Cargo.toml"
+bump_cargo_toml "tooling/sanctifier-core/Cargo.toml"
+bump_cargo_toml "tooling/sanctifier-detector/Cargo.toml"
+bump_cargo_toml "tooling/sanctifier-wasm/Cargo.toml"
+
+bump_cargo_dep_version "tooling/sanctifier-cli/Cargo.toml" "sanctifier-core"
+
+bump_package_json "vscode-extension/package.json"
+bump_package_json "packages/sanctifier-cli-npm/package.json"
+
+bump_homebrew_formula "homebrew/sanctifier.rb"
+
+echo ""
+echo "Version bump complete: $prev_version → $VERSION"
+echo ""
+echo "Next steps:"
+echo "  1. Review the changes: git diff"
+echo "  2. Update CHANGELOG.md — move Unreleased entries to a new [$VERSION] section"
+echo "  3. Commit: git commit -am 'chore: bump version to $VERSION'"
+echo "  4. Tag:    git tag -a v$VERSION -m 'Release v$VERSION'"
+echo "  5. Push:   git push origin main && git push origin v$VERSION"


### PR DESCRIPTION
closes #1057 
closes #1059 
closes #1061 
closes #1062 


## Summary

Add four distribution channels and a fully automated release pipeline so users can install Sanctifier without a Rust toolchain.

## Changes

### 1. Docker image (`ghcr.io/hypersafed/sanctifier`)

- Rewrote `Dockerfile` as a minimal multi-stage build that downloads the pre-built musl binary from GitHub Releases, verifies SHA256, and copies it into `FROM scratch`
- Added `Dockerfile.ci` for the release workflow that packages the just-built binary
- Release workflow builds and pushes `:latest` + `:vX.Y.Z` tags on every version tag
- `action.yml` now accepts `use-docker: true` to run analysis via `docker run` instead of `cargo install`

```
docker run --rm -v $(pwd):/workspace ghcr.io/hypersafed/sanctifier analyze /workspace
```

### 2. npm wrapper (`@hypersafed/sanctifier-cli`)

- Created `packages/sanctifier-cli-npm/` with `package.json` and `bin/sanctifier.js`
- Detects platform (macOS x64/arm64, Linux x64), downloads the matching pre-built binary from GitHub Releases, caches in `~/.sanctifier/bin/`
- Uses native `fetch` with a `curl` fallback
- Published to npm automatically on release

```
npx @hypersafed/sanctifier-cli analyze ./my-contract
```

### 3. Homebrew formula

- Created `homebrew/sanctifier.rb` supporting macOS (Intel + Apple Silicon) and Linux
- Release workflow `homebrew-update` job: downloads macOS binaries, computes SHA256, updates the formula, pushes to `HyperSafeD/homebrew-sanctifier`
- Skips gracefully if `HOMEBREW_TAP_TOKEN` is not configured

```
brew tap HyperSafeD/sanctifier && brew install sanctifier
```

### 4. Release automation

- `scripts/release.sh X.Y.Z` — bumps versions across all `Cargo.toml` (workspace, core, cli, detector, wasm), `package.json` (vscode, npm), and `homebrew/sanctifier.rb`
- Updated `RELEASE_CHECKLIST.md` with end-to-end steps including Docker/npm/Homebrew verification and rollback
- `CHANGELOG.md` now includes format guidelines

### Release workflow additions

| Job | Trigger | Purpose |
|---|---|---|
| `docker` | `v*` tag | Build and push Docker image to GHCR |
| `npm-publish` | `v*` tag | Publish `@hypersafed/sanctifier-cli` to npm |
| `homebrew-update` | `v*` tag | Update formula checksums and push to tap repo |

### Secrets required

| Secret | Used by |
|---|---|
| `NPM_TOKEN` | npm publish job |
| `HOMEBREW_TAP_TOKEN` | Homebrew tap push (optional — skips if absent) |
| `GITHUB_TOKEN` | Auto-provided; used for GHCR login and release downloads |

## Files changed

```
.github/workflows/release.yml              | +166  (docker, npm, homebrew jobs)
CHANGELOG.md                               |  +13  (format guidelines, new entries)
Dockerfile                                 |  -39/+16  (pre-built binary approach)
Dockerfile.ci                              | +5  (CI-specific minimal image)
RELEASE_CHECKLIST.md                       |  +23/-8  (automation + verification)
action.yml                                 |  +44/-1  (use-docker input)
homebrew/sanctifier.rb                     | +31  (formula template)
packages/sanctifier-cli-npm/bin/sanctifier.js  | +129  (platform detection + download)
packages/sanctifier-cli-npm/package.json       | +38  (npm metadata)
scripts/release.sh                         | +76  (version bump script)
```
