### PR TITLE
feat: configure cargo-deny and add check to Rust CI workflow (#1063)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,18 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  cargo-deny:
+    name: Cargo Deny Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,38 @@
+# deny.toml configuration for cargo-deny
+
+[graph]
+targets = []
+
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerabilities = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+
+[licenses]
+# Disallow unlicensed dependencies
+unlicensed = "deny"
+# Allowed open-source licenses
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+]
+# Explicitly ban GPL-3.0 and any copyleft licenses
+deny = [
+    "GPL-3.0",
+]
+copyleft = "deny"
+# Confidence threshold for license matching
+confidence-threshold = 0.8
+
+[bans]
+# Check for duplicate dependencies
+multiple-versions = "deny"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
Closes #1063

### Summary
Adds `cargo-deny` configuration and integrates it as a GitHub Actions check in the Rust CI pipeline to automatically scan Rust dependencies.

### Changes
1. **Added `deny.toml`**:
   - Enabled advisories check against the RustSec Advisory Database (fails on vulnerabilities/unmaintained/yanked).
   - Configured license check to:
     - Allow common permissive open-source licenses: `MIT`, `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`.
     - Explicitly ban `GPL-3.0` and all other copyleft licenses.
     - Fail on unlicensed/unknown dependencies.
   - Enabled bans check to prevent duplicate versions (`multiple-versions = "deny"`) and wildcards.
   - Enabled sources check to prevent unknown registries and git sources.
2. **Updated `.github/workflows/rust.yml`**:
   - Added a new `cargo-deny` job running `embarkstudios/cargo-deny-action@v2` on every push and pull request.
