### PR TITLE
docs: add wave retrospective template (#1261)

### DIFF
--- a/docs/RETRO_TEMPLATE.md
+++ b/docs/RETRO_TEMPLATE.md
@@ -1,0 +1,112 @@
+# Wave Retrospective Template
+
+> **How to use:** Copy this file to `docs/retros/RETRO_<WAVE_NAME>_<YYYY-MM-DD>.md`, fill in each section collaboratively during the retro session, then open a PR to merge it into `main`. Aim for ≤90 minutes total.
+
+---
+
+## Wave / Milestone
+
+| Field | Value |
+|---|---|
+| Wave name | |
+| Milestones covered | |
+| Retro date | |
+| Facilitator | |
+| Attendees | |
+
+---
+
+## 1. What went well?
+
+> Things to repeat, amplify, or protect.
+
+- 
+- 
+- 
+
+---
+
+## 2. What didn't go well?
+
+> Problems, friction, mistakes — stated as facts, not blame.
+
+- 
+- 
+- 
+
+---
+
+## 3. What surprised us?
+
+> Assumptions that turned out wrong; unknowns that surfaced late; estimates that were significantly off.
+
+| Surprise | Expected | Actual | Impact |
+|---|---|---|---|
+| | | | |
+
+---
+
+## 4. Estimation accuracy
+
+> For issues that were significantly over- or under-estimated, note why.
+
+| Issue | Estimated effort | Actual effort | Root cause of delta |
+|---|---|---|---|
+| | | | |
+
+---
+
+## 5. Dependencies and blockers
+
+> Which cross-team or cross-issue dependencies caused the most friction? Were they visible early enough?
+
+- 
+- 
+
+---
+
+## 6. Process and tooling
+
+> CI, review flow, labelling, milestone hygiene — what helped, what slowed us down?
+
+- 
+- 
+
+---
+
+## 7. Action items
+
+> Concrete, owned, time-bound changes for the next wave.
+
+| # | Action | Owner | Due |
+|---|---|---|---|
+| 1 | | | |
+| 2 | | | |
+| 3 | | | |
+
+---
+
+## 8. Carry-forward items
+
+> Issues or sub-tasks explicitly deferred to the next wave (link each).
+
+- [ ] 
+- [ ] 
+
+---
+
+## 9. Overall wave health
+
+Rate each dimension 1 (poor) – 5 (excellent):
+
+| Dimension | Score | Notes |
+|---|---|---|
+| Scope accuracy | | |
+| Estimation accuracy | | |
+| Coordination / communication | | |
+| Technical quality | | |
+| Delivery confidence for next wave | | |
+
+---
+
+*Template version: 1.0 — update the version when structure changes so past retros remain interpretable.*


### PR DESCRIPTION
## Summary

Adds `docs/RETRO_TEMPLATE.md` — a reusable retrospective template for capturing lessons at wave close, as specified in #1261.

## Template covers

- What went well / didn't / surprised us
- Estimation accuracy table with root-cause column
- Dependency and blocker tracking
- Process and tooling notes
- Concrete action items (owner + due date)
- Carry-forward issue checklist
- Wave health scores across 5 dimensions

Closes #1261
Closes #1253