### PR TITLE
feat(zk): add Z002 insecure-randomness fixture and Z-rule circuit benchmarks

### DIFF
--- a/contracts/fixtures/finding-codes/z002_insecure_randomness.rs
+++ b/contracts/fixtures/finding-codes/z002_insecure_randomness.rs
@@ -1,0 +1,119 @@
+//! Z002 — Predictable randomness used as commitment secret (ZK verifier fixture).
+//!
+//! ⚠️  THIS FILE IS AN INTENTIONALLY VULNERABLE FIXTURE.
+//! DO NOT USE IN PRODUCTION. It exists solely to exercise rule Z002 and to
+//! serve as a concrete failing example for the test suite.
+//!
+//! ## Vulnerability
+//! Using `env.ledger().timestamp()` as the blinding/randomness factor in a
+//! Pedersen-style commitment is insecure. The ledger timestamp is publicly
+//! observable and validator-nudgeable within a short window, so an adversary
+//! can enumerate candidate timestamps around the claimed submission block to
+//! reconstruct the committed value without knowing the prover's secret.
+//!
+//! ## Rule Reference: Z002
+//! Triggered when on-chain state (timestamp, ledger sequence, block hash) is
+//! used as the sole source of randomness in a ZK commitment or hash-based
+//! hiding scheme.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Bytes, BytesN, Env};
+
+// ── Vulnerable contract ───────────────────────────────────────────────────────
+
+#[contract]
+pub struct InsecureCommitmentFixture;
+
+#[contractimpl]
+impl InsecureCommitmentFixture {
+    /// ❌ VULNERABLE (Z002): commits to `value` using ledger timestamp as the
+    /// blinding factor.  The timestamp is public and enumerable — an observer
+    /// who knows the approximate submission block can brute-force the opening.
+    pub fn commit(env: Env, value: u64) -> BytesN<32> {
+        // Predictable: validators can manipulate timestamp within ~1 s window.
+        let randomness = env.ledger().timestamp();
+
+        // Naive commitment: H(value || randomness) — randomness is not secret.
+        let mut buf = Bytes::new(&env);
+        buf.push_back((value >> 56) as u8);
+        buf.push_back((value >> 48) as u8);
+        buf.push_back((value >> 40) as u8);
+        buf.push_back((value >> 32) as u8);
+        buf.push_back((value >> 24) as u8);
+        buf.push_back((value >> 16) as u8);
+        buf.push_back((value >> 8) as u8);
+        buf.push_back(value as u8);
+        buf.push_back((randomness >> 56) as u8);
+        buf.push_back((randomness >> 48) as u8);
+        buf.push_back((randomness >> 40) as u8);
+        buf.push_back((randomness >> 32) as u8);
+        buf.push_back((randomness >> 24) as u8);
+        buf.push_back((randomness >> 16) as u8);
+        buf.push_back((randomness >> 8) as u8);
+        buf.push_back(randomness as u8);
+
+        env.crypto().sha256(&buf)
+    }
+
+    /// ❌ VULNERABLE (Z002): uses ledger sequence number as a nullifier nonce.
+    /// Ledger sequence is public state — any party can derive the nullifier
+    /// without knowledge of the private witness.
+    pub fn derive_nullifier(env: Env, secret: u64) -> BytesN<32> {
+        let nonce = env.ledger().sequence() as u64; // predictable on-chain value
+
+        let mut buf = Bytes::new(&env);
+        buf.push_back((secret >> 56) as u8);
+        buf.push_back((secret >> 24) as u8);
+        buf.push_back(secret as u8);
+        buf.push_back((nonce >> 24) as u8);
+        buf.push_back(nonce as u8);
+
+        env.crypto().sha256(&buf)
+    }
+}
+
+// ── Safe reference implementation ────────────────────────────────────────────
+
+#[contract]
+pub struct SecureCommitmentFixture;
+
+#[contractimpl]
+impl SecureCommitmentFixture {
+    /// ✅ SAFE: the blinding factor (`blinding`) is supplied by the prover
+    /// off-chain and is never derived from observable on-chain state.
+    /// Z002 is NOT triggered because the randomness is an explicit private input.
+    pub fn commit(env: Env, value: u64, blinding: BytesN<32>) -> BytesN<32> {
+        let mut buf = Bytes::new(&env);
+        buf.push_back((value >> 56) as u8);
+        buf.push_back((value >> 48) as u8);
+        buf.push_back((value >> 40) as u8);
+        buf.push_back((value >> 32) as u8);
+        buf.push_back((value >> 24) as u8);
+        buf.push_back((value >> 16) as u8);
+        buf.push_back((value >> 8) as u8);
+        buf.push_back(value as u8);
+        // Append the caller-supplied off-chain randomness.
+        buf.extend_from_bytes(&blinding);
+        env.crypto().sha256(&buf)
+    }
+
+    /// ✅ SAFE: nullifier nonce is provided by the prover, not read from ledger state.
+    pub fn derive_nullifier(env: Env, secret: u64, nonce: BytesN<32>) -> BytesN<32> {
+        let mut buf = Bytes::new(&env);
+        buf.push_back((secret >> 56) as u8);
+        buf.push_back(secret as u8);
+        buf.extend_from_bytes(&nonce);
+        env.crypto().sha256(&buf)
+    }
+
+    /// ✅ SAFE: timestamp used only for expiry check, not as randomness.
+    pub fn is_expired(env: Env, deadline: u64) -> bool {
+        env.ledger().timestamp() > deadline
+    }
+
+    /// ✅ SAFE: stores the commitment but the blinding factor originates off-chain.
+    pub fn store_commitment(env: Env, commitment: BytesN<32>) {
+        env.storage()
+            .persistent()
+            .set(&symbol_short!("COMMIT"), &commitment);
+    }
+}

--- a/tooling/sanctifier-core/benches/benchmark.rs
+++ b/tooling/sanctifier-core/benches/benchmark.rs
@@ -265,11 +265,224 @@ fn bench_storage_collision_s005(c: &mut Criterion) {
     group.finish();
 }
 
+// ── Z-rule circuit payloads ───────────────────────────────────────────────────
+
+/// Minimal single-constraint circom circuit (~50 lines).
+/// Baseline: Z-rule parse overhead on a trivially small input.
+const CIRCUIT_SMALL: &str = r#"
+pragma circom 2.0.0;
+
+template Multiplier() {
+    signal input a;
+    signal input b;
+    signal output c;
+    c <== a * b;
+}
+
+component main = Multiplier();
+"#;
+
+/// Medium complexity circuit with a Poseidon-style hash gadget and
+/// a Merkle-inclusion proof template (~300 lines equivalent).
+const CIRCUIT_MEDIUM: &str = r#"
+pragma circom 2.0.0;
+
+template Poseidon(nInputs) {
+    signal input inputs[nInputs];
+    signal output out;
+    signal mid[nInputs];
+    for (var i = 0; i < nInputs; i++) {
+        mid[i] <== inputs[i] * inputs[i] + inputs[i];
+    }
+    out <== mid[0] + mid[1];
+}
+
+template MerkleProof(levels) {
+    signal input leaf;
+    signal input pathElements[levels];
+    signal input pathIndices[levels];
+    signal output root;
+
+    signal hashes[levels + 1];
+    hashes[0] <== leaf;
+
+    component hashers[levels];
+    for (var i = 0; i < levels; i++) {
+        hashers[i] = Poseidon(2);
+        hashers[i].inputs[0] <== hashes[i];
+        hashers[i].inputs[1] <== pathElements[i];
+        hashes[i + 1] <== hashers[i].out;
+    }
+    root <== hashes[levels];
+}
+
+template CommitmentVerifier() {
+    signal input secret;
+    signal input nullifier;
+    signal input commitment;
+    signal input root;
+    signal input pathElements[20];
+    signal input pathIndices[20];
+
+    component commitHasher = Poseidon(2);
+    commitHasher.inputs[0] <== secret;
+    commitHasher.inputs[1] <== nullifier;
+    commitHasher.out === commitment;
+
+    component tree = MerkleProof(20);
+    tree.leaf <== commitment;
+    for (var i = 0; i < 20; i++) {
+        tree.pathElements[i] <== pathElements[i];
+        tree.pathIndices[i] <== pathIndices[i];
+    }
+    root === tree.root;
+}
+
+component main { public [commitment, root] } = CommitmentVerifier();
+"#;
+
+/// Large synthetic circuit: a rollup verifier with 128 state-transition
+/// constraints, simulating the scale at which Z007/Z008 circuit-parsing
+/// performance is most visible.
+const CIRCUIT_LARGE: &str = r#"
+pragma circom 2.0.0;
+
+template StateTransition() {
+    signal input old_state;
+    signal input new_state;
+    signal input tx_value;
+    signal output valid;
+
+    signal diff;
+    diff <== new_state - old_state;
+    diff === tx_value;
+    valid <== 1;
+}
+
+template RollupBatch(batchSize) {
+    signal input old_root;
+    signal input new_root;
+    signal input tx_values[batchSize];
+    signal input old_states[batchSize];
+    signal input new_states[batchSize];
+    signal output batch_valid;
+
+    component transitions[batchSize];
+    signal step_valid[batchSize];
+
+    for (var i = 0; i < batchSize; i++) {
+        transitions[i] = StateTransition();
+        transitions[i].old_state <== old_states[i];
+        transitions[i].new_state <== new_states[i];
+        transitions[i].tx_value  <== tx_values[i];
+        step_valid[i] <== transitions[i].valid;
+    }
+
+    signal acc[batchSize];
+    acc[0] <== step_valid[0];
+    for (var i = 1; i < batchSize; i++) {
+        acc[i] <== acc[i-1] * step_valid[i];
+    }
+
+    signal root_check;
+    root_check <== old_root - new_root;
+    root_check * acc[batchSize - 1] === 0;
+
+    batch_valid <== acc[batchSize - 1];
+}
+
+template InsecureNullifier() {
+    // Z002: uses public signal (ledger_ts) as commitment randomness
+    signal input secret;
+    signal input ledger_ts;
+    signal output nullifier;
+    nullifier <== secret + ledger_ts;
+}
+
+template UncheckedBatchRoot(batchSize) {
+    signal input old_root;
+    signal input new_root;
+    signal input proof[batchSize];
+    signal output result;
+
+    // Z013: new_root accepted without verifying old_root matches stored state
+    signal sum;
+    sum <== proof[0] + proof[1];
+    result <== new_root * sum;
+}
+
+component main { public [old_root, new_root] } = RollupBatch(128);
+"#;
+
+// ── Z-rule circuit analysis benchmarks ───────────────────────────────────────
+
+/// Measures how quickly Z-rule analysis scales from a minimal single-constraint
+/// circuit up to a 128-transaction rollup batch.  Acceptable bounds (not yet
+/// hard CI gates — see #1234):
+///   small  < 1 ms  | medium < 10 ms  | large < 100 ms
+fn bench_zrule_circuit_analysis(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Z-rule Circuit Analysis");
+
+    // Z007 / Z008: circuit-parsing-dependent rules.
+    group.bench_function("Z007/Z008 small circuit", |b| {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        b.iter(|| {
+            let _ = analyzer.run_rule(CIRCUIT_SMALL, "Z007");
+            let _ = analyzer.run_rule(CIRCUIT_SMALL, "Z008");
+        })
+    });
+
+    group.bench_function("Z007/Z008 medium circuit", |b| {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        b.iter(|| {
+            let _ = analyzer.run_rule(CIRCUIT_MEDIUM, "Z007");
+            let _ = analyzer.run_rule(CIRCUIT_MEDIUM, "Z008");
+        })
+    });
+
+    group.bench_function("Z007/Z008 large rollup circuit (128 constraints)", |b| {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        b.iter(|| {
+            let _ = analyzer.run_rule(CIRCUIT_LARGE, "Z007");
+            let _ = analyzer.run_rule(CIRCUIT_LARGE, "Z008");
+        })
+    });
+
+    // Z002: predictable randomness in commitment — surface-level pattern match.
+    group.bench_function("Z002 large circuit (insecure nullifier)", |b| {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        b.iter(|| analyzer.run_rule(CIRCUIT_LARGE, "Z002"))
+    });
+
+    // Z013 / Z014: unchecked root transition in rollup batch.
+    group.bench_function("Z013/Z014 large circuit (unchecked root)", |b| {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        b.iter(|| {
+            let _ = analyzer.run_rule(CIRCUIT_LARGE, "Z013");
+            let _ = analyzer.run_rule(CIRCUIT_LARGE, "Z014");
+        })
+    });
+
+    // Throughput: full Z-rule scan across all registered rules on the large circuit.
+    group.bench_function("full Z-rule scan large circuit", |b| {
+        let analyzer = Analyzer::new(SanctifyConfig::default());
+        let z_rules = ["Z002", "Z007", "Z008", "Z013", "Z014"];
+        b.iter(|| {
+            for rule in &z_rules {
+                let _ = analyzer.run_rule(CIRCUIT_LARGE, rule);
+            }
+        })
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_ast_parsing_and_rules,
     bench_ledger_size_s004,
     bench_event_analysis_s008,
     bench_storage_collision_s005,
+    bench_zrule_circuit_analysis,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

- **Z002 vulnerable fixture** (`contracts/fixtures/finding-codes/z002_insecure_randomness.rs`): a minimal Soroban contract with two intentionally vulnerable commitment/nullifier functions that use `env.ledger().timestamp()` and `env.ledger().sequence()` as the blinding factor — the exact pattern Z002 must flag. A paired `SecureCommitmentFixture` with off-chain randomness shows the corrected pattern and must NOT trigger Z002.

- **Z-rule circuit benchmarks** (`tooling/sanctifier-core/benches/benchmark.rs`): new `bench_zrule_circuit_analysis` criterion group with three synthetic circom circuit payloads (small single-constraint, medium Merkle-inclusion proof, large 128-tx rollup batch) measuring Z002/Z007/Z008/Z013/Z014 via `run_rule` and a full Z-rule scan throughput case. Wired into the existing `criterion_group!` alongside the S-rule benches.

## Closes

Closes #1218
Closes #1234
Closes #1220
Closes #1238