### PR TITLE
feat: project-board triage, Z-rule authoring guide, wave deps doc, milestone verification

### DIFF
--- a/.github/workflows/project-board-triage.yml
+++ b/.github/workflows/project-board-triage.yml
@@ -1,0 +1,54 @@
+name: Project Board Auto-Triage
+
+# Issue #1260 — Automatically add new issues labelled `mainnet` or `zk` to
+# the relevant project-board column so the epics (#1252, #1253) and board
+# views stay in sync without manual triage overhead.
+#
+# Setup (one-time, repo admin):
+#   1. Create/confirm the two GitHub Projects (v2) boards:
+#        • "Mainnet Launch Readiness"  → set MAINNET_PROJECT_URL in repo vars
+#        • "ZK Integration"            → set ZK_PROJECT_URL in repo vars
+#   2. Create a fine-grained PAT (or use a GitHub App token) with
+#      `project: read/write` scope and store it as secret PROJECT_TOKEN.
+#
+# The `actions/add-to-project` action adds the issue to the project board;
+# GitHub Projects v2 handles column/status assignment based on the project's
+# own automation rules (e.g. "To Do" on issue open).
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  triage-mainnet:
+    name: Add to Mainnet Launch Readiness board
+    if: github.event.label.name == 'mainnet'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to Mainnet Launch Readiness project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: ${{ vars.MAINNET_PROJECT_URL }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+
+  triage-zk:
+    name: Add to ZK Integration board
+    if: github.event.label.name == 'zk'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to ZK Integration project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: ${{ vars.ZK_PROJECT_URL }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+
+  triage-area-zk:
+    name: Add to ZK Integration board (area:zk label)
+    if: github.event.label.name == 'area: zk'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to ZK Integration project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: ${{ vars.ZK_PROJECT_URL }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,6 +296,111 @@ cargo clippy -p sanctifier-core -- -D warnings
 
 Follow the PR process outlined below.
 
+## Contributing Z-Rules (ZK Analysis)
+
+> **Required reading before proposing a Z-rule:** the ZK threat model (#1193)
+> and the namespace/severity ADR (#1192). These two documents define the
+> contracts that every Z-rule must honour.
+
+Z-rules are Sanctifier's family of security-analysis rules targeting
+zero-knowledge (ZK) circuit and verifier patterns used in Soroban smart
+contracts. They live in the same rules layer as S-rules but occupy their own
+finding-code namespace and carry ZK-specific severity guidance.
+
+### Z-Rule Numbering Convention
+
+All ZK findings use the `Z0xx` namespace — parallel to the `S0xx` namespace
+used by standard static rules:
+
+| Range | Reserved for |
+|-------|-------------|
+| `Z001`–`Z049` | Circuit constraint violations (under-constrained outputs, missing range checks) |
+| `Z050`–`Z099` | Verifier integration issues (missing nullifier checks, replay attacks) |
+| `Z100`–`Z149` | Proof-system misuse (wrong curve, insecure hash-to-field) |
+| `Z150`+       | Reserved for future ZK vulnerability classes |
+
+Choose the next available ID in the appropriate range. If your rule spans
+multiple classes, place it in the class that represents the highest-impact
+consequence.
+
+### Severity Guidance for ZK Rules
+
+ZK vulnerabilities can have a higher blast radius than typical Soroban bugs
+because a single under-constrained wire may compromise every proof ever
+generated. Apply the following guidance in addition to the general severity
+taxonomy (`schemas/severity-taxonomy.schema.json`):
+
+| ZK vulnerability class | Minimum severity |
+|------------------------|-----------------|
+| Under-constrained output wire | **Critical** |
+| Missing nullifier uniqueness check | **Critical** |
+| Replay / double-spend vector | **High** |
+| Missing range check on private input | **High** |
+| Insecure hash-to-field (non-injective) | **High** |
+| Proof system parameter mismatch | **Medium** |
+| Missing public-input binding | **Medium** |
+
+### Step-by-Step: Add a New Z-Rule
+
+Follow the same seven steps as for S-rules (see [How to Add a New Rule](#how-to-add-a-new-rule) above), with these ZK-specific additions:
+
+#### Naming and ID
+
+```rust
+fn id(&self) -> &'static str {
+    "Z042"  // next free ID in the relevant range
+}
+```
+
+Place the implementation file in `tooling/sanctifier-core/src/rules/` and
+prefix it `z` to group it with other Z-rules:
+`tooling/sanctifier-core/src/rules/z042_missing_nullifier_check.rs`
+
+#### Required Fixture Pairs
+
+Every Z-rule **must** ship two fixture files in
+`tooling/sanctifier-core/tests/fixtures/z-rules/`:
+
+- `z042_VULNERABLE.rs` — a minimal Soroban contract that **triggers** the rule.
+- `z042_SAFE.rs` — the same contract with the vulnerability fixed; the rule must **not** fire.
+
+Without both fixtures the PR will not be accepted.
+
+#### SARIF Severity Wiring
+
+After assigning your ID, add a corresponding entry to
+`data/sarif/severity-map.yaml` following the pattern for existing rules.
+Omitting this entry causes the SARIF report to emit `none` for your finding,
+which breaks the CI severity gate.
+
+#### Documentation
+
+Add a rule reference page at `docs/rules/Z042.md` (copy the template from
+any existing `docs/rules/S0xx.md`). Include:
+
+- Finding code and name
+- Affected ZK pattern (circuit constraint, verifier call, etc.)
+- Example vulnerable contract snippet
+- Example fixed contract snippet
+- Links to the threat model section that motivates the rule (#1193)
+
+#### Checklist for Z-Rule PRs
+
+- [ ] ID chosen from the correct `Z0xx` range
+- [ ] Implementation file prefixed `z` and placed in `rules/`
+- [ ] Both `z<ID>_VULNERABLE.rs` and `z<ID>_SAFE.rs` fixtures present
+- [ ] `data/sarif/severity-map.yaml` entry added
+- [ ] `docs/rules/Z<ID>.md` rule reference page added
+- [ ] Severity set per the guidance table above (never lower than the minimum)
+- [ ] Threat model reference included in doc and code comments
+
+### Where to Start
+
+- **Threat model** (#1193) — lists the prioritised ZK vulnerability classes
+- **Namespace/severity ADR** (#1192) — the authoritative spec for `Z0xx` conventions
+- **`docs/rule-authoring-guide.md`** — general YAML/Rust rule authoring tutorial
+- **`docs/rules/`** — existing S-rule reference pages as structural templates
+
 ## PR Checklist
 
 Before submitting a pull request, ensure the following:

--- a/docs/MILESTONE_SETUP.md
+++ b/docs/MILESTONE_SETUP.md
@@ -1,0 +1,68 @@
+# Milestone Setup: "Mainnet Launch Readiness" & "ZK Integration"
+
+> **Issue #1256** — Verification record for the two Next Wave GitHub milestones.
+
+This document confirms that both milestones are correctly configured and tracks
+the verification pass performed at wave kickoff.
+
+---
+
+## Milestones
+
+### Mainnet Launch Readiness
+
+| Field | Value |
+|-------|-------|
+| **Title** | Mainnet Launch Readiness |
+| **Epic** | #1252 |
+| **Description** | Tracks all work required before Sanctifier is ready for a mainnet deployment: security audit (#1112), performance regression gate (#1182), deployment hardening, and operator runbook finalisation. |
+| **Due date** | Not set (per team preference; adjust when freeze date is confirmed) |
+| **Issue range** | #1112–#1181, #1183–#1191, #1244–#1255 (mainnet-scoped) |
+
+### ZK Integration
+
+| Field | Value |
+|-------|-------|
+| **Title** | ZK Integration |
+| **Epic** | #1253 |
+| **Description** | Tracks the full ZK workstream: Z-rule namespace ADR (#1192), ZK threat model (#1193), Z-rules Z001–Z099 (#1197–#1210 and follow-ups), rule-registry wiring (#1230), ZK specialist review (#1251), and feature-flag removal (#1142). |
+| **Due date** | Not set (gated on #1251 specialist availability) |
+| **Issue range** | #1142, #1192–#1243 (ZK-scoped) |
+
+---
+
+## Verification Checklist
+
+- [x] Both milestones exist in the GitHub repository
+- [x] Milestone descriptions are accurate and link to their epics
+- [x] `Mainnet Launch Readiness` milestone assigned to all mainnet-scoped issues
+- [x] `ZK Integration` milestone assigned to all ZK-scoped issues
+- [x] Open/closed issue counts visible on the milestone page reflect actual progress
+- [x] `Next Wave — Program Ops` milestone used for ops/tooling issues (#1256–#1260) that support both epics without belonging to either workstream
+
+---
+
+## How to Assign Issues in Bulk
+
+If issues need to be reassigned after milestone creation, use the GitHub CLI:
+
+```bash
+# Assign a single issue to a milestone (get milestone number from GitHub UI)
+gh api repos/HyperSafeD/Sanctifier/issues/<issue_number> \
+  --method PATCH \
+  --field milestone=<milestone_number>
+
+# Bulk-assign a range (example: issues 1192–1210 to ZK Integration milestone 3)
+for i in $(seq 1192 1210); do
+  gh api repos/HyperSafeD/Sanctifier/issues/$i \
+    --method PATCH \
+    --field milestone=3
+done
+```
+
+---
+
+## Cross-Reference
+
+See [`docs/WAVE_DEPENDENCIES.md`](WAVE_DEPENDENCIES.md) for the cross-milestone
+dependency graph that explains which workstreams block each other.

--- a/docs/WAVE_DEPENDENCIES.md
+++ b/docs/WAVE_DEPENDENCIES.md
@@ -1,0 +1,127 @@
+# Cross-Milestone Dependencies: ZK Rules ↔ Mainnet-Freeze Testing Gate
+
+> **Issue #1257** — Cross-team kickoff doc.
+> Linked from epic #1252 (Mainnet Launch Readiness) and epic #1253 (ZK Integration).
+
+This document makes the cross-cutting dependencies between the two Next Wave
+milestones explicit so no contributor accidentally ships past a blocking
+dependency. It supplements (but does not replace) the individual issue
+checklists.
+
+---
+
+## Milestone Overview
+
+| Milestone | Epic | Focus |
+|-----------|------|-------|
+| **Mainnet Launch Readiness** | #1252 | Audit, freeze testing, performance gates, deployment hardening |
+| **ZK Integration** | #1253 | Z-rule namespace, ZK rules Z001–Z099, ZK specialist review, feature flag removal |
+
+Both milestones may be worked in parallel by different contributors. The
+dependencies below are **hard gates** — the downstream work must not merge
+before the upstream item lands.
+
+---
+
+## Hard Dependencies
+
+### 1. Performance-regression gate before Z-rules land
+
+**Upstream:** #1182 — Performance regression CI gate (Mainnet milestone)
+**Downstream:** #1197–#1210 — Z-rules Z001–Z014 (ZK milestone)
+
+**Rationale:** Z-rules add new analysis passes that run on every `sanctify`
+invocation. The regression gate in #1182 establishes a baseline latency budget
+and CI check. If Z-rules land first, the gate has no baseline to compare
+against and will pass trivially even if the rules cause a 10× slowdown.
+
+**Action:** Do not merge any of #1197–#1210 until #1182's CI gate is green on
+`main`.
+
+---
+
+### 2. ZK specialist review gates ZK feature-flag removal — independent of main audit
+
+**Upstream:** #1251 — ZK specialist security review
+**Downstream:** #1142 — Remove `zk_features` feature flag (ZK milestone)
+
+**Rationale:** The ZK verifier integration (#1142) is behind a feature flag
+pending expert review. The main mainnet security audit (#1112) covers the
+overall contract surface but is **not** a substitute for the ZK-specific
+review (#1251) because ZK circuit soundness requires specialist expertise. The
+flag must not be removed until #1251 delivers a clean report, regardless of
+whether #1112 is complete.
+
+**Action:** #1142 is blocked on #1251. Do not merge #1142 until #1251 is
+resolved, even if #1112 closes first.
+
+---
+
+### 3. Namespace/severity ADR before any Z-rule is merged
+
+**Upstream:** #1192 — `Z0xx` namespace and severity taxonomy ADR
+**Downstream:** #1197–#1210, #1230 (all Z-rules and rule-registry wiring)
+
+**Rationale:** The ADR defines the finding-code numbering scheme and SARIF
+severity mapping that every Z-rule must conform to. Rules merged before the
+ADR creates a patch-up burden and may ship inconsistent severity ratings into
+production SARIF output.
+
+**Action:** #1192 must merge before any Z-rule PR (#1197–#1210) or the
+rule-registry wiring (#1230) is reviewed.
+
+---
+
+### 4. Labels and milestones configured before triage automation activates
+
+**Upstream:** #1255 — Label consistency pass; #1256 — Milestone setup
+**Downstream:** #1260 — Project-board automation
+
+**Rationale:** The auto-triage workflow (`.github/workflows/project-board-triage.yml`)
+triggers on `mainnet` and `zk` label events. If labels are renamed or missing,
+issues silently skip the automation.
+
+**Action:** Verify #1255 and #1256 are complete and the `MAINNET_PROJECT_URL` /
+`ZK_PROJECT_URL` repository variables are set before enabling the triage
+workflow.
+
+---
+
+## Soft Dependencies (ordering recommended, not blocking)
+
+| Recommended order | Reason |
+|-------------------|--------|
+| #1193 (ZK threat model) before #1197–#1210 | Rules are easier to scope when the threat model is agreed |
+| #1112 (main audit) before mainnet freeze date | Audit findings may require changes that shift the freeze |
+| #1182 (perf gate) before #1251 (ZK review) | ZK review findings may add rules; baseline should be set first |
+
+---
+
+## Dependency Graph (simplified)
+
+```
+[#1255 labels] ──┐
+[#1256 milestones]─┤
+                   └──► [#1260 board triage]
+
+[#1192 Z-namespace ADR] ─────────────────────► [#1197–#1210 Z-rules]
+                                                       │
+[#1182 perf gate] ──────────────────────────────────► │ (both must land first)
+
+[#1193 ZK threat model] ────────────────────► [#1197–#1210 Z-rules]
+
+[#1251 ZK specialist review] ───────────────► [#1142 remove zk_features flag]
+
+[#1112 main audit] ──► [mainnet freeze / deploy] (independent of #1142)
+```
+
+---
+
+## Contacts
+
+| Area | Point of contact |
+|------|-----------------|
+| Mainnet milestone (#1252) | Tag `@HyperSafeD` on the epic |
+| ZK milestone (#1253) | ZK specialist assigned in #1251 |
+| Performance gate (#1182) | CI / core-engine contributors |
+| This document | Update via PR; link remains stable at `docs/WAVE_DEPENDENCIES.md` |


### PR DESCRIPTION
## Summary

- **#1260** — `.github/workflows/project-board-triage.yml`: new workflow triggered on `issues: labeled`. Three jobs cover `mainnet`, `zk`, and `area: zk` labels — each uses `actions/add-to-project@v1.0.2` to place the issue on the correct board. Reads project URLs from repository variables `MAINNET_PROJECT_URL` / `ZK_PROJECT_URL` and a `PROJECT_TOKEN` secret (one-time admin setup documented inline).
- **#1259** — `CONTRIBUTING.md`: new **"Contributing Z-Rules (ZK Analysis)"** section inserted before the PR checklist. Covers the `Z0xx` numbering convention (three ID ranges with rationale), minimum-severity table per ZK vulnerability class, step-by-step Z-rule authoring additions (fixture pair requirement, SARIF wiring, `docs/rules/Z<ID>.md` template), and a Z-rule PR checklist. Links to threat model (#1193) and namespace ADR (#1192) as required reading.
- **#1257** — `docs/WAVE_DEPENDENCIES.md`: cross-team kickoff document listing four hard dependencies (#1182 before Z-rules; #1251 before #1142 flag removal; #1192 before any Z-rule; #1255/#1256 before #1260) with rationale and a dependency graph. Linked from both epics (#1252, #1253).
- **#1256** — `docs/MILESTONE_SETUP.md`: verification record confirming both milestones ("Mainnet Launch Readiness" / "ZK Integration") are correctly described, scoped, and populated. Includes a bulk-assignment `gh` CLI snippet for future issue reassignment and cross-reference to `WAVE_DEPENDENCIES.md`.

Closes #1260, Closes #1259, Closes #1257, Closes #1256