### PR TITLE
feat: ZK finding badges, hover/quick-fix descriptions, constraint graph, ZK playground

### DIFF
--- a/.sanctify.toml
+++ b/.sanctify.toml
@@ -16,3 +16,27 @@ severity = "High"
 name = "no_mem_forget"
 pattern = "std::mem::forget"
 severity = "Medium"
+
+# ---------------------------------------------------------------------------
+# ZK rule pack (#1233)
+# ---------------------------------------------------------------------------
+# Controls whether Sanctifier loads and runs the Z-rule pack (Z001–Z0NN).
+# Most pure-Soroban projects have no circuit source; leaving 'auto' avoids
+# parser-loading overhead and irrelevant findings for those projects.
+#
+# enabled = "auto"   — enable only when .circom or .nr files are detected
+# enabled = true     — always run ZK rules
+# enabled = false    — always skip ZK rules
+[zk]
+enabled = "auto"
+
+# Directories to add to Circom's include search path (relative to repo root).
+# Uncomment and extend if you vendor circomlib or other libraries locally.
+# circom_include_dirs = ["./circuits/lib"]
+
+# Path to the Nargo.toml directory for Noir projects (default: repo root).
+# noir_project_root = "./circuits"
+
+# Z-rule codes to suppress in this project.  Prefer the generic rule-disable
+# mechanism (enabled_rules / #1230) for permanent suppressions.
+# skip_rules = ["Z003"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "contracts/benchmark",
     "contracts/deposit-withdraw",
     "contracts/sep41-compliance",
+    "contracts/zk-verifier",
 
 ]
 resolver = "2"

--- a/contracts/fixtures/finding-codes/z001_missing_nullifier.rs
+++ b/contracts/fixtures/finding-codes/z001_missing_nullifier.rs
@@ -1,0 +1,121 @@
+// ⚠️  VULNERABLE FIXTURE — FOR TESTING AND EDUCATIONAL PURPOSES ONLY
+// Classification: Z001 — Missing Nullifier Check
+// This file intentionally omits the nullifier check present in the secure
+// reference implementation so that rule Z001 correctly flags it.
+// DO NOT deploy this contract; it allows double-spending of ZK proofs.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Bytes};
+
+/// Groth16 verification key stored in contract instance storage.
+#[contracttype]
+#[derive(Clone)]
+pub struct VerifyingKey {
+    pub alpha_g1: Bytes,
+    pub beta_g2:  Bytes,
+    pub gamma_g2: Bytes,
+    pub delta_g2: Bytes,
+    pub ic:       Bytes,
+}
+
+/// A Groth16 proof supplied by the caller.
+#[contracttype]
+#[derive(Clone)]
+pub struct Proof {
+    pub a: Bytes,
+    pub b: Bytes,
+    pub c: Bytes,
+}
+
+const KEY_VK: &str = "VK";
+
+#[contract]
+pub struct VulnerableZkVerifier;
+
+#[contractimpl]
+impl VulnerableZkVerifier {
+    /// Store the verifying key (admin only — omitted here for brevity).
+    pub fn init(env: Env, vk: VerifyingKey) {
+        env.storage().instance().set(&symbol_short!(KEY_VK), &vk);
+    }
+
+    /// Verify a Groth16 proof against stored public inputs.
+    ///
+    /// # Z001 Vulnerability
+    /// The nullifier is accepted as a parameter but is **never checked against
+    /// the spent-nullifiers set**.  An attacker can replay the same valid proof
+    /// with the same nullifier an unlimited number of times, triggering
+    /// double-spend of whatever asset this contract gates.
+    ///
+    /// The secure version (`z001_secure_nullifier.rs`) adds:
+    /// ```rust
+    /// nullifier_set.assert_unspent(&env, &nullifier);
+    /// nullifier_set.mark_spent(&env, &nullifier);
+    /// ```
+    /// before granting access.
+    pub fn verify(
+        env: Env,
+        proof: Proof,
+        public_inputs: Bytes,
+        nullifier: Bytes,  // received but never stored or checked ← Z001
+    ) -> bool {
+        let vk: VerifyingKey = env
+            .storage()
+            .instance()
+            .get(&symbol_short!(KEY_VK))
+            .expect("verifying key not initialised");
+
+        // Pairing check stub — real implementation would call a host-function
+        // or off-chain oracle; logic omitted so the fixture compiles on its own.
+        let _ = (vk, proof, public_inputs);
+
+        // ❌  Missing: nullifier_set.assert_unspent(&env, &nullifier);
+        // ❌  Missing: nullifier_set.mark_spent(&env, &nullifier);
+        let _ = nullifier;
+
+        true  // placeholder — Z001 flags this function for the missing checks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{testutils::Env as _, Bytes, Env};
+    use super::{VulnerableZkVerifier, VulnerableZkVerifierClient, VerifyingKey, Proof};
+
+    fn dummy_bytes(env: &Env) -> Bytes {
+        Bytes::from_slice(env, &[0u8; 32])
+    }
+
+    #[test]
+    fn z001_replay_attack_succeeds_on_vulnerable_contract() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, VulnerableZkVerifier);
+        let client = VulnerableZkVerifierClient::new(&env, &contract_id);
+
+        let vk = VerifyingKey {
+            alpha_g1: dummy_bytes(&env),
+            beta_g2:  dummy_bytes(&env),
+            gamma_g2: dummy_bytes(&env),
+            delta_g2: dummy_bytes(&env),
+            ic:       dummy_bytes(&env),
+        };
+        client.init(&vk);
+
+        let proof = Proof {
+            a: dummy_bytes(&env),
+            b: dummy_bytes(&env),
+            c: dummy_bytes(&env),
+        };
+        let nullifier = dummy_bytes(&env);
+
+        // First call — expected to succeed on both vulnerable and secure versions.
+        assert!(client.verify(&proof, &dummy_bytes(&env), &nullifier));
+
+        // Second call with identical nullifier — succeeds on vulnerable contract
+        // (double-spend). A secure contract would panic/return false here.
+        assert!(
+            client.verify(&proof, &dummy_bytes(&env), &nullifier),
+            "Z001: replay with same nullifier was not rejected (double-spend possible)"
+        );
+    }
+}

--- a/contracts/zk-verifier/Cargo.toml
+++ b/contracts/zk-verifier/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "zk-verifier"
+version = "0.1.0"
+edition = "2021"
+description = "NullifierSet storage module and ZK-verifier reference implementation for Sanctifier"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0

--- a/contracts/zk-verifier/src/lib.rs
+++ b/contracts/zk-verifier/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+pub mod nullifier_set;
+
+pub use nullifier_set::{NullifierSet, NullifierState, NullifierKey};

--- a/contracts/zk-verifier/src/nullifier_set.rs
+++ b/contracts/zk-verifier/src/nullifier_set.rs
@@ -1,0 +1,176 @@
+//! NullifierSet — persistent spent-nullifier registry with explicit TTL bumps.
+//!
+//! # TTL / Eviction Rationale
+//! Soroban `persistent()` storage entries can be archived/evicted after
+//! `max_ttl` ledgers if their TTL is not extended.  A silently-evicted
+//! nullifier entry would read as "absent" rather than "spent", reintroducing
+//! the double-spend risk that Z001 is meant to prevent.
+//!
+//! This module therefore:
+//! 1. Bumps the TTL on every write (`mark_spent`).
+//! 2. **Fails closed** on read: an absent entry is treated as "unknown /
+//!    must reject", never as "unspent / allow".  The `assert_unspent` method
+//!    panics on both "definitely spent" and "evicted / unknown" states,
+//!    matching the closed-world assumption of a spend check.
+//!
+//! Callers that want to distinguish "unknown" from "spent" should use
+//! `state()` directly and apply their own policy.
+
+use soroban_sdk::{contracttype, Bytes, Env};
+
+/// Minimum number of ledgers a nullifier entry must survive after being
+/// written. 1 year ≈ 6 307 200 ledgers at 5 s/ledger.
+const TTL_BUMP_THRESHOLD: u32 = 100_000;
+/// Target ledger count for TTL extension — significantly above threshold so
+/// we do not bump on every single transaction.
+const TTL_BUMP_TO: u32 = 6_307_200; // ~1 year
+
+#[derive(Clone, PartialEq)]
+#[contracttype]
+pub enum NullifierState {
+    /// Nullifier has been spent; the associated proof must not be accepted again.
+    Spent,
+}
+
+/// Composite storage key scoping nullifiers to a specific campaign or context.
+#[contracttype]
+#[derive(Clone)]
+pub struct NullifierKey {
+    pub context: Bytes,
+    pub nullifier: Bytes,
+}
+
+/// Thin wrapper around Soroban persistent storage providing a
+/// spend-check / mark-spent API with explicit TTL management.
+pub struct NullifierSet;
+
+impl NullifierSet {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Returns `true` if `nullifier` is definitely recorded as spent.
+    ///
+    /// Returns `false` for **both** the "unspent" and the "evicted / absent"
+    /// cases.  Callers that must distinguish eviction from genuinely-unspent
+    /// should use `state()` and apply their own policy; most callers should
+    /// use `assert_unspent` which fails closed on both.
+    pub fn is_spent(&self, env: &Env, context: &Bytes, nullifier: &Bytes) -> bool {
+        let key = NullifierKey { context: context.clone(), nullifier: nullifier.clone() };
+        env.storage()
+            .persistent()
+            .get::<NullifierKey, NullifierState>(&key)
+            .map(|s| s == NullifierState::Spent)
+            .unwrap_or(false)
+    }
+
+    /// Returns the raw `Option<NullifierState>` from storage.
+    ///
+    /// `None` means the entry is absent — either genuinely unspent *or*
+    /// evicted due to TTL expiry.  Treat `None` as untrusted.
+    pub fn state(&self, env: &Env, context: &Bytes, nullifier: &Bytes) -> Option<NullifierState> {
+        let key = NullifierKey { context: context.clone(), nullifier: nullifier.clone() };
+        env.storage().persistent().get::<NullifierKey, NullifierState>(&key)
+    }
+
+    /// Panics if `nullifier` is spent **or absent** (fail-closed policy).
+    ///
+    /// Call this before granting any asset access, then call `mark_spent`
+    /// before returning.
+    pub fn assert_unspent(&self, env: &Env, context: &Bytes, nullifier: &Bytes) {
+        let key = NullifierKey { context: context.clone(), nullifier: nullifier.clone() };
+        match env.storage().persistent().get::<NullifierKey, NullifierState>(&key) {
+            Some(NullifierState::Spent) => {
+                panic!("nullifier already spent — replay attack rejected")
+            }
+            None => {
+                // Fail closed: absent could mean evicted.  Reject to prevent
+                // a TTL-eviction-based replay attack.
+                //
+                // If this fires unexpectedly in production it means entries
+                // are expiring faster than expected; increase TTL_BUMP_TO or
+                // migrate spent nullifiers to a longer-lived tier.
+                panic!("nullifier absent (possibly evicted) — failing closed to prevent replay")
+            }
+            _ => {} // NullifierState::Spent is the only variant; exhaustive.
+        }
+        // Unreachable: both Some(Spent) and None panic above.  The match
+        // guard keeps the compiler happy if new variants are added later.
+        let _ = key;
+    }
+
+    /// Mark `nullifier` as spent and bump its TTL.
+    ///
+    /// Must be called **after** `assert_unspent` and **before** returning
+    /// from the verify function to prevent TOCTOU races in parallel
+    /// transaction scenarios.
+    pub fn mark_spent(&self, env: &Env, context: &Bytes, nullifier: &Bytes) {
+        let key = NullifierKey { context: context.clone(), nullifier: nullifier.clone() };
+        env.storage()
+            .persistent()
+            .set::<NullifierKey, NullifierState>(&key, &NullifierState::Spent);
+        // Explicit TTL bump — without this the entry expires after max_ttl
+        // ledgers and an evicted nullifier would no longer protect against
+        // replays.
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_BUMP_THRESHOLD, TTL_BUMP_TO);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Env as _, Bytes, Env};
+
+    fn ctx(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"test-campaign")
+    }
+
+    fn null(env: &Env, n: u8) -> Bytes {
+        Bytes::from_slice(env, &[n; 32])
+    }
+
+    #[test]
+    fn unspent_nullifier_is_not_spent() {
+        let env = Env::default();
+        let ns = NullifierSet::new();
+        assert!(!ns.is_spent(&env, &ctx(&env), &null(&env, 0x01)));
+    }
+
+    #[test]
+    fn mark_spent_records_nullifier() {
+        let env = Env::default();
+        let ns = NullifierSet::new();
+        let nullifier = null(&env, 0x02);
+        ns.mark_spent(&env, &ctx(&env), &nullifier);
+        assert!(ns.is_spent(&env, &ctx(&env), &nullifier));
+    }
+
+    #[test]
+    #[should_panic(expected = "nullifier already spent")]
+    fn assert_unspent_panics_on_spent() {
+        let env = Env::default();
+        let ns = NullifierSet::new();
+        let nullifier = null(&env, 0x03);
+        ns.mark_spent(&env, &ctx(&env), &nullifier);
+        ns.assert_unspent(&env, &ctx(&env), &nullifier);
+    }
+
+    #[test]
+    #[should_panic(expected = "nullifier absent (possibly evicted) — failing closed")]
+    fn assert_unspent_panics_on_absent_entry_fail_closed() {
+        let env = Env::default();
+        let ns = NullifierSet::new();
+        // Simulate eviction: write then manually remove the key so the entry
+        // appears absent to storage, then assert_unspent must panic (fail closed).
+        let nullifier = null(&env, 0x04);
+        let key = NullifierKey { context: ctx(&env), nullifier: nullifier.clone() };
+        env.storage()
+            .persistent()
+            .set::<NullifierKey, NullifierState>(&key, &NullifierState::Spent);
+        env.storage().persistent().remove(&key);
+        // Now the entry is absent — as if it had been evicted.
+        ns.assert_unspent(&env, &ctx(&env), &nullifier);
+    }
+}

--- a/docs/rules/Z001.md
+++ b/docs/rules/Z001.md
@@ -1,0 +1,61 @@
+# Z001 — Missing Nullifier Check
+
+## Overview
+
+A ZK-verifier contract accepts a valid proof but never records or checks the
+proof's nullifier, allowing the same proof to be submitted multiple times
+(double-spend / replay attack).
+
+## Severity
+
+**Critical** — any asset gated behind the verifier can be drained by replaying
+a single valid proof.
+
+## Description
+
+ZK proof systems (Groth16, PLONK, etc.) use **nullifiers** to make each proof
+one-time-use: before granting access the verifier must:
+
+1. Check that `nullifier` is not already in the spent set → reject if it is.
+2. Mark `nullifier` as spent in persistent storage → prevent future replays.
+
+Omitting either step breaks the double-spend guarantee even when the
+cryptographic pairing check passes.
+
+## Vulnerable Pattern
+
+```rust
+pub fn verify(env: Env, proof: Proof, public_inputs: Bytes, nullifier: Bytes) -> bool {
+    let vk = load_vk(&env);
+    groth16_verify(&vk, &proof, &public_inputs); // pairing check passes
+    // ❌ nullifier never checked or stored
+    true
+}
+```
+
+## Secure Pattern
+
+```rust
+pub fn verify(env: Env, proof: Proof, public_inputs: Bytes, nullifier: Bytes) -> bool {
+    let vk = load_vk(&env);
+    groth16_verify(&vk, &proof, &public_inputs);
+
+    // ✅ fail closed if already spent
+    let nullifier_set = NullifierSet::new();
+    nullifier_set.assert_unspent(&env, &nullifier);
+
+    // ✅ mark spent before returning — prevents TOCTOU races
+    nullifier_set.mark_spent(&env, &nullifier);
+    true
+}
+```
+
+See `contracts/fixtures/finding-codes/z001_missing_nullifier.rs` for the
+triggering fixture and `contracts/zk-verifier/src/nullifier_set.rs` for the
+`NullifierSet` reference implementation.
+
+## References
+
+- [Tornado Cash double-spend postmortem](https://tornado.cash)
+- Soroban TTL / eviction semantics → `docs/rules/missing-ttl-bump.md`
+- NullifierSet module → `contracts/zk-verifier/src/nullifier_set.rs`

--- a/frontend/app/components/ConstraintGraph.tsx
+++ b/frontend/app/components/ConstraintGraph.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { Finding } from "../types";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface CircuitSignal {
+  id: string;
+  name: string;
+  /** "input" | "output" | "intermediate" */
+  kind: "input" | "output" | "intermediate";
+  /** ZK finding codes that flag this signal (e.g. ["Z001", "Z007"]) */
+  flaggedBy?: string[];
+}
+
+export interface CircuitConstraint {
+  id: string;
+  /** Human-readable label for the constraint, e.g. "a * b === c" */
+  label: string;
+  /** Signal IDs involved */
+  signals: string[];
+  /** Finding codes flagging this constraint */
+  flaggedBy?: string[];
+}
+
+export interface CircuitGraph {
+  signals: CircuitSignal[];
+  constraints: CircuitConstraint[];
+}
+
+interface ConstraintGraphProps {
+  graph: CircuitGraph;
+  /** Findings from the ZK analysis, used to highlight flagged nodes */
+  findings?: Finding[];
+  className?: string;
+}
+
+// ── Layout ────────────────────────────────────────────────────────────────────
+
+const COL_X: Record<CircuitSignal["kind"], number> = {
+  input: 60,
+  intermediate: 260,
+  output: 460,
+};
+
+const NODE_R = 22;
+const ROW_GAP = 70;
+
+interface LayoutSignal extends CircuitSignal {
+  x: number;
+  y: number;
+}
+
+function layoutSignals(signals: CircuitSignal[]): LayoutSignal[] {
+  const counters: Record<string, number> = { input: 0, intermediate: 0, output: 0 };
+  return signals.map((s) => {
+    const row = counters[s.kind]++;
+    return { ...s, x: COL_X[s.kind], y: 60 + row * ROW_GAP };
+  });
+}
+
+// ── Colors ────────────────────────────────────────────────────────────────────
+
+const KIND_COLOR: Record<CircuitSignal["kind"], { fill: string; stroke: string; dark: string }> = {
+  input:        { fill: "#dbeafe", stroke: "#3b82f6", dark: "#1e3a5f" },
+  intermediate: { fill: "#f3f4f6", stroke: "#6b7280", dark: "#27272a" },
+  output:       { fill: "#d1fae5", stroke: "#10b981", dark: "#052e16" },
+};
+
+const ZK_FLAG_COLOR = "#8b5cf6"; // violet — matches ZkBadge in FindingsList
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+/**
+ * Interactive constraint-graph visualization for ZK circuits (issue #1236).
+ *
+ * Renders circuit signals as nodes (grouped by input / intermediate / output)
+ * with constraints shown as edges. Signals flagged by Z-rule findings are
+ * highlighted in violet so developers can immediately spot problem areas.
+ */
+export function ConstraintGraph({ graph, findings = [], className = "" }: ConstraintGraphProps) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const [selectedSignal, setSelectedSignal] = useState<string | null>(null);
+
+  // Build a set of flagged signal IDs from findings + explicit flaggedBy fields.
+  const flaggedSignalIds = useMemo<Set<string>>(() => {
+    const s = new Set<string>();
+    for (const sig of graph.signals) {
+      if (sig.flaggedBy && sig.flaggedBy.length > 0) s.add(sig.id);
+    }
+    // Also flag signals whose names appear in finding locations/titles.
+    for (const f of findings) {
+      if (/^Z\d+$/.test(f.code)) {
+        for (const sig of graph.signals) {
+          if (f.title.includes(sig.name) || (f.location ?? "").includes(sig.name)) {
+            s.add(sig.id);
+          }
+        }
+      }
+    }
+    return s;
+  }, [graph.signals, findings]);
+
+  const layouted = useMemo(() => layoutSignals(graph.signals), [graph.signals]);
+  const byId = useMemo(
+    () => new Map(layouted.map((s) => [s.id, s])),
+    [layouted],
+  );
+
+  const svgHeight = useMemo(() => {
+    const maxRows = Math.max(
+      graph.signals.filter((s) => s.kind === "input").length,
+      graph.signals.filter((s) => s.kind === "intermediate").length,
+      graph.signals.filter((s) => s.kind === "output").length,
+      1,
+    );
+    return 60 + maxRows * ROW_GAP + 40;
+  }, [graph.signals]);
+
+  const selectedInfo = selectedSignal ? byId.get(selectedSignal) : null;
+
+  if (graph.signals.length === 0) {
+    return (
+      <div className={`flex items-center justify-center rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 p-12 text-zinc-400 dark:text-zinc-500 ${className}`}>
+        No circuit signals to display.
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col gap-4 ${className}`}>
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-4 text-xs text-zinc-500 dark:text-zinc-400">
+        {(["input", "intermediate", "output"] as const).map((kind) => (
+          <span key={kind} className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-3 w-3 rounded-full border-2"
+              style={{ background: KIND_COLOR[kind].fill, borderColor: KIND_COLOR[kind].stroke }}
+            />
+            {kind.charAt(0).toUpperCase() + kind.slice(1)} signal
+          </span>
+        ))}
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-3 w-3 rounded-full border-2" style={{ background: "#ede9fe", borderColor: ZK_FLAG_COLOR }} />
+          Flagged by Z-rule
+        </span>
+      </div>
+
+      {/* SVG graph */}
+      <div className="overflow-x-auto rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow">
+        <svg
+          viewBox={`0 0 600 ${svgHeight}`}
+          width="100%"
+          style={{ minWidth: 480, minHeight: svgHeight }}
+          role="img"
+          aria-label="Circuit constraint graph"
+        >
+          {/* Column labels */}
+          {(["input", "intermediate", "output"] as const).map((kind) => (
+            <text
+              key={kind}
+              x={COL_X[kind]}
+              y={28}
+              textAnchor="middle"
+              fontSize={11}
+              fontWeight={600}
+              fill="#6b7280"
+              fontFamily="monospace"
+            >
+              {kind.toUpperCase()}
+            </text>
+          ))}
+
+          {/* Constraint edges */}
+          {graph.constraints.map((c) => {
+            const involved = c.signals.map((id) => byId.get(id)).filter(Boolean) as LayoutSignal[];
+            if (involved.length < 2) return null;
+            const isFlagged = (c.flaggedBy?.length ?? 0) > 0;
+            const color = isFlagged ? ZK_FLAG_COLOR : "#d1d5db";
+            // Draw lines between consecutive pairs of involved signals.
+            return involved.slice(0, -1).map((a, idx) => {
+              const b = involved[idx + 1];
+              return (
+                <line
+                  key={`${c.id}-${idx}`}
+                  x1={a.x}
+                  y1={a.y}
+                  x2={b.x}
+                  y2={b.y}
+                  stroke={color}
+                  strokeWidth={isFlagged ? 2 : 1.5}
+                  strokeDasharray={isFlagged ? "5 3" : undefined}
+                  opacity={0.7}
+                />
+              );
+            });
+          })}
+
+          {/* Signal nodes */}
+          {layouted.map((sig) => {
+            const flagged = flaggedSignalIds.has(sig.id);
+            const isHovered = hovered === sig.id;
+            const isSelected = selectedSignal === sig.id;
+            const colors = KIND_COLOR[sig.kind];
+            return (
+              <g
+                key={sig.id}
+                onClick={() => setSelectedSignal(isSelected ? null : sig.id)}
+                onMouseEnter={() => setHovered(sig.id)}
+                onMouseLeave={() => setHovered(null)}
+                style={{ cursor: "pointer" }}
+                role="button"
+                aria-pressed={isSelected}
+                aria-label={`Signal: ${sig.name}${flagged ? " (flagged)" : ""}`}
+              >
+                {/* Outer glow for flagged signals */}
+                {flagged && (
+                  <circle
+                    cx={sig.x}
+                    cy={sig.y}
+                    r={NODE_R + 6}
+                    fill={ZK_FLAG_COLOR}
+                    opacity={0.15}
+                  />
+                )}
+                <circle
+                  cx={sig.x}
+                  cy={sig.y}
+                  r={NODE_R}
+                  fill={flagged ? "#ede9fe" : colors.fill}
+                  stroke={flagged ? ZK_FLAG_COLOR : isHovered || isSelected ? colors.stroke : colors.stroke}
+                  strokeWidth={flagged ? 2.5 : isHovered || isSelected ? 2 : 1.5}
+                />
+                <text
+                  x={sig.x}
+                  y={sig.y + 1}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontSize={9}
+                  fontWeight={600}
+                  fontFamily="monospace"
+                  fill={flagged ? ZK_FLAG_COLOR : "#374151"}
+                >
+                  {sig.name.length > 8 ? sig.name.slice(0, 7) + "…" : sig.name}
+                </text>
+                {/* ZK flag indicator dot */}
+                {flagged && (
+                  <circle cx={sig.x + NODE_R - 4} cy={sig.y - NODE_R + 4} r={5} fill={ZK_FLAG_COLOR} stroke="#fff" strokeWidth={1} />
+                )}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* Detail panel for selected signal */}
+      {selectedInfo && (
+        <div className="rounded-xl border border-violet-200 dark:border-violet-800 bg-violet-50 dark:bg-violet-950/30 p-4 text-sm">
+          <p className="font-semibold text-violet-800 dark:text-violet-200 font-mono">{selectedInfo.name}</p>
+          <p className="text-violet-600 dark:text-violet-400 capitalize mt-0.5">{selectedInfo.kind} signal</p>
+          {flaggedSignalIds.has(selectedInfo.id) && selectedInfo.flaggedBy && selectedInfo.flaggedBy.length > 0 && (
+            <p className="mt-2 text-violet-700 dark:text-violet-300">
+              Flagged by: <span className="font-mono font-bold">{selectedInfo.flaggedBy.join(", ")}</span>
+            </p>
+          )}
+          {!flaggedSignalIds.has(selectedInfo.id) && (
+            <p className="mt-2 text-zinc-500 dark:text-zinc-400">No Z-rule findings for this signal.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/FindingsList.tsx
+++ b/frontend/app/components/FindingsList.tsx
@@ -9,6 +9,41 @@ import { Sparkles, FileCode } from "lucide-react";
 import { AiFixPanel } from "./AiFixPanel";
 import { filterFindings } from "../lib/finding-filters";
 
+/** Returns true when the finding code belongs to the ZK rule family (Z-rules). */
+function isZkFinding(code: string): boolean {
+  return /^Z\d+$/.test(code);
+}
+
+/**
+ * Visual badge for ZK-circuit findings (issue #1240).
+ * A small lock/circuit glyph lets users distinguish Z-rule findings from
+ * standard S-rule findings at a glance.
+ */
+function ZkBadge() {
+  return (
+    <span
+      aria-label="ZK circuit finding"
+      title="ZK circuit finding — applies to zero-knowledge constraint systems"
+      className="inline-flex items-center gap-1 rounded-full border border-violet-400/50 bg-violet-500/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-violet-600 dark:border-violet-400/40 dark:bg-violet-500/15 dark:text-violet-300 theme-high-contrast:border-white theme-high-contrast:text-white"
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 16 16"
+        fill="none"
+        aria-hidden="true"
+        className="shrink-0"
+      >
+        <rect x="5" y="1" width="6" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M3 7h10v8H3z" stroke="currentColor" strokeWidth="1.5" fill="none" />
+        <circle cx="8" cy="11" r="1.25" fill="currentColor" />
+        <path d="M8 12v2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+      ZK
+    </span>
+  );
+}
+
 interface FindingsListProps {
   findings: Finding[];
   severityFilter: Severity | "all";
@@ -89,6 +124,7 @@ function FindingCard({ finding, onSelectAiFix, onViewSource }: FindingCardProps)
           <span className="font-mono text-xs rounded border border-zinc-300/70 dark:border-zinc-600 px-2 py-1 text-zinc-700 dark:text-zinc-300 theme-high-contrast:border-white theme-high-contrast:text-white" aria-label={`Error code: ${finding.code}`}>
             {finding.code}
           </span>
+          {isZkFinding(finding.code) && <ZkBadge />}
         </div>
       </div>
       {finding.snippet && (

--- a/frontend/app/components/ZkFindingsPanel.tsx
+++ b/frontend/app/components/ZkFindingsPanel.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { ExternalLink, ShieldAlert, ZapOff } from "lucide-react";
+import type { Finding } from "../types";
+
+// Feature-flagged via NEXT_PUBLIC_ZK_ENABLED env var (issue #1142).
+// The panel renders only when the flag is truthy so non-ZK projects
+// never see it in their scan results.
+export const ZK_ENABLED =
+  typeof process !== "undefined" &&
+  process.env.NEXT_PUBLIC_ZK_ENABLED === "true";
+
+const RULE_DOCS_BASE =
+  "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/";
+
+/** Z-rule codes that carry ZK-specific metadata fields. */
+const ZK_RULE_CODES = new Set([
+  "Z001", "Z002", "Z003", "Z004", "Z005",
+  "Z006", "Z007", "Z008", "Z009", "Z010",
+]);
+
+function isZkFinding(f: Finding): boolean {
+  return ZK_RULE_CODES.has(f.code) || f.category === "zk";
+}
+
+interface ZkFindingCardProps {
+  finding: Finding;
+}
+
+function ZkFindingCard({ finding }: ZkFindingCardProps) {
+  const meta = finding.raw as Record<string, unknown> | null;
+  const circuitFile   = meta?.circuit_file   as string | undefined;
+  const signalName    = meta?.signal_name    as string | undefined;
+  const templateName  = meta?.template_name  as string | undefined;
+  const constraintRef = meta?.constraint_ref as string | undefined;
+  const docsUrl = `${RULE_DOCS_BASE}${finding.code}.md`;
+
+  const severityBg: Record<string, string> = {
+    critical: "border-red-500/60 bg-red-500/8",
+    high:     "border-orange-500/60 bg-orange-500/8",
+    medium:   "border-amber-500/60 bg-amber-500/8",
+    low:      "border-zinc-400/40 bg-zinc-500/5",
+  };
+
+  const severityBadge: Record<string, string> = {
+    critical: "bg-red-500/15 text-red-600 dark:text-red-400",
+    high:     "bg-orange-500/15 text-orange-600 dark:text-orange-400",
+    medium:   "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+    low:      "bg-zinc-500/15 text-zinc-600 dark:text-zinc-400",
+  };
+
+  return (
+    <div
+      className={`rounded-lg border p-4 space-y-2 ${severityBg[finding.severity] ?? severityBg.low}`}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className={`inline-block px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide ${severityBadge[finding.severity] ?? severityBadge.low}`}
+            >
+              {finding.severity}
+            </span>
+            <span className="font-mono text-xs text-zinc-500 dark:text-zinc-400">
+              {finding.code}
+            </span>
+            <a
+              href={docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[10px] text-blue-600 dark:text-blue-400 hover:underline"
+              aria-label={`Documentation for ${finding.code}`}
+            >
+              docs <ExternalLink size={10} />
+            </a>
+          </div>
+          <h3 className="mt-1 text-sm font-semibold leading-snug">{finding.title}</h3>
+        </div>
+        <ShieldAlert
+          size={18}
+          className="flex-shrink-0 text-zinc-400 dark:text-zinc-500 mt-0.5"
+          aria-hidden
+        />
+      </div>
+
+      {/* Circuit context — ZK-specific fields */}
+      {(circuitFile || signalName || templateName || constraintRef) && (
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+          {circuitFile && (
+            <>
+              <dt className="text-zinc-500 dark:text-zinc-400">Circuit file</dt>
+              <dd className="font-mono truncate" title={circuitFile}>{circuitFile}</dd>
+            </>
+          )}
+          {templateName && (
+            <>
+              <dt className="text-zinc-500 dark:text-zinc-400">Template</dt>
+              <dd className="font-mono truncate">{templateName}</dd>
+            </>
+          )}
+          {signalName && (
+            <>
+              <dt className="text-zinc-500 dark:text-zinc-400">Signal</dt>
+              <dd className="font-mono truncate">{signalName}</dd>
+            </>
+          )}
+          {constraintRef && (
+            <>
+              <dt className="text-zinc-500 dark:text-zinc-400">Constraint</dt>
+              <dd className="font-mono truncate">{constraintRef}</dd>
+            </>
+          )}
+        </dl>
+      )}
+
+      {/* Location + suggestion */}
+      {finding.location && (
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 font-mono truncate">
+          {finding.location}
+          {finding.line !== undefined && `:${finding.line}`}
+        </p>
+      )}
+      {finding.suggestion && (
+        <p className="text-xs text-zinc-600 dark:text-zinc-300 border-l-2 border-zinc-300 dark:border-zinc-600 pl-2">
+          {finding.suggestion}
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface ZkFindingsPanelProps {
+  findings: Finding[];
+}
+
+/**
+ * ZkFindingsPanel — renders Z-rule findings with circuit-appropriate context.
+ *
+ * Gated behind `NEXT_PUBLIC_ZK_ENABLED=true` (issue #1142 feature flag).
+ * Non-ZK findings in the `findings` array are ignored by this panel; the
+ * standard FindingsList handles them.
+ */
+export function ZkFindingsPanel({ findings }: ZkFindingsPanelProps) {
+  if (!ZK_ENABLED) return null;
+
+  const zkFindings = findings.filter(isZkFinding);
+  if (zkFindings.length === 0) return null;
+
+  return (
+    <section aria-labelledby="zk-findings-heading" className="space-y-3">
+      {/* Panel header */}
+      <div className="flex items-center gap-2">
+        <ZapOff size={16} className="text-purple-500" aria-hidden />
+        <h2
+          id="zk-findings-heading"
+          className="text-sm font-semibold text-zinc-800 dark:text-zinc-200"
+        >
+          ZK Findings
+          <span className="ml-2 text-xs font-normal text-zinc-500 dark:text-zinc-400">
+            ({zkFindings.length})
+          </span>
+        </h2>
+        <a
+          href={`${RULE_DOCS_BASE}Z001.md`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-auto text-[10px] text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+        >
+          Z-rule docs <ExternalLink size={10} />
+        </a>
+      </div>
+
+      {/* Finding cards */}
+      <div className="space-y-2">
+        {zkFindings.map((f) => (
+          <ZkFindingCard key={f.id} finding={f} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/playground/page.tsx
+++ b/frontend/app/playground/page.tsx
@@ -356,6 +356,13 @@ function PlaygroundPageInner() {
             <p className="text-zinc-500 max-w-xl">
               Write, compile, and test Soroban smart contracts in real-time without local setup.
             </p>
+            <a
+              href="/playground/zk"
+              className="inline-flex items-center gap-1.5 text-xs font-semibold text-violet-600 dark:text-violet-400 hover:underline mt-1"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="5" y="1" width="6" height="5" rx="1.5" stroke="currentColor" strokeWidth="1.5"/><path d="M3 7h10v8H3z" stroke="currentColor" strokeWidth="1.5" fill="none"/><circle cx="8" cy="11" r="1.25" fill="currentColor"/></svg>
+              Switch to ZK Playground →
+            </a>
           </div>
 
           <div className="flex items-center gap-3">

--- a/frontend/app/playground/zk/page.tsx
+++ b/frontend/app/playground/zk/page.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+/**
+ * ZK proof-verification playground (issue #1237).
+ *
+ * Extends the playground pattern to ZK circuits: accepts circom-style circuit
+ * source and an optional sample proof, runs client-side Z-rule analysis via
+ * the /api/analyze/zk endpoint (or WASM entry point when available), and
+ * displays results using the shared FindingsList panel and ConstraintGraph.
+ */
+
+import { useState, useCallback } from "react";
+import { Play, RotateCcw, Lock, AlertTriangle, CheckCircle } from "lucide-react";
+import { FindingsList } from "../../components/FindingsList";
+import { ConstraintGraph } from "../../components/ConstraintGraph";
+import type { Finding } from "../../types";
+import type { CircuitGraph } from "../../components/ConstraintGraph";
+
+// ── Default circuit sample ────────────────────────────────────────────────────
+
+const DEFAULT_CIRCUIT = `pragma circom 2.0.0;
+
+// Example: a simple multiplier circuit
+// This circuit proves knowledge of a and b such that a * b = c
+// Z-rule analysis will check for constraint soundness.
+
+template Multiplier() {
+    signal input a;
+    signal input b;
+    signal output c;
+
+    // Constraint: a * b === c
+    c <== a * b;
+}
+
+component main = Multiplier();`;
+
+const DEFAULT_PROOF = `{
+  "protocol": "groth16",
+  "curve": "bn128",
+  "pi_a": ["0x1234", "0x5678", "0x0001"],
+  "pi_b": [["0xabcd", "0xef01"], ["0x2345", "0x6789"], ["0x0001", "0x0000"]],
+  "pi_c": ["0x9abc", "0xdef0", "0x0001"]
+}`;
+
+// ── ZK sample circuits ────────────────────────────────────────────────────────
+
+const ZK_SAMPLES: Record<string, { label: string; circuit: string; description: string }> = {
+  "under-constrained": {
+    label: "Under-constrained Signal (Z001)",
+    description: "Signal 'x' is used in output but not constrained — Z001 should fire.",
+    circuit: `pragma circom 2.0.0;
+
+template UnderConstrained() {
+    signal input a;
+    signal input b;
+    signal x;        // BUG: x is assigned but not constrained
+    signal output c;
+
+    x <-- a + b;     // x is computed but not constrained with <==
+    c <== a * b;     // x is never tied to c, so a prover can set x freely
+}
+
+component main = UnderConstrained();`,
+  },
+  "missing-nullifier": {
+    label: "Missing Nullifier (Z002)",
+    description: "Spend circuit has no nullifier check — same witness can be reused.",
+    circuit: `pragma circom 2.0.0;
+
+template Spend() {
+    signal input secret;
+    signal input nonce;
+    signal output commitment;
+
+    // BUG: no nullifier computed or checked — double-spend possible
+    commitment <== secret * nonce;
+}
+
+component main = Spend();`,
+  },
+  "sound-multiplier": {
+    label: "Sound Multiplier (no findings)",
+    description: "A correctly constrained multiplier — analysis should report no issues.",
+    circuit: DEFAULT_CIRCUIT,
+  },
+};
+
+// ── Simulated ZK analysis ─────────────────────────────────────────────────────
+// In production this calls the WASM ZK-analysis entry point from #1231.
+// For the playground, a deterministic simulation is used so the UI is fully
+// exercisable without a backend.
+
+function simulateZkAnalysis(circuit: string): {
+  findings: Finding[];
+  graph: CircuitGraph;
+} {
+  const findings: Finding[] = [];
+  const signals: CircuitGraph["signals"] = [];
+  const constraints: CircuitGraph["constraints"] = [];
+
+  // Parse signal declarations (very simplified — real impl uses the AST from #1227).
+  const signalRe = /signal\s+(input|output|)\s*(\w+)\s*;/g;
+  let m: RegExpExecArray | null;
+  let sigIdx = 0;
+  while ((m = signalRe.exec(circuit)) !== null) {
+    const rawKind = m[1].trim();
+    const kind: "input" | "output" | "intermediate" =
+      rawKind === "input" ? "input" : rawKind === "output" ? "output" : "intermediate";
+    signals.push({ id: `sig-${sigIdx++}`, name: m[2], kind });
+  }
+
+  // Z001: detect signals assigned with <-- but not constrained with <==.
+  const weakAssignRe = /(\w+)\s*<--[^=]/g;
+  const strongConstraintRe = /(\w+)\s*<==/g;
+  const weakNames = new Set<string>();
+  const strongNames = new Set<string>();
+  let wm: RegExpExecArray | null;
+  while ((wm = weakAssignRe.exec(circuit)) !== null) weakNames.add(wm[1]);
+  while ((wm = strongConstraintRe.exec(circuit)) !== null) strongNames.add(wm[1]);
+  for (const name of weakNames) {
+    if (!strongNames.has(name)) {
+      const sig = signals.find((s) => s.name === name);
+      if (sig) sig.flaggedBy = ["Z001"];
+      findings.push({
+        id: `z001-${name}`,
+        code: "Z001",
+        severity: "high",
+        category: "ZK Circuit",
+        title: `Under-constrained signal: ${name}`,
+        location: `circuit.circom`,
+        suggestion: `Replace '<--' with '<==' or add an explicit equality constraint.`,
+        raw: {},
+      });
+    }
+  }
+
+  // Z002: detect templates without any nullifier signal.
+  const templateRe = /template\s+(\w+)\s*\(\s*\)/g;
+  const hasNullifier = /nullifier/i.test(circuit);
+  const isSpendTemplate = /spend|withdraw|claim/i.test(circuit);
+  let tm: RegExpExecArray | null;
+  while ((tm = templateRe.exec(circuit)) !== null) {
+    if (isSpendTemplate && !hasNullifier) {
+      findings.push({
+        id: `z002-${tm[1]}`,
+        code: "Z002",
+        severity: "critical",
+        category: "ZK Circuit",
+        title: `Missing nullifier in spend template: ${tm[1]}`,
+        location: `circuit.circom`,
+        suggestion: `Add a nullifier signal and constrain it to prevent double-spend.`,
+        raw: {},
+      });
+    }
+  }
+
+  // Build constraints from <== expressions.
+  const constraintRe = /(\w+)\s*<==\s*(.+?);/g;
+  let cm: RegExpExecArray | null;
+  let cIdx = 0;
+  while ((cm = constraintRe.exec(circuit)) !== null) {
+    const lhs = cm[1];
+    const rhs = cm[2];
+    const involved = [lhs, ...rhs.match(/\b([a-zA-Z_]\w*)\b/g) ?? []]
+      .map((name) => signals.find((s) => s.name === name)?.id)
+      .filter(Boolean) as string[];
+    if (involved.length >= 2) {
+      constraints.push({
+        id: `c-${cIdx++}`,
+        label: `${lhs} <== ${rhs.trim()}`,
+        signals: [...new Set(involved)],
+      });
+    }
+  }
+
+  return { findings, graph: { signals, constraints } };
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function ZkPlaygroundPage() {
+  const [circuit, setCircuit] = useState(DEFAULT_CIRCUIT);
+  const [proof, setProof] = useState(DEFAULT_PROOF);
+  const [showProof, setShowProof] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [findings, setFindings] = useState<Finding[]>([]);
+  const [graph, setGraph] = useState<CircuitGraph>({ signals: [], constraints: [] });
+  const [activeTab, setActiveTab] = useState<"findings" | "graph">("findings");
+  const [hasRun, setHasRun] = useState(false);
+
+  const addLog = useCallback((msg: string) => {
+    setLogs((prev) => [...prev, `[${new Date().toLocaleTimeString()}] ${msg}`]);
+  }, []);
+
+  const runAnalysis = useCallback(async () => {
+    setIsRunning(true);
+    setLogs([]);
+    setFindings([]);
+    setGraph({ signals: [], constraints: [] });
+    setHasRun(false);
+
+    addLog("Initializing ZK analysis engine…");
+    addLog("Parsing circuit signals and constraints…");
+
+    // Simulate async WASM invocation (replaced by real WASM call from #1231).
+    await new Promise((r) => setTimeout(r, 800));
+
+    const result = simulateZkAnalysis(circuit);
+
+    addLog(`Parsed ${result.graph.signals.length} signals, ${result.graph.constraints.length} constraints.`);
+    addLog("Running Z-rule checks…");
+
+    await new Promise((r) => setTimeout(r, 400));
+
+    if (result.findings.length === 0) {
+      addLog("✅ No Z-rule findings detected.");
+    } else {
+      const critical = result.findings.filter((f) => f.severity === "critical").length;
+      const high = result.findings.filter((f) => f.severity === "high").length;
+      if (critical > 0) addLog(`🔴 ${critical} critical finding(s)`);
+      if (high > 0) addLog(`🟠 ${high} high-severity finding(s)`);
+      addLog(`📊 Analysis complete: ${result.findings.length} finding(s) total`);
+    }
+
+    setFindings(result.findings);
+    setGraph(result.graph);
+    setHasRun(true);
+    setIsRunning(false);
+  }, [circuit, addLog]);
+
+  const resetCircuit = useCallback(() => {
+    if (!confirm("Reset to default circuit?")) return;
+    setCircuit(DEFAULT_CIRCUIT);
+    setProof(DEFAULT_PROOF);
+    setLogs([]);
+    setFindings([]);
+    setGraph({ signals: [], constraints: [] });
+    setHasRun(false);
+  }, []);
+
+  const loadSample = useCallback((key: string) => {
+    const s = ZK_SAMPLES[key];
+    if (!s) return;
+    setCircuit(s.circuit);
+    setLogs([]);
+    setFindings([]);
+    setGraph({ signals: [], constraints: [] });
+    setHasRun(false);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 pb-20">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-12 space-y-8">
+        {/* Header */}
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 font-mono text-xs font-bold uppercase tracking-widest text-violet-500">
+              <Lock size={14} />
+              ZK Mode — Alpha
+            </div>
+            <h1 className="text-4xl font-bold tracking-tight">ZK Playground</h1>
+            <p className="text-zinc-500 max-w-xl">
+              Paste a circom circuit and optional proof. Z-rule analysis runs client-side — no setup required.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {/* Sample picker */}
+            <select
+              className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-2 focus:ring-violet-500"
+              defaultValue=""
+              onChange={(e) => { if (e.target.value) loadSample(e.target.value); }}
+            >
+              <option value="" disabled>Load sample…</option>
+              {Object.entries(ZK_SAMPLES).map(([key, s]) => (
+                <option key={key} value={key}>{s.label}</option>
+              ))}
+            </select>
+            <button
+              onClick={resetCircuit}
+              className="p-2.5 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+              title="Reset circuit"
+            >
+              <RotateCcw size={20} />
+            </button>
+            <button
+              onClick={runAnalysis}
+              disabled={isRunning}
+              className="flex items-center gap-2 px-6 py-2.5 rounded-xl bg-violet-600 hover:bg-violet-700 text-white font-bold transition-all shadow-lg shadow-violet-500/20 active:scale-95 disabled:opacity-50 disabled:pointer-events-none"
+            >
+              <Play size={18} fill="currentColor" />
+              {isRunning ? "Analyzing…" : "Analyze"}
+            </button>
+          </div>
+        </div>
+
+        {/* Editor grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Circuit editor */}
+          <div className="flex flex-col rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 overflow-hidden shadow-xl h-[600px]">
+            <div className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-950/50 flex items-center justify-between">
+              <span className="text-xs font-mono text-zinc-500">circuit.circom</span>
+              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">Circom 2.0</span>
+            </div>
+            <textarea
+              value={circuit}
+              onChange={(e) => setCircuit(e.target.value)}
+              spellCheck={false}
+              aria-label="Circuit source code"
+              className="flex-1 p-6 font-mono text-sm bg-transparent outline-none resize-none leading-relaxed text-zinc-700 dark:text-zinc-300"
+            />
+            {/* Optional proof pane */}
+            <div className="border-t border-zinc-200 dark:border-zinc-800">
+              <button
+                onClick={() => setShowProof((v) => !v)}
+                className="w-full px-4 py-2 text-left text-xs font-medium text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors flex items-center justify-between"
+              >
+                <span>Sample proof (optional)</span>
+                <span>{showProof ? "▲" : "▼"}</span>
+              </button>
+              {showProof && (
+                <textarea
+                  value={proof}
+                  onChange={(e) => setProof(e.target.value)}
+                  spellCheck={false}
+                  aria-label="Sample proof JSON"
+                  className="w-full h-36 p-4 font-mono text-xs bg-zinc-50 dark:bg-zinc-950 outline-none resize-none text-zinc-600 dark:text-zinc-400 border-t border-zinc-200 dark:border-zinc-800"
+                  placeholder='{ "protocol": "groth16", ... }'
+                />
+              )}
+            </div>
+          </div>
+
+          {/* Results panel */}
+          <div className="flex flex-col gap-4 h-[600px] overflow-hidden">
+            {/* Terminal log */}
+            <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-zinc-900 overflow-hidden shadow-xl h-40 flex-shrink-0">
+              <div className="px-4 py-2 border-b border-zinc-800 bg-zinc-950/80 flex items-center gap-2">
+                <div className="flex gap-1">
+                  {["bg-red-500", "bg-yellow-500", "bg-green-500"].map((c) => (
+                    <div key={c} className={`w-2.5 h-2.5 rounded-full ${c}`} />
+                  ))}
+                </div>
+                <span className="text-xs font-mono text-zinc-500">zk-analysis terminal</span>
+              </div>
+              <div className="p-4 font-mono text-xs text-emerald-400 overflow-y-auto h-24 space-y-1">
+                {logs.length === 0 ? (
+                  <span className="text-zinc-600">Ready. Click Analyze to run Z-rule checks.</span>
+                ) : (
+                  logs.map((l, i) => <div key={i}>{l}</div>)
+                )}
+              </div>
+            </div>
+
+            {/* Findings / Graph tabs */}
+            <div className="flex-1 flex flex-col overflow-hidden rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-xl">
+              <div className="flex gap-1 border-b border-zinc-200 dark:border-zinc-800 px-4 pt-2">
+                {(["findings", "graph"] as const).map((tab) => (
+                  <button
+                    key={tab}
+                    onClick={() => setActiveTab(tab)}
+                    className={`px-4 py-2 text-sm font-medium border-b-2 capitalize transition-colors -mb-px ${
+                      activeTab === tab
+                        ? "border-violet-500 text-violet-600 dark:text-violet-400"
+                        : "border-transparent text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+                    }`}
+                  >
+                    {tab}
+                    {tab === "findings" && findings.length > 0 && (
+                      <span className="ml-2 rounded-full bg-violet-100 dark:bg-violet-900/30 px-1.5 py-0.5 text-[10px] font-bold text-violet-700 dark:text-violet-300">
+                        {findings.length}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex-1 overflow-y-auto p-4">
+                {!hasRun ? (
+                  <div className="flex flex-col items-center justify-center h-full text-zinc-400 dark:text-zinc-500 gap-3">
+                    <Lock size={32} className="opacity-40" />
+                    <p className="text-sm">Run the analysis to see Z-rule findings.</p>
+                  </div>
+                ) : activeTab === "findings" ? (
+                  findings.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center h-full gap-3 text-emerald-600 dark:text-emerald-400">
+                      <CheckCircle size={32} />
+                      <p className="text-sm font-medium">No Z-rule findings detected.</p>
+                      <p className="text-xs text-zinc-400">Circuit passed all enabled checks.</p>
+                    </div>
+                  ) : (
+                    <div className="space-y-4">
+                      <div className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
+                        <AlertTriangle size={16} />
+                        <span className="font-medium">{findings.length} finding(s) found</span>
+                      </div>
+                      <FindingsList
+                        findings={findings}
+                        severityFilter="all"
+                      />
+                    </div>
+                  )
+                ) : (
+                  <ConstraintGraph
+                    graph={graph}
+                    findings={findings}
+                    className="h-full"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Sample descriptions */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {Object.entries(ZK_SAMPLES).map(([key, s]) => (
+            <button
+              key={key}
+              onClick={() => loadSample(key)}
+              className="text-left rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 hover:border-violet-300 dark:hover:border-violet-700 transition-colors"
+            >
+              <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-200">{s.label}</p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">{s.description}</p>
+            </button>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/scan/page.tsx
+++ b/frontend/app/scan/page.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import { AnalysisTerminal } from "../components/AnalysisTerminal";
 import { SanctityScore } from "../components/SanctityScore";
 import { FindingsList } from "../components/FindingsList";
+import { ZkFindingsPanel } from "../components/ZkFindingsPanel";
 import { SeverityFilter } from "../components/SeverityFilter";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { nextScanProgressPhase } from "../lib/scan-progress";
@@ -229,6 +230,7 @@ export default function ScanPage() {
                 <SeverityFilter selected={severityFilter} onChange={setSeverityFilter} />
               </div>
               <ErrorBoundary>
+                <ZkFindingsPanel findings={findings} />
                 <FindingsList findings={findings} severityFilter={severityFilter} />
               </ErrorBoundary>
             </div>

--- a/schemas/sanctifier.json
+++ b/schemas/sanctifier.json
@@ -68,6 +68,38 @@
         },
         "required": ["name", "pattern", "severity"]
       }
+    },
+    "zk": {
+      "type": "object",
+      "description": "ZK rule pack configuration. Most non-ZK projects can leave this section absent; 'auto' mode skips the pack when no .circom or .nr files are detected.",
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["auto"] }
+          ],
+          "description": "Enable the ZK rule pack. true = always on, false = always off, 'auto' (default) = enable only when .circom or .nr files are found in the project.",
+          "default": "auto"
+        },
+        "circom_include_dirs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional directories to search for Circom library imports (e.g. circomlib). Paths are relative to the project root.",
+          "default": []
+        },
+        "noir_project_root": {
+          "type": "string",
+          "description": "Path to the Noir project root (directory containing Nargo.toml). Defaults to the repo root.",
+          "default": "."
+        },
+        "skip_rules": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Z-rule codes to exclude from this run (e.g. ['Z003', 'Z007']). Prefer the generic rule-disable mechanism once #1230 lands.",
+          "default": []
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/vscode-extension/src/code-actions.test.ts
+++ b/vscode-extension/src/code-actions.test.ts
@@ -218,4 +218,51 @@ describe('SanctifierCodeActionProvider', () => {
     const actions = provider.provideCodeActions(doc, emptyRange, emptyContext(diags));
     expect(actions).toHaveLength(3);
   });
+
+  // ── Z-rule quick-fix tests (issue #1239) ────────────────────────────────────
+
+  it('returns auth-constraint scaffold for Z010', () => {
+    const doc = makeDocument([
+      '  template AuthGate() {',
+      '    signal input secret;',
+      '  }',
+    ]);
+    const diag = makeDiag('Z010', 1);
+    const actions = provider.provideCodeActions(doc, emptyRange, emptyContext([diag]));
+    expect(actions).toHaveLength(1);
+    expect(actions[0].title).toContain('Z010');
+    const edit = actions[0].edit as unknown as WorkspaceEdit;
+    expect(edit._inserts).toHaveLength(1);
+    // Inserted after the flagged line
+    expect(edit._inserts[0].position).toEqual(new Position(2, 0));
+    expect(edit._inserts[0].text).toContain('pubKeyHash');
+  });
+
+  it('returns nullifier-check scaffold for Z002', () => {
+    const doc = makeDocument([
+      '  template Spend() {',
+      '    signal input nonce;',
+      '  }',
+    ]);
+    const diag = makeDiag('Z002', 1);
+    const actions = provider.provideCodeActions(doc, emptyRange, emptyContext([diag]));
+    expect(actions).toHaveLength(1);
+    expect(actions[0].title).toContain('Z002');
+    const edit = actions[0].edit as unknown as WorkspaceEdit;
+    expect(edit._inserts[0].text).toContain('nullifier');
+  });
+
+  it('returns no quick-fix for Z-rules without a mechanical fix (e.g. Z007)', () => {
+    const doc = makeDocument(['    signal range_value;']);
+    const diag = makeDiag('Z007', 0);
+    const actions = provider.provideCodeActions(doc, emptyRange, emptyContext([diag]));
+    expect(actions).toHaveLength(0);
+  });
+
+  it('returns no quick-fix for unknown Z-rule codes', () => {
+    const doc = makeDocument(['    signal x;']);
+    const diag = makeDiag('Z999', 0);
+    const actions = provider.provideCodeActions(doc, emptyRange, emptyContext([diag]));
+    expect(actions).toHaveLength(0);
+  });
 });

--- a/vscode-extension/src/code-actions.ts
+++ b/vscode-extension/src/code-actions.ts
@@ -5,8 +5,14 @@ import {
   buildUnwrapFix,
   buildCheckedArithFix,
 } from './analyzer';
+import { isZkRule } from './hover';
 
 const SOURCE = 'sanctifier';
+
+// Z-rule codes that have well-defined mechanical quick-fixes (issue #1239).
+// Rules requiring deep contextual judgment (Z007 range-check design, etc.)
+// provide hover-only explanations; they are not listed here.
+const ZK_QUICK_FIX_CODES = new Set(['Z010', 'Z002']);
 
 export class SanctifierCodeActionProvider implements vscode.CodeActionProvider {
   static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
@@ -40,6 +46,11 @@ export class SanctifierCodeActionProvider implements vscode.CodeActionProvider {
         }
       } else if (code === CODES.ARITHMETIC_OVERFLOW) {
         const action = this.buildArithAction(document, diag);
+        if (action) {
+          actions.push(action);
+        }
+      } else if (isZkRule(code) && ZK_QUICK_FIX_CODES.has(code)) {
+        const action = this.buildZkQuickFixAction(document, diag, code);
         if (action) {
           actions.push(action);
         }
@@ -118,6 +129,48 @@ export class SanctifierCodeActionProvider implements vscode.CodeActionProvider {
     action.isPreferred = true;
     action.edit = new vscode.WorkspaceEdit();
     action.edit.replace(document.uri, document.lineAt(lineIdx).range, fixed);
+    return action;
+  }
+
+  /**
+   * Quick-fix scaffolds for Z-rules with well-defined mechanical remediation
+   * (issue #1239). Inserts a comment block with the required constraint pattern
+   * directly after the flagged line.
+   */
+  private buildZkQuickFixAction(
+    document: vscode.TextDocument,
+    diag: vscode.Diagnostic,
+    code: string,
+  ): vscode.CodeAction | null {
+    const lineIdx = diag.range.start.line;
+    const lineText = document.lineAt(lineIdx).text;
+    const indent = (lineText.match(/^(\s*)/) ?? ['', ''])[1];
+
+    let snippet: string;
+    let label: string;
+
+    if (code === 'Z010') {
+      label = 'Add ZK auth constraint (Z010)';
+      snippet =
+        `${indent}// Z010 fix: constrain the authority signal\n` +
+        `${indent}// signal pubKeyHash <== Poseidon(1)([secret]);\n` +
+        `${indent}// pubKeyHash === knownPubKeyHash;\n`;
+    } else if (code === 'Z002') {
+      label = 'Add nullifier check scaffold (Z002)';
+      snippet =
+        `${indent}// Z002 fix: verify nullifier uniqueness before spend\n` +
+        `${indent}// signal nullifier <== Poseidon(2)([secret, nonce]);\n` +
+        `${indent}// nullifiers[nullifier] === 0;\n` +
+        `${indent}// nullifiers[nullifier] <== 1;\n`;
+    } else {
+      return null;
+    }
+
+    const action = new vscode.CodeAction(label, vscode.CodeActionKind.QuickFix);
+    action.diagnostics = [diag];
+    action.isPreferred = true;
+    action.edit = new vscode.WorkspaceEdit();
+    action.edit.insert(document.uri, new vscode.Position(lineIdx + 1, 0), snippet);
     return action;
   }
 }

--- a/vscode-extension/src/hover.ts
+++ b/vscode-extension/src/hover.ts
@@ -3,7 +3,8 @@ import type { EditorFinding } from './types';
 
 const RULE_DOCS_BASE = 'https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules';
 
-const CODE_TO_MARKDOWN: Record<string, { title: string; description: string; fix: string }> = {
+const CODE_TO_MARKDOWN: Record<string, { title: string; description: string; fix: string; isZk?: boolean }> = {
+  // ── S-rules (Soroban / standard) ────────────────────────────────────────────
   S001: {
     title: 'Authentication Gap',
     description: 'A public function performs a privileged operation (storage mutation or cross-contract call) without `require_auth`. Anyone can invoke it.',
@@ -24,28 +25,75 @@ const CODE_TO_MARKDOWN: Record<string, { title: string; description: string; fix
     description: '`.unwrap()` or `.expect()` can abort the contract if the precondition fails. Use explicit error handling instead.',
     fix: '// Instead of val.unwrap()\nmatch val {\n    Some(v) => v,\n    None => return Err(Error::NotFound),\n}',
   },
+  // ── Z-rules (ZK circuit) ────────────────────────────────────────────────────
+  Z001: {
+    isZk: true,
+    title: 'Under-constrained Signal',
+    description: 'A circuit signal is used in an output or assertion but lacks sufficient constraints to be uniquely determined. An under-constrained signal allows a malicious prover to choose arbitrary values, defeating the soundness guarantee of the proof.',
+    fix: '// Add explicit range or equality constraints for each signal:\n// component eq = IsEqual();\n// eq.in[0] <== signal;\n// eq.in[1] <== expected;',
+  },
+  Z002: {
+    isZk: true,
+    title: 'Missing Nullifier Check',
+    description: 'A spend or claim path does not verify a nullifier, allowing the same witness to produce valid proofs multiple times (double-spend). Every private input that represents a unique spend must commit to an on-chain nullifier.',
+    fix: '// Compute nullifier commitment and verify uniqueness:\n// signal nullifier <== Poseidon(2)([secret, nonce]);\n// nullifiers[nullifier] === 0; // check not spent\n// nullifiers[nullifier] <== 1; // mark spent',
+  },
+  Z003: {
+    isZk: true,
+    title: 'Unconstrained Public Input',
+    description: 'A public input to the circuit is not tied to any constraint, so any value passes verification. This breaks the binding property: the verifier cannot trust what the prover claims the public input represents.',
+    fix: '// Bind public inputs to internal signals via constraints:\n// signal input pub_value;\n// internal_signal === pub_value; // enforce binding',
+  },
+  Z007: {
+    isZk: true,
+    title: 'Missing Range Check',
+    description: 'A numeric signal is not bounded to an expected range of values. Without a range check, a prover may supply out-of-range values (e.g., negative balances encoded as large field elements) that pass all other constraints.',
+    fix: '// Use a range check component:\n// component range = Num2Bits(64);\n// range.in <== value;\n// // This constrains value to [0, 2^64)',
+  },
+  Z008: {
+    isZk: true,
+    title: 'Arithmetic Soundness (ZK)',
+    description: 'An arithmetic operation inside the circuit is not sound: either it can overflow the field prime, produce an ambiguous result, or relies on native integer arithmetic assumptions that do not hold inside a finite field.',
+    fix: '// Perform arithmetic in the field explicitly:\n// // Avoid: a * b where result may exceed field prime\n// // Prefer: split into constrained sub-operations\n// component mul = Multiplier();\n// mul.a <== a;\n// mul.b <== b;',
+  },
+  Z010: {
+    isZk: true,
+    title: 'Missing Auth Constraint (ZK)',
+    description: 'A circuit that gates access to a privileged action does not verify the authority signal (e.g., a hash of a secret key). Anyone who can construct a valid witness can bypass the intended authorization.',
+    fix: '// Verify authority in the circuit:\n// signal input secret;\n// signal pubKeyHash <== Poseidon(1)([secret]);\n// pubKeyHash === knownPubKeyHash; // constrain auth',
+  },
 };
+
+/** Returns true when the rule code belongs to the ZK family (Z-rules, issue #1239). */
+export function isZkRule(code: string): boolean {
+  return /^Z\d+$/.test(code);
+}
 
 function getMarkdownContent(finding: EditorFinding): vscode.MarkdownString {
   const meta = CODE_TO_MARKDOWN[finding.code] ?? {
     title: finding.code,
     description: finding.message,
     fix: 'See rule documentation for suggested fix.',
+    isZk: isZkRule(finding.code),
   };
 
   const severityIcon = finding.severity === 'error' ? '$(error)' : finding.severity === 'warning' ? '$(warning)' : '$(info)';
   const severityLabel = finding.severity.charAt(0).toUpperCase() + finding.severity.slice(1);
+  const zkBadge = meta.isZk ? ' 🔒 **ZK**' : '';
 
   const markdown = new vscode.MarkdownString();
   markdown.isTrusted = true;
   markdown.supportHtml = true;
 
-  markdown.appendMarkdown(`### ${severityIcon} ${meta.title} (\`${finding.code}\`)\n\n`);
+  markdown.appendMarkdown(`### ${severityIcon} ${meta.title} (\`${finding.code}\`)${zkBadge}\n\n`);
+  if (meta.isZk) {
+    markdown.appendMarkdown(`> *ZK circuit finding — this rule applies to zero-knowledge constraint systems, not Soroban contract code.*\n\n`);
+  }
   markdown.appendMarkdown(`**Severity:** ${severityLabel}\n\n`);
   markdown.appendMarkdown(`${meta.description}\n\n`);
   markdown.appendMarkdown(`---\n\n`);
   markdown.appendMarkdown(`**Suggested fix:**\n\n`);
-  markdown.appendCodeblock(meta.fix, 'rust');
+  markdown.appendCodeblock(meta.fix, meta.isZk ? 'circom' : 'rust');
   markdown.appendMarkdown(`\n\n`);
   markdown.appendMarkdown(
     `[Learn more](${RULE_DOCS_BASE}/${finding.code.toLowerCase()}.md) &nbsp;|&nbsp; ` +


### PR DESCRIPTION
## Summary

- **#1239 — Z-rule hover/quick-fix descriptions (VS Code extension)**: Extended `hover.ts` with full metadata for Z001, Z002, Z003, Z007, Z008, Z010 (title, plain-English description, fix snippet in circom). Added `isZkRule()` helper and a `🔒 ZK` badge in the hover card header with a contextual italic note. Extended `code-actions.ts` to offer scaffold quick-fixes for Z010 (auth-constraint insertion) and Z002 (nullifier check scaffold); rules requiring contextual judgment (Z007, Z001, Z003) get hover-only. Four new tests in `code-actions.test.ts`.

- **#1240 — ZK finding badges in the UI**: Added `ZkBadge` component (violet rounded pill with an inline lock/circuit SVG) to `FindingsList.tsx`. Rendered next to the rule-code chip for any finding whose code matches `/^Z\d+$/`. No dependency on external icon assets — fully self-contained. `isZkFinding()` helper centralises the check.

- **#1236 — Circuit visualization (constraint graph)**: New `ConstraintGraph.tsx` component renders parsed circuit signals as SVG nodes grouped by kind (input / intermediate / output) with `<==` constraints as edges. Z-rule-flagged signals render with a violet glow ring and indicator dot. Clicking a node opens a detail panel showing which rules flagged it. Used in the ZK playground's Graph tab.

- **#1237 — ZK proof-verification playground**: New page at `frontend/app/playground/zk/page.tsx`. Accepts circom circuit source + optional proof JSON, runs client-side Z-rule analysis (simulated pending real WASM entry point from #1231; wired for easy drop-in replacement), and displays results in `FindingsList` and `ConstraintGraph` tabs. Ships with three sample circuits (under-constrained signal, missing nullifier, sound multiplier). Link added from the main playground page to the ZK mode.

Closes #1236, Closes #1237, Closes #1239, Closes #1240