### PR TITLE
feat: ZK rule docs (Z001–Z014), security guide, vulnerability-db entries, Noir parser skeleton

### DIFF
--- a/data/vulnerability-db.json
+++ b/data/vulnerability-db.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0",
-  "last_updated": "2026-02-26",
+  "version": "1.1.0",
+  "last_updated": "2026-07-26",
   "description": "Community-sourced vulnerability database for Soroban smart contracts",
   "vulnerabilities": [
     {
@@ -130,6 +130,198 @@
       "pattern": "supply\\s*\\+|supply\\s*\\+=|total_supply.*\\+",
       "recommendation": "Use checked_add(), checked_sub(), checked_mul() for all token arithmetic.",
       "references": []
+    },
+    {
+      "id": "ZK-2026-001",
+      "name": "Missing ZK Nullifier / Double-Spend Check",
+      "description": "A ZK-verifier entry point verifies a proof and performs a state-changing action (transfer, mint, claim) without recording a nullifier for the proof's unique identifier, allowing the same proof to be replayed indefinitely.",
+      "severity": "critical",
+      "category": "zk-proof-integrity",
+      "rule": "Z001",
+      "pattern": "verify_proof[^}]*transfer|verify_proof[^}]*mint|verify_proof[^}]*claim",
+      "recommendation": "Before executing the state-changing action, check that the proof's nullifier has not been spent, then record it in persistent storage after verification.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z001.md",
+        "https://github.com/tornadocash/tornado-core",
+        "https://github.com/0xPARC/zk-bug-tracker"
+      ]
+    },
+    {
+      "id": "ZK-2026-002",
+      "name": "Insecure Predictable Randomness as ZK Circuit Input",
+      "description": "On-chain predictable values (ledger sequence, ledger timestamp) are used as the sole source of entropy for a ZK circuit input such as a blinding factor or commitment salt, allowing an adversary to enumerate or predict the committed value.",
+      "severity": "high",
+      "category": "zk-randomness",
+      "rule": "Z002",
+      "pattern": "ledger\\(\\)\\.sequence\\(\\)|ledger\\(\\)\\.timestamp\\(\\)",
+      "recommendation": "Generate blinding factors off-chain using a cryptographically secure RNG and pass them as caller-supplied private inputs. The contract should never derive circuit entropy from on-chain values.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z002.md"
+      ]
+    },
+    {
+      "id": "ZK-2026-003",
+      "name": "Missing Public-Input Binding — Proof Malleability",
+      "description": "A ZK-verifier entry point does not include transaction-specific context (caller, recipient, amount, contract ID) in the public inputs, allowing an attacker to substitute their own public inputs and redirect the proof's effect.",
+      "severity": "critical",
+      "category": "zk-proof-integrity",
+      "rule": "Z003",
+      "pattern": "verify_proof[^;]*public_inputs",
+      "recommendation": "Always include recipient address, amount, and contract ID as public inputs so the circuit commits to this specific transaction's parameters.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z003.md",
+        "https://eprint.iacr.org/2019/099.pdf"
+      ]
+    },
+    {
+      "id": "ZK-2026-004",
+      "name": "Hardcoded ZK Trusted-Setup Parameters",
+      "description": "A ZK verifying key or Common Reference String is hardcoded as a literal in contract source, preventing rotation after a trusted-setup compromise and making build-pipeline substitution undetectable at runtime.",
+      "severity": "critical",
+      "category": "zk-trusted-setup",
+      "rule": "Z004",
+      "pattern": "const\\s+VK|const\\s+CRS|static\\s+VERIFYING_KEY",
+      "recommendation": "Store the verifying key in governance-controlled persistent storage. Set and validate an integrity hash at deployment. Protect rotation with admin require_auth().",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z004.md",
+        "https://z.cash/technology/paramgen/"
+      ]
+    },
+    {
+      "id": "ZK-2026-005",
+      "name": "Missing Verifying-Key Integrity Check Before Use",
+      "description": "A contract loads a verifying key from storage and uses it for proof verification without first comparing its hash against a reference value committed at deployment, allowing a silently corrupted or swapped key to go undetected.",
+      "severity": "high",
+      "category": "zk-trusted-setup",
+      "rule": "Z005",
+      "pattern": "storage\\(\\)[^;]*get[^;]*VerifyingKey|storage\\(\\)[^;]*get[^;]*vk",
+      "recommendation": "After loading the verifying key from storage, compute its sha256 hash and assert equality with the stored VkHash before calling the verifier.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z005.md"
+      ]
+    },
+    {
+      "id": "ZK-2026-006",
+      "name": "Missing ZK Proof Nonce / Uniqueness Enforcement",
+      "description": "A ZK-verifier entry point does not include a per-epoch nonce or time-window value in the public inputs, making a valid proof from one period replayable in a future period.",
+      "severity": "high",
+      "category": "zk-proof-integrity",
+      "rule": "Z006",
+      "pattern": "verify_proof[^}]*public_inputs",
+      "recommendation": "Include the current epoch or a ledger-range window in the public inputs so a proof verified in epoch N cannot be submitted in epoch N+1.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z006.md",
+        "https://github.com/0xPARC/zk-bug-tracker"
+      ]
+    },
+    {
+      "id": "ZK-2026-007",
+      "name": "Under-Constrained ZK Circuit Inputs",
+      "description": "Public inputs passed to a ZK verifier are accepted without validating that each field element lies within the circuit's expected range, enabling out-of-range values that pass the verifier but trigger undefined behavior in contract logic.",
+      "severity": "critical",
+      "category": "zk-circuit-constraints",
+      "rule": "Z007",
+      "pattern": "verify_proof[^;]*as u64|public_inputs[^;]*push",
+      "recommendation": "Validate all public input field elements for correct range (positive, below maximum) before including them in the inputs vector or calling the verifier.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z007.md",
+        "https://github.com/0xPARC/zk-bug-tracker"
+      ]
+    },
+    {
+      "id": "ZK-2026-008",
+      "name": "ZK Curve / Field Mismatch",
+      "description": "A ZK verifier accepts proofs without asserting that the curve or field identifier matches the one the off-chain circuit was compiled for, enabling proof forgery or degenerate-element attacks using a weaker curve.",
+      "severity": "critical",
+      "category": "zk-circuit-constraints",
+      "rule": "Z008",
+      "pattern": "groth16_verify|plonk_verify",
+      "recommendation": "Accept an explicit curve_id parameter, assert it equals the contract's configured CURVE_ID constant before calling the verifier.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z008.md",
+        "https://nvd.nist.gov/vuln/detail/CVE-2019-7167"
+      ]
+    },
+    {
+      "id": "ZK-2026-009",
+      "name": "Unbounded ZK Proof-Verification Loop",
+      "description": "A loop over a caller-supplied collection of proofs or public-input sets lacks an explicit length cap, allowing an attacker to submit an oversized batch that exhausts Soroban CPU or memory limits.",
+      "severity": "high",
+      "category": "zk-resource",
+      "rule": "Z009",
+      "pattern": "for[^}]*proofs\\.iter\\(\\)|for[^}]*in proofs",
+      "recommendation": "Assert proofs.len() <= MAX_BATCH before the loop, where MAX_BATCH is a protocol constant chosen to stay within Soroban resource limits.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z009.md",
+        "https://soroban.stellar.org/docs/fundamentals/fees-and-metering"
+      ]
+    },
+    {
+      "id": "ZK-2026-010",
+      "name": "Missing Access Control on Verifying-Key Rotation",
+      "description": "A function that writes a new verifying key to persistent storage does not call require_auth() on a privileged admin, allowing any caller to replace the cryptographic root of trust.",
+      "severity": "critical",
+      "category": "zk-access-control",
+      "rule": "Z010",
+      "pattern": "fn\\s+set_verifying_key|fn\\s+update_vk|fn\\s+rotate_vk",
+      "recommendation": "Load the admin address from storage and call admin.require_auth() before accepting a new verifying key. Also update the VkHash integrity record.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z010.md"
+      ]
+    },
+    {
+      "id": "ZK-2026-011",
+      "name": "ZK Commitment Reuse Without Domain Separation",
+      "description": "Multiple distinct commitment types (nullifiers, amounts, recipients) are hashed using the same function call with no domain-separation prefix, enabling cross-context collision attacks.",
+      "severity": "high",
+      "category": "zk-cryptography",
+      "rule": "Z011",
+      "pattern": "sha256[^;]*value|crypto\\(\\)\\.sha256",
+      "recommendation": "Prefix every hash call with a unique, versioned domain tag (e.g. b\"app:nullifier:v1\") that is distinct across all commitment types.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z011.md",
+        "https://www.rfc-editor.org/rfc/rfc9380"
+      ]
+    },
+    {
+      "id": "ZK-2026-012",
+      "name": "ZK Property Leak via Public-Output Over-Exposure",
+      "description": "A ZK-verifier contract emits or logs more information than the application's privacy model permits — such as the full public-input vector — breaking zero-knowledge confidentiality even when the proof itself is sound.",
+      "severity": "medium",
+      "category": "zk-privacy",
+      "rule": "Z012",
+      "pattern": "events\\(\\)\\.publish[^;]*public_inputs|log[^;]*public_inputs",
+      "recommendation": "Emit only the minimal public signal required (e.g. a nullifier hash). Never publish the full public-input vector, blinding factors, or witness fragments.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z012.md"
+      ]
+    },
+    {
+      "id": "ZK-2026-013",
+      "name": "Insufficient Batch-Validation in ZK-Rollup Transitions",
+      "description": "A ZK-rollup batch-proof entry point accepts a claimed old state root without verifying it matches the contract's current committed root, allowing an attacker to submit a valid proof for a forked state history.",
+      "severity": "critical",
+      "category": "zk-proof-integrity",
+      "rule": "Z013",
+      "pattern": "fn\\s+submit_batch|fn\\s+post_batch|fn\\s+process_batch",
+      "recommendation": "Assert old_root == current_root (loaded from persistent storage) before verifying the transition proof and updating the committed state root.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z013.md"
+      ]
+    },
+    {
+      "id": "ZK-2026-014",
+      "name": "Missing Merkle-Root Inclusion-Proof Verification",
+      "description": "A contract accepts membership claims or UTXOs without verifying a Merkle inclusion proof against the contract's own committed root, or accepts a caller-supplied root instead, allowing fake membership proofs.",
+      "severity": "critical",
+      "category": "zk-proof-integrity",
+      "rule": "Z014",
+      "pattern": "verify_merkle_proof[^;]*merkle_root|fn\\s+claim[^}]*merkle",
+      "recommendation": "Always load the Merkle root from persistent storage; never accept it as a parameter. Verify the inclusion proof against the stored root before taking any action.",
+      "references": [
+        "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z014.md",
+        "https://semaphore.appliedzkp.org/"
+      ]
     }
   ]
 }

--- a/docs/rules/Z001.md
+++ b/docs/rules/Z001.md
@@ -1,0 +1,79 @@
+# Z001 — Missing Nullifier / Double-Spend Check
+
+**Category:** zk-proof-integrity  
+**Severity:** Critical  
+**Rule name:** `missing_nullifier`
+
+---
+
+## What it detects
+
+Any ZK-verifier entry point that calls a proof-verification routine and then performs a state-changing action (transfer, mint, claim) without first checking — and recording — a nullifier for that proof's unique identifier in persistent storage.
+
+---
+
+## Why it matters
+
+A valid ZK proof can be replayed indefinitely if the contract never records that it has been consumed. An attacker can submit the same proof multiple times to double-spend tokens, double-claim rewards, or re-enter a vote. This is one of the highest-impact ZK vulnerability classes: every real-world ZK application that moves value must nullify proofs exactly once.
+
+---
+
+## Vulnerable example
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+#[contract]
+pub struct ZkVault;
+
+#[contractimpl]
+impl ZkVault {
+    // Z001: proof is verified, funds transferred, but the nullifier is never
+    // stored — the same proof can be submitted again to drain the vault.
+    pub fn claim(env: Env, proof: Vec<u64>, public_inputs: Vec<u64>) {
+        verify_proof(&env, &proof, &public_inputs);
+        transfer_funds(&env, &public_inputs);
+    }
+}
+```
+
+---
+
+## Safe example
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Vec};
+
+#[contract]
+pub struct ZkVault;
+
+#[contractimpl]
+impl ZkVault {
+    pub fn claim(env: Env, proof: Vec<u64>, public_inputs: Vec<u64>) {
+        let nullifier = compute_nullifier(&public_inputs);
+
+        // Check: reject if already spent.
+        let key = (symbol_short!("null"), nullifier.clone());
+        assert!(
+            !env.storage().persistent().has(&key),
+            "proof already consumed"
+        );
+
+        verify_proof(&env, &proof, &public_inputs);
+        transfer_funds(&env, &public_inputs);
+
+        // Record: mark as spent so replay is impossible.
+        env.storage().persistent().set(&key, &true);
+    }
+}
+```
+
+---
+
+## References
+
+- [Tornado Cash double-spend — nullifier set pattern](https://github.com/tornadocash/tornado-core)
+- [Trail of Bits: ZK bug classes](https://blog.trailofbits.com/2022/04/13/part-1-coordinated-disclosure-of-vulnerabilities-affecting-girault-bulletproofs-and-plonk/)
+- [Z001 implementation issue #1197](https://github.com/HyperSafeD/Sanctifier/issues/1197)

--- a/docs/rules/Z002.md
+++ b/docs/rules/Z002.md
@@ -1,0 +1,49 @@
+# Z002 — Insecure or Predictable Randomness as Circuit Input
+
+**Category:** zk-randomness  
+**Severity:** High  
+**Rule name:** `insecure_zk_randomness`
+
+---
+
+## What it detects
+
+Use of on-chain predictable values — ledger sequence, ledger timestamp, block hash, or contract address — as the sole source of entropy for a ZK circuit input (e.g. blinding factor, commitment randomness, salt).
+
+---
+
+## Why it matters
+
+ZK commitments and blinding factors must be unpredictable to prevent an adversary from brute-forcing the committed value. Predictable on-chain entropy is observable before it is finalized and can be manipulated by validators or MEV-equivalent actors on Stellar. If an attacker can predict the blinding factor they can open the commitment and deanonymize the user or front-run the proof.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn commit(env: Env, value: u64) -> BytesN<32> {
+    // Z002: ledger sequence is predictable and observable — anyone can
+    // enumerate possible blinding factors.
+    let blinding = env.ledger().sequence() as u64;
+    pedersen_commit(&env, value, blinding)
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn commit(env: Env, value: u64, blinding: BytesN<32>) -> BytesN<32> {
+    // Blinding factor supplied by the caller from a secure off-chain RNG;
+    // the contract never derives randomness itself.
+    pedersen_commit_bytes(&env, value, &blinding)
+}
+```
+
+---
+
+## References
+
+- [Predictable randomness in Soroban](https://soroban.stellar.org/docs/fundamentals/contract-lifecycle)
+- [Z002 implementation issue #1198](https://github.com/HyperSafeD/Sanctifier/issues/1198)

--- a/docs/rules/Z003.md
+++ b/docs/rules/Z003.md
@@ -1,0 +1,52 @@
+# Z003 — Missing Public-Input Binding (Proof Malleability)
+
+**Category:** zk-proof-integrity  
+**Severity:** Critical  
+**Rule name:** `missing_public_input_binding`
+
+---
+
+## What it detects
+
+A ZK-verifier entry point where the public inputs passed to the verifier are not explicitly bound to the transaction context (caller, recipient, amount, contract ID) before or during verification, allowing an attacker to substitute their own public inputs and redirect the proof's effect.
+
+---
+
+## Why it matters
+
+A ZK proof is only as secure as what it proves. If the verifier accepts `(proof, arbitrary_public_inputs)` without checking that the inputs correspond to *this* transaction, an attacker can take a valid proof, swap the recipient address in the public inputs, and replay it to redirect a transfer to themselves. This is proof malleability in the application layer.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn withdraw(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
+    // Z003: public inputs are constructed from caller-supplied values with no
+    // binding check — attacker substitutes a different recipient.
+    let public_inputs = vec![&env, amount as u64];
+    verify_proof(&env, &proof, &public_inputs);
+    token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn withdraw(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
+    // Bind recipient and amount into public inputs so the circuit commits to them.
+    let recipient_hash = hash_address(&env, &recipient);
+    let public_inputs = vec![&env, recipient_hash, amount as u64];
+    verify_proof(&env, &proof, &public_inputs);
+    token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+}
+```
+
+---
+
+## References
+
+- [Proof malleability — ZKP security considerations](https://eprint.iacr.org/2019/099.pdf)
+- [Z003 implementation issue #1199](https://github.com/HyperSafeD/Sanctifier/issues/1199)

--- a/docs/rules/Z004.md
+++ b/docs/rules/Z004.md
@@ -1,0 +1,55 @@
+# Z004 — Unverified or Hardcoded Trusted-Setup Parameters ("Toxic Waste")
+
+**Category:** zk-trusted-setup  
+**Severity:** Critical  
+**Rule name:** `hardcoded_trusted_setup`
+
+---
+
+## What it detects
+
+A verifying key or trusted-setup parameter (Common Reference String, SRS, or proving key hash) that is hardcoded as a literal in contract source rather than being loaded from a governance-controlled storage key and validated against a known hash.
+
+---
+
+## Why it matters
+
+Most practical ZK proof systems (Groth16, PLONK) require a trusted setup ceremony. The output — the verifying key — must be authentic. If the verifying key is hardcoded, an attacker who compromises the build pipeline can substitute a key they control, generating valid proofs for false statements. Additionally, a hardcoded key cannot be rotated after a ceremony compromise is discovered.
+
+---
+
+## Vulnerable example
+
+```rust
+// Z004: verifying key baked into source. Cannot be updated after deployment;
+// a build-time compromise is undetectable at runtime.
+const VK_ALPHA: &[u8] = &[0xde, 0xad, 0xbe, 0xef, /* ... */];
+
+pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+    groth16_verify(VK_ALPHA, &proof, &inputs)
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+    // Verifying key loaded from governance-controlled storage and checked
+    // against a hash committed at deployment.
+    let vk: BytesN<64> = env.storage().persistent().get(&DataKey::VerifyingKey)
+        .expect("verifying key not set");
+    let expected_hash: BytesN<32> = env.storage().persistent().get(&DataKey::VkHash)
+        .expect("vk hash not set");
+    assert_eq!(env.crypto().sha256(&vk.into()), expected_hash, "VK integrity check failed");
+    groth16_verify(vk.as_ref(), &proof, &inputs)
+}
+```
+
+---
+
+## References
+
+- [Zcash Sprout trusted setup](https://z.cash/technology/paramgen/)
+- [Z004 implementation issue #1200](https://github.com/HyperSafeD/Sanctifier/issues/1200)

--- a/docs/rules/Z005.md
+++ b/docs/rules/Z005.md
@@ -1,0 +1,55 @@
+# Z005 — Missing Verifying-Key Integrity Check Before Use
+
+**Category:** zk-trusted-setup  
+**Severity:** High  
+**Rule name:** `missing_vk_integrity_check`
+
+---
+
+## What it detects
+
+A contract that loads a verifying key from storage and uses it for proof verification without first checking its hash/fingerprint against a reference value committed at deployment.
+
+---
+
+## Why it matters
+
+Storage corruption, a malicious admin rotation (see Z010), or an upgrade bug could silently swap the verifying key to one controlled by an attacker. Without an integrity check before every verification call the contract would accept proofs generated under the attacker's fake key. The defense is cheap: a single `sha256` comparison prevents the entire class.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+    // Z005: key is loaded from storage and used directly — no hash check.
+    let vk: BytesN<64> = env.storage().persistent().get(&DataKey::VerifyingKey).unwrap();
+    groth16_verify(vk.as_ref(), &proof, &inputs)
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+    let vk: BytesN<64> = env.storage().persistent().get(&DataKey::VerifyingKey)
+        .expect("VK not set");
+    let expected: BytesN<32> = env.storage().persistent().get(&DataKey::VkHash)
+        .expect("VK hash not set");
+    // Integrity gate: abort if the stored key has been tampered with.
+    assert_eq!(
+        env.crypto().sha256(&Bytes::from_slice(&env, vk.as_ref())),
+        expected,
+        "verifying key integrity check failed"
+    );
+    groth16_verify(vk.as_ref(), &proof, &inputs)
+}
+```
+
+---
+
+## References
+
+- [Z005 implementation issue #1201](https://github.com/HyperSafeD/Sanctifier/issues/1201)

--- a/docs/rules/Z006.md
+++ b/docs/rules/Z006.md
@@ -1,0 +1,52 @@
+# Z006 — Missing Proof Nonce / Uniqueness Enforcement (Replay Attack)
+
+**Category:** zk-proof-integrity  
+**Severity:** High  
+**Rule name:** `missing_proof_nonce`
+
+---
+
+## What it detects
+
+A ZK-verifier entry point that does not include a per-call uniqueness value (nonce, epoch, or ledger-sequence window) in the public inputs, making the proof valid indefinitely and replayable across ledger heights or contract instances.
+
+---
+
+## Why it matters
+
+Unlike a nullifier (Z001), which ties replay prevention to a specific proof's output, a nonce binds the proof to a *time window* or *round*. Without it, a valid proof from epoch N can be replayed in epoch N+1 to re-trigger the same action. This is especially dangerous in recurring yield claims, voting, or bridge relays where the same proof should only be valid once per period.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn vote(env: Env, proof: Vec<u64>, candidate_id: u64) {
+    // Z006: no epoch or nonce in public inputs — the same proof is valid
+    // in every future governance round.
+    let public_inputs = vec![&env, candidate_id];
+    verify_proof(&env, &proof, &public_inputs);
+    record_vote(&env, candidate_id);
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn vote(env: Env, proof: Vec<u64>, candidate_id: u64) {
+    let epoch: u64 = env.storage().persistent().get(&DataKey::CurrentEpoch).unwrap_or(0);
+    // Epoch bound into public inputs — proof is only valid for this round.
+    let public_inputs = vec![&env, candidate_id, epoch];
+    verify_proof(&env, &proof, &public_inputs);
+    record_vote(&env, candidate_id);
+}
+```
+
+---
+
+## References
+
+- [Replay attacks in ZK applications](https://github.com/0xPARC/zk-bug-tracker)
+- [Z006 implementation issue #1202](https://github.com/HyperSafeD/Sanctifier/issues/1202)

--- a/docs/rules/Z007.md
+++ b/docs/rules/Z007.md
@@ -1,0 +1,54 @@
+# Z007 — Under-Constrained Circuit Inputs (Missing Field-Element Range Checks)
+
+**Category:** zk-circuit-constraints  
+**Severity:** Critical  
+**Rule name:** `under_constrained_inputs`
+
+---
+
+## What it detects
+
+A ZK verifier entry point whose public inputs are accepted without validating that each field element lies within the circuit's expected range (e.g. [0, p-1] for the proof system's prime field). This allows an attacker to supply out-of-range inputs that pass the verifier but trigger undefined/exploitable behavior in the contract logic.
+
+---
+
+## Why it matters
+
+ZK proof systems operate over a finite field of prime order *p*. If a public input is accepted as, say, a `u64` amount but is never checked to be non-negative or below a maximum, an attacker can supply values that wrap around, yield a negative balance, or produce a hash collision inside the circuit. Several real-world exploits have used out-of-range field elements to mint unbounded tokens.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn mint(env: Env, proof: Vec<u64>, amount: i128) {
+    // Z007: `amount` is never checked for being positive or within a max cap.
+    // A negative amount could underflow the recipient's balance.
+    let public_inputs = vec![&env, amount as u64];
+    verify_proof(&env, &proof, &public_inputs);
+    token_client.mint(&recipient, &amount);
+}
+```
+
+---
+
+## Safe example
+
+```rust
+const MAX_MINT: i128 = 1_000_000_000 * 10_000_000; // protocol cap
+
+pub fn mint(env: Env, proof: Vec<u64>, amount: i128) {
+    assert!(amount > 0 && amount <= MAX_MINT, "amount out of range");
+    let public_inputs = vec![&env, amount as u64];
+    verify_proof(&env, &proof, &public_inputs);
+    token_client.mint(&recipient, &amount);
+}
+```
+
+---
+
+## References
+
+- [zkSync token mint bug — under-constrained field element (2023)](https://medium.com/immunefi/zksync-bugs-writeup)
+- [0xPARC ZK bug tracker](https://github.com/0xPARC/zk-bug-tracker)
+- [Z007 implementation issue #1203](https://github.com/HyperSafeD/Sanctifier/issues/1203)

--- a/docs/rules/Z008.md
+++ b/docs/rules/Z008.md
@@ -1,0 +1,48 @@
+# Z008 — Curve / Field Mismatch Between On-Chain Verifier and Off-Chain Circuit
+
+**Category:** zk-circuit-constraints  
+**Severity:** Critical  
+**Rule name:** `curve_field_mismatch`
+
+---
+
+## What it detects
+
+A verifier contract that accepts proofs without asserting the curve or field identifier matches the one the off-chain circuit was compiled for. Detected as: no curve/field constant or identifier checked in the verifier entry point.
+
+---
+
+## Why it matters
+
+A Groth16 proof generated over BN254 is entirely different from one generated over BLS12-381. Supplying a proof from the wrong curve to a verifier does not just fail — on some native implementations it may pass due to degenerate group elements or cause a panic that halts the contract. More critically, in multi-verifier systems where an attacker controls circuit compilation, they can redirect the verifier to a weaker curve for which they can forge proofs.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+    // Z008: no curve identifier check — proof from any curve is accepted.
+    groth16_verify_bn254(&proof, &inputs)
+}
+```
+
+---
+
+## Safe example
+
+```rust
+const CURVE_ID: u32 = 254; // BN254
+
+pub fn verify(env: Env, curve_id: u32, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+    assert_eq!(curve_id, CURVE_ID, "unsupported curve");
+    groth16_verify_bn254(&proof, &inputs)
+}
+```
+
+---
+
+## References
+
+- [Zcash Sapling curve mismatch (CVE-2019-7167)](https://nvd.nist.gov/vuln/detail/CVE-2019-7167)
+- [Z008 implementation issue #1204](https://github.com/HyperSafeD/Sanctifier/issues/1204)

--- a/docs/rules/Z009.md
+++ b/docs/rules/Z009.md
@@ -1,0 +1,52 @@
+# Z009 — Unbounded Proof-Verification Loop (Resource / Gas DoS)
+
+**Category:** zk-resource  
+**Severity:** High  
+**Rule name:** `unbounded_zk_loop`
+
+---
+
+## What it detects
+
+A loop over a caller-supplied collection of proofs or public-input sets that lacks an explicit length cap, allowing an attacker to submit a vector large enough to exhaust CPU or memory limits and deny service.
+
+---
+
+## Why it matters
+
+ZK proof verification is computationally expensive — a single Groth16 verification costs several hundred milliseconds off-chain and proportionally more CPU instructions on Soroban. A loop over an unbounded caller-supplied array of proofs can halt the contract's ledger slot, revert other users' transactions, or allow a low-cost griefing attack. Soroban enforces resource limits per transaction, but the error manifests as a resource-exhaustion panic, not a clean rejection.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn batch_verify(env: Env, proofs: Vec<Vec<u64>>, inputs: Vec<Vec<u64>>) {
+    // Z009: no length check — attacker submits 10_000-element vectors.
+    for (proof, input) in proofs.iter().zip(inputs.iter()) {
+        verify_proof(&env, proof, input);
+    }
+}
+```
+
+---
+
+## Safe example
+
+```rust
+const MAX_BATCH: u32 = 16;
+
+pub fn batch_verify(env: Env, proofs: Vec<Vec<u64>>, inputs: Vec<Vec<u64>>) {
+    assert!(proofs.len() <= MAX_BATCH as usize, "batch too large");
+    for (proof, input) in proofs.iter().zip(inputs.iter()) {
+        verify_proof(&env, proof, input);
+    }
+}
+```
+
+---
+
+## References
+
+- [Soroban resource limits](https://soroban.stellar.org/docs/fundamentals/fees-and-metering)
+- [Z009 implementation issue #1205](https://github.com/HyperSafeD/Sanctifier/issues/1205)

--- a/docs/rules/Z010.md
+++ b/docs/rules/Z010.md
@@ -1,0 +1,51 @@
+# Z010 — Missing Access Control on Verifying-Key Rotation / Upgrade
+
+**Category:** zk-access-control  
+**Severity:** Critical  
+**Rule name:** `unprotected_vk_rotation`
+
+---
+
+## What it detects
+
+A function that writes a new verifying key (or trusted-setup parameter) to persistent storage without a preceding `require_auth()` call on a privileged admin or a multi-sig guardian address.
+
+---
+
+## Why it matters
+
+The verifying key is the cryptographic root of trust for all proofs the contract accepts. An unprotected rotation function lets any caller replace the key with one they generated, after which they can produce valid proofs for any false statement — minting tokens at will, bypassing nullifier checks, or proving ownership of assets they do not hold. This is equivalent to an unprotected `set_admin` (S001) but with no on-chain evidence of the compromise.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn set_verifying_key(env: Env, new_vk: BytesN<64>) {
+    // Z010: anyone can replace the verifying key — no auth check.
+    env.storage().persistent().set(&DataKey::VerifyingKey, &new_vk);
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn set_verifying_key(env: Env, new_vk: BytesN<64>) {
+    let admin: Address = env.storage().persistent().get(&DataKey::Admin)
+        .expect("not initialized");
+    admin.require_auth();
+    env.storage().persistent().set(&DataKey::VerifyingKey, &new_vk);
+    // Update integrity hash so Z005 checks remain consistent.
+    let new_hash = env.crypto().sha256(&Bytes::from_slice(&env, new_vk.as_ref()));
+    env.storage().persistent().set(&DataKey::VkHash, &new_hash);
+}
+```
+
+---
+
+## References
+
+- [Z010 implementation issue #1206](https://github.com/HyperSafeD/Sanctifier/issues/1206)
+- Related: [S001 — Missing Auth Guard](S001.md)

--- a/docs/rules/Z011.md
+++ b/docs/rules/Z011.md
@@ -1,0 +1,61 @@
+# Z011 — Commitment-Scheme Reuse Without Domain Separation
+
+**Category:** zk-cryptography  
+**Severity:** High  
+**Rule name:** `commitment_reuse_no_domain_sep`
+
+---
+
+## What it detects
+
+A contract that computes multiple distinct commitments (e.g. one for a transfer amount and one for a recipient) using the same hash function call with no domain-separation prefix, tag, or DST (domain separation tag), enabling cross-context collision attacks.
+
+---
+
+## Why it matters
+
+If `commit(amount)` and `commit(recipient)` use the same hash function with the same input encoding, an attacker may be able to find inputs in one domain that collide with an honest commitment in another, allowing them to open a commitment in the wrong context. This is a well-documented pitfall in multi-commitment ZK systems (e.g. Pedersen commitments used for both nullifiers and balances).
+
+---
+
+## Vulnerable example
+
+```rust
+fn commit(env: &Env, value: BytesN<32>) -> BytesN<32> {
+    // Z011: same function used for both amount and recipient commitments —
+    // no domain tag distinguishes them.
+    env.crypto().sha256(&value.into())
+}
+
+pub fn deposit(env: Env, amount_preimage: BytesN<32>, recipient_preimage: BytesN<32>) {
+    let amount_comm = commit(&env, amount_preimage);
+    let recipient_comm = commit(&env, recipient_preimage);
+    // ...
+}
+```
+
+---
+
+## Safe example
+
+```rust
+fn commit_with_domain(env: &Env, domain: &[u8], value: BytesN<32>) -> BytesN<32> {
+    let mut input = Bytes::new(env);
+    input.extend_from_slice(domain);
+    input.extend_from_slice(value.as_ref());
+    env.crypto().sha256(&input)
+}
+
+pub fn deposit(env: Env, amount_preimage: BytesN<32>, recipient_preimage: BytesN<32>) {
+    let amount_comm    = commit_with_domain(&env, b"sanctifier:amount:v1",    amount_preimage);
+    let recipient_comm = commit_with_domain(&env, b"sanctifier:recipient:v1", recipient_preimage);
+    // ...
+}
+```
+
+---
+
+## References
+
+- [IETF RFC 9380 — Hashing to Elliptic Curves, domain separation](https://www.rfc-editor.org/rfc/rfc9380)
+- [Z011 implementation issue #1207](https://github.com/HyperSafeD/Sanctifier/issues/1207)

--- a/docs/rules/Z012.md
+++ b/docs/rules/Z012.md
@@ -1,0 +1,52 @@
+# Z012 — ZK Property Leak via Public-Output Over-Exposure
+
+**Category:** zk-privacy  
+**Severity:** Medium  
+**Rule name:** `public_output_overexposure`
+
+---
+
+## What it detects
+
+A ZK-verifier contract that emits or stores intermediate computation values, witness fragments, or more public outputs than the application's privacy model requires, leaking information the zero-knowledge proof was designed to conceal.
+
+---
+
+## Why it matters
+
+The zero-knowledge property means a verifier learns *nothing* about the witness beyond what the public inputs reveal. If the contract logs the full public-input vector, stores intermediate hashes, or emits events with values that were meant to be private, the on-chain record breaks ZK confidentiality even when the proof itself is sound. This is especially critical for privacy-preserving payment or credential systems.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn verify_credential(env: Env, proof: Vec<u64>, public_inputs: Vec<u64>) {
+    verify_proof(&env, &proof, &public_inputs);
+    // Z012: emitting the full public_inputs vector — which may include a
+    // hash of the user's identity — breaks the privacy guarantee.
+    env.events().publish((symbol_short!("verified"),), public_inputs.clone());
+    mark_verified(&env, &public_inputs);
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn verify_credential(env: Env, proof: Vec<u64>, public_inputs: Vec<u64>) {
+    verify_proof(&env, &proof, &public_inputs);
+    // Emit only the nullifier (the minimal public signal) — not the full inputs.
+    let nullifier = public_inputs.get(0).unwrap_or(0);
+    env.events().publish((symbol_short!("verified"),), nullifier);
+    mark_verified(&env, &public_inputs);
+}
+```
+
+---
+
+## References
+
+- [Privacy properties of ZK systems](https://zkproof.org/2020/08/12/honest-verifier-zero-knowledge/)
+- [Z012 implementation issue #1208](https://github.com/HyperSafeD/Sanctifier/issues/1208)

--- a/docs/rules/Z013.md
+++ b/docs/rules/Z013.md
@@ -1,0 +1,53 @@
+# Z013 — Insufficient Batch-Validation in ZK-Rollup Style State Transitions
+
+**Category:** zk-proof-integrity  
+**Severity:** Critical  
+**Rule name:** `insufficient_batch_validation`
+
+---
+
+## What it detects
+
+A ZK-rollup or batch-proof entry point that accepts a batch state-transition proof without verifying that the claimed pre-state root matches the contract's current committed state root, allowing an attacker to submit a valid proof for a different state history and overwrite the canonical state.
+
+---
+
+## Why it matters
+
+In a ZK-rollup the contract is the on-chain source of truth. The prover submits `(old_root, new_root, proof)` proving that the state transition is valid. If the contract does not check `old_root == current_root`, an attacker can fork the state history: prove a valid transition from an earlier root (e.g. before their balance was debited), and replace the canonical state with one where they still hold funds.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn submit_batch(env: Env, old_root: BytesN<32>, new_root: BytesN<32>, proof: Vec<u64>) {
+    // Z013: old_root is in the public inputs but never checked against the
+    // contract's current committed root — allows state-history fork.
+    let inputs = build_inputs(&old_root, &new_root);
+    verify_proof(&env, &proof, &inputs);
+    env.storage().persistent().set(&DataKey::StateRoot, &new_root);
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn submit_batch(env: Env, old_root: BytesN<32>, new_root: BytesN<32>, proof: Vec<u64>) {
+    let current_root: BytesN<32> = env.storage().persistent()
+        .get(&DataKey::StateRoot).expect("not initialized");
+    assert_eq!(old_root, current_root, "pre-state root mismatch");
+    let inputs = build_inputs(&old_root, &new_root);
+    verify_proof(&env, &proof, &inputs);
+    env.storage().persistent().set(&DataKey::StateRoot, &new_root);
+}
+```
+
+---
+
+## References
+
+- [Polygon zkEVM state-root verification](https://docs.polygon.technology/zkEVM/)
+- [Z013 implementation issue #1209](https://github.com/HyperSafeD/Sanctifier/issues/1209)

--- a/docs/rules/Z014.md
+++ b/docs/rules/Z014.md
@@ -1,0 +1,57 @@
+# Z014 — Missing Merkle-Root Inclusion-Proof Verification
+
+**Category:** zk-proof-integrity  
+**Severity:** Critical  
+**Rule name:** `missing_merkle_inclusion`
+
+---
+
+## What it detects
+
+A contract that accepts a caller's claim of membership in a set (e.g. whitelist, UTXO set, anonymity set) without verifying a Merkle inclusion proof against a committed root stored in persistent storage.
+
+---
+
+## Why it matters
+
+Merkle trees are the standard on-chain commitment to a set. A contract that accepts membership claims without verifying the inclusion proof — or that verifies the proof against a root supplied by the caller rather than the contract's committed root — allows any caller to fake membership, bypassing whitelist access control, claiming rewards without holding the required token, or spending UTXOs they do not own.
+
+---
+
+## Vulnerable example
+
+```rust
+pub fn claim_reward(env: Env, leaf: BytesN<32>, merkle_root: BytesN<32>, proof: Vec<BytesN<32>>) {
+    // Z014: the root is caller-supplied, not the contract's committed root —
+    // the attacker supplies a root for a tree they constructed themselves.
+    assert!(verify_merkle_proof(&leaf, &proof, &merkle_root), "not in set");
+    transfer_reward(&env);
+}
+```
+
+---
+
+## Safe example
+
+```rust
+pub fn claim_reward(env: Env, leaf: BytesN<32>, proof: Vec<BytesN<32>>) {
+    // Root is loaded from contract storage — cannot be manipulated by caller.
+    let committed_root: BytesN<32> = env.storage().persistent()
+        .get(&DataKey::MerkleRoot).expect("root not set");
+    assert!(verify_merkle_proof(&leaf, &proof, &committed_root), "not in set");
+
+    // Nullify the leaf to prevent double-claim (see Z001).
+    let spent_key = (symbol_short!("spent"), leaf.clone());
+    assert!(!env.storage().persistent().has(&spent_key), "already claimed");
+    env.storage().persistent().set(&spent_key, &true);
+
+    transfer_reward(&env);
+}
+```
+
+---
+
+## References
+
+- [Semaphore — Merkle-based anonymity sets](https://semaphore.appliedzkp.org/)
+- [Z014 implementation issue #1210](https://github.com/HyperSafeD/Sanctifier/issues/1210)

--- a/docs/zk-security-guide.md
+++ b/docs/zk-security-guide.md
@@ -1,0 +1,274 @@
+# ZK Security Guide for Soroban Contracts
+
+> **Audience:** Developers building zero-knowledge features on Soroban / Stellar.  
+> **Purpose:** Secure design patterns, common pitfalls mapped to Z-rules, and a pre-deployment checklist.  
+> **Related:** [Threat Model](adr/), [Individual Z-rule docs](rules/), [Security Checklist](SECURITY-CHECKLIST.md)
+
+---
+
+## Table of Contents
+
+1. [ZK on Soroban — Overview](#1-zk-on-soroban--overview)  
+2. [Secure Design Patterns](#2-secure-design-patterns)  
+   - 2.1 Nullifiers  
+   - 2.2 Commitments and Blinding Factors  
+   - 2.3 Public-Input Binding  
+   - 2.4 Trusted-Setup Key Management  
+   - 2.5 Domain Separation  
+   - 2.6 Merkle Membership Proofs  
+3. [Z-Rule Catalog](#3-z-rule-catalog)  
+4. [Pre-Deployment Security Checklist](#4-pre-deployment-security-checklist)  
+5. [Further Reading](#5-further-reading)
+
+---
+
+## 1. ZK on Soroban — Overview
+
+Soroban smart contracts can act as **on-chain ZK verifiers**: they receive a cryptographic proof, verify it against a committed verifying key, and take an action (mint, transfer, vote, update state) if the proof is valid.
+
+This pattern is powerful but introduces an entirely new attack surface beyond traditional smart-contract security. The ZK verifier sits at the intersection of:
+
+- **On-chain authorization logic** — who can call which function, and when?  
+- **Cryptographic correctness** — is the proof system instantiated correctly?  
+- **Application-layer soundness** — does a valid proof actually mean what the contract thinks it means?
+
+Sanctifier's **Z-rule set** (Z001–Z014) covers the recurring vulnerability classes at this intersection, grounded in real-world audit findings and post-mortems.
+
+### Key principles
+
+| Principle | One-liner |
+|-----------|-----------|
+| Consume proofs exactly once | Every verified proof must leave a nullifier record (Z001, Z006) |
+| Bind proofs to context | Public inputs must commit to the caller, recipient, amount (Z003) |
+| Guard the verifying key | Rotation must require admin auth; integrity must be checked before use (Z004, Z005, Z010) |
+| Range-check all field elements | Public inputs must be validated before the verifier call (Z007) |
+| Separate commitment domains | Never reuse a hash function across distinct commitment types (Z011) |
+| Verify against your root | Merkle proofs must check against the contract's committed root (Z014) |
+
+---
+
+## 2. Secure Design Patterns
+
+### 2.1 Nullifiers
+
+A **nullifier** is a unique, deterministic identifier derived from a secret (e.g. the leaf's secret key). It is stored after a proof is consumed to prevent replay.
+
+**Pattern:**
+
+```rust
+pub fn claim(env: Env, proof: Vec<u64>, public_inputs: Vec<u64>) {
+    let nullifier = public_inputs.get(0).expect("nullifier required");
+
+    // 1. Check — reject if already spent.
+    let key = (symbol_short!("null"), nullifier);
+    assert!(!env.storage().persistent().has(&key), "proof already consumed");
+
+    // 2. Verify — proof is sound.
+    verify_proof(&env, &proof, &public_inputs);
+
+    // 3. Effect — take the action.
+    transfer_funds(&env, &public_inputs);
+
+    // 4. Record — mark as spent.
+    env.storage().persistent().set(&key, &true);
+}
+```
+
+**Rules covered:** [Z001](rules/Z001.md), [Z006](rules/Z006.md)
+
+---
+
+### 2.2 Commitments and Blinding Factors
+
+Commitments hide a value while binding the prover to it. The blinding factor must be:
+
+- **Unpredictable** — generated off-chain by a secure RNG, never derived from ledger sequence, timestamp, or other on-chain predictables.
+- **Secret** — never included in any event, log, or public output.
+
+**Pattern:**
+
+```rust
+// Caller generates blinding factor off-chain (e.g. with `crypto.getRandomValues`)
+// and passes it as a private input to the circuit. The contract never sees it.
+pub fn commit(env: Env, commitment: BytesN<32>) {
+    env.storage().persistent().set(&DataKey::Commitment, &commitment);
+}
+```
+
+**Rules covered:** [Z002](rules/Z002.md), [Z012](rules/Z012.md)
+
+---
+
+### 2.3 Public-Input Binding
+
+Every ZK-verifier entry point must include transaction-specific context in the public inputs: caller, recipient, amount, and contract ID. This prevents an attacker from taking a valid proof and redirecting its effect.
+
+**Pattern:**
+
+```rust
+pub fn withdraw(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
+    // Validate range before including in public inputs (Z007).
+    assert!(amount > 0 && amount <= MAX_WITHDRAW, "amount out of range");
+
+    // Bind to this transaction's context.
+    let recipient_hash = hash_address(&env, &recipient);
+    let contract_id_hash = hash_address(&env, &env.current_contract_address());
+    let public_inputs = vec![&env, recipient_hash, amount as u64, contract_id_hash];
+
+    verify_proof(&env, &proof, &public_inputs);
+    token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+}
+```
+
+**Rules covered:** [Z003](rules/Z003.md), [Z007](rules/Z007.md)
+
+---
+
+### 2.4 Trusted-Setup Key Management
+
+The verifying key is the cryptographic root of trust. Treat it like an admin key:
+
+1. **Never hardcode it** — store in governance-controlled persistent storage.  
+2. **Protect rotation** — require admin `require_auth()` before any update.  
+3. **Verify integrity before use** — hash-check the loaded key on every verification call.
+
+**Pattern:**
+
+```rust
+pub fn set_verifying_key(env: Env, vk: BytesN<64>) {
+    let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
+    admin.require_auth();
+    let hash = env.crypto().sha256(&Bytes::from_slice(&env, vk.as_ref()));
+    env.storage().persistent().set(&DataKey::VerifyingKey, &vk);
+    env.storage().persistent().set(&DataKey::VkHash, &hash);
+}
+
+pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+    let vk: BytesN<64> = env.storage().persistent().get(&DataKey::VerifyingKey).unwrap();
+    let expected: BytesN<32> = env.storage().persistent().get(&DataKey::VkHash).unwrap();
+    assert_eq!(env.crypto().sha256(&Bytes::from_slice(&env, vk.as_ref())), expected);
+    groth16_verify(vk.as_ref(), &proof, &inputs)
+}
+```
+
+**Rules covered:** [Z004](rules/Z004.md), [Z005](rules/Z005.md), [Z010](rules/Z010.md)
+
+---
+
+### 2.5 Domain Separation
+
+Always use a distinct, versioned domain tag when hashing for different commitment types. Prefix every hash call with a unique byte string that identifies the context.
+
+```rust
+fn commit_with_domain(env: &Env, domain: &[u8], value: &[u8]) -> BytesN<32> {
+    let mut input = Bytes::new(env);
+    input.extend_from_slice(domain);
+    input.extend_from_slice(value);
+    env.crypto().sha256(&input)
+}
+
+// Example usage
+let nullifier_hash  = commit_with_domain(&env, b"sanctifier:nullifier:v1",  secret.as_ref());
+let amount_hash     = commit_with_domain(&env, b"sanctifier:amount:v1",     &amount.to_be_bytes());
+let recipient_hash  = commit_with_domain(&env, b"sanctifier:recipient:v1",  recipient_bytes.as_ref());
+```
+
+**Rules covered:** [Z011](rules/Z011.md)
+
+---
+
+### 2.6 Merkle Membership Proofs
+
+When using Merkle trees for on-chain set commitments (whitelists, UTXOs, anonymity sets):
+
+- **Load the root from contract storage** — never accept a caller-supplied root.
+- **Verify the proof** before taking any action.
+- **Nullify the leaf** after use to prevent double-claim (combine with Z001 pattern).
+
+```rust
+pub fn claim(env: Env, leaf: BytesN<32>, path: Vec<BytesN<32>>) {
+    let root: BytesN<32> = env.storage().persistent().get(&DataKey::MerkleRoot).unwrap();
+    assert!(verify_merkle_proof(&leaf, &path, &root), "not a member");
+
+    let spent_key = (symbol_short!("spent"), leaf.clone());
+    assert!(!env.storage().persistent().has(&spent_key), "already claimed");
+    env.storage().persistent().set(&spent_key, &true);
+
+    transfer_reward(&env);
+}
+```
+
+**Rules covered:** [Z014](rules/Z014.md)
+
+---
+
+## 3. Z-Rule Catalog
+
+| Rule | Name | Severity | Category |
+|------|------|----------|----------|
+| [Z001](rules/Z001.md) | Missing Nullifier / Double-Spend Check | Critical | zk-proof-integrity |
+| [Z002](rules/Z002.md) | Insecure or Predictable Randomness as Circuit Input | High | zk-randomness |
+| [Z003](rules/Z003.md) | Missing Public-Input Binding (Proof Malleability) | Critical | zk-proof-integrity |
+| [Z004](rules/Z004.md) | Hardcoded Trusted-Setup Parameters | Critical | zk-trusted-setup |
+| [Z005](rules/Z005.md) | Missing Verifying-Key Integrity Check | High | zk-trusted-setup |
+| [Z006](rules/Z006.md) | Missing Proof Nonce / Uniqueness Enforcement | High | zk-proof-integrity |
+| [Z007](rules/Z007.md) | Under-Constrained Circuit Inputs | Critical | zk-circuit-constraints |
+| [Z008](rules/Z008.md) | Curve / Field Mismatch | Critical | zk-circuit-constraints |
+| [Z009](rules/Z009.md) | Unbounded Proof-Verification Loop | High | zk-resource |
+| [Z010](rules/Z010.md) | Missing Access Control on Verifying-Key Rotation | Critical | zk-access-control |
+| [Z011](rules/Z011.md) | Commitment Reuse Without Domain Separation | High | zk-cryptography |
+| [Z012](rules/Z012.md) | ZK Property Leak via Public-Output Over-Exposure | Medium | zk-privacy |
+| [Z013](rules/Z013.md) | Insufficient Batch-Validation in ZK-Rollup Transitions | Critical | zk-proof-integrity |
+| [Z014](rules/Z014.md) | Missing Merkle-Root Inclusion-Proof Verification | Critical | zk-proof-integrity |
+
+**Critical rules** (Z001, Z003, Z004, Z007, Z008, Z010, Z013, Z014) must be resolved before mainnet deployment. **High rules** should be resolved before public testnet exposure.
+
+---
+
+## 4. Pre-Deployment Security Checklist
+
+### Proof lifecycle
+
+- [ ] Every proof-consuming entry point records a nullifier before transferring value (Z001)
+- [ ] Proofs are bound to an epoch or nonce to prevent cross-period replay (Z006)
+- [ ] Public inputs include recipient, amount, and contract ID (Z003)
+- [ ] All public input field elements are range-validated before the verifier call (Z007)
+
+### Trusted setup
+
+- [ ] Verifying key is stored in governance-controlled persistent storage, not hardcoded (Z004)
+- [ ] Verifying-key rotation is protected by `require_auth()` on an admin/multisig (Z010)
+- [ ] Verifying-key integrity is hash-checked before every use (Z005)
+- [ ] Curve/field identifier is validated at verifier entry (Z008)
+
+### Cryptographic hygiene
+
+- [ ] Blinding factors are generated off-chain by a secure RNG — no on-chain entropy (Z002)
+- [ ] All commitment types use distinct, versioned domain separation tags (Z011)
+- [ ] Public outputs do not include private witness values or full input vectors (Z012)
+
+### State integrity
+
+- [ ] Merkle inclusion proofs are verified against the contract's committed root, not a caller-supplied root (Z014)
+- [ ] Batch/rollup proofs assert `old_root == current_root` before accepting a state transition (Z013)
+- [ ] Batch-proof loops are bounded by a protocol constant (Z009)
+
+### General (S-rules still apply)
+
+- [ ] All privileged functions have `require_auth()` guards (S001)
+- [ ] Arithmetic operations are overflow-safe (S002)
+- [ ] Storage keys avoid collisions (S004)
+- [ ] Contract is protected against re-initialization (S008)
+
+---
+
+## 5. Further Reading
+
+- [0xPARC ZK Bug Tracker](https://github.com/0xPARC/zk-bug-tracker) — curated list of real-world ZK application bugs
+- [Trail of Bits: ZK Security](https://blog.trailofbits.com/2022/04/13/part-1-coordinated-disclosure-of-vulnerabilities-affecting-girault-bulletproofs-and-plonk/)
+- [Zellic: Common ZK vulnerabilities](https://www.zellic.io/blog/the-frozen-heart-vulnerability-in-plonk)
+- [Noir language documentation](https://noir-lang.org/)
+- [Soroban authorization model](https://soroban.stellar.org/docs/fundamentals/authorization)
+- [Soroban fees and metering](https://soroban.stellar.org/docs/fundamentals/fees-and-metering)
+- [Sanctifier S-rule documentation](rules/) — general Soroban security rules
+- [Sanctifier Security Checklist](SECURITY-CHECKLIST.md)

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod finding_codes;
 pub mod gas_estimator;
 pub mod gas_report;
 pub mod input_validation;
+pub mod noir_parser;
 pub mod parser;
 pub mod patcher;
 pub mod reentrancy;

--- a/tooling/sanctifier-core/src/noir_parser.rs
+++ b/tooling/sanctifier-core/src/noir_parser.rs
@@ -1,0 +1,382 @@
+//! Noir (`.nr`) source parser front-end (#1228).
+//!
+//! Maps a subset of Noir circuit source onto the same intermediate
+//! representation used by the circom front-end, so Z-rules can analyse Noir
+//! circuits with minimal rule-specific special-casing.
+//!
+//! # Coverage
+//!
+//! This parser covers the subset of Noir required for Z-rule analysis:
+//! - Function definitions (`fn name(params) -> ReturnType { ... }`)
+//! - Public / private parameter annotations (`pub`, implicit private)
+//! - `assert` and `assert_eq` constraint statements
+//! - Storage reads/writes via the `Storage` struct convention
+//! - Hash calls (`std::hash::pedersen_hash`, `std::hash::sha256`)
+//!
+//! # Gaps
+//!
+//! The following Noir constructs are not yet parsed and are silently ignored:
+//! - Traits and trait implementations
+//! - Closures
+//! - Macro invocations (`comptime { ... }`)
+//! - Generic type parameters beyond simple `Field` / `u64` / `bool`
+//!
+//! Extend `parse_statement` to cover additional constructs as Z-rule coverage
+//! expands to require them.
+
+use std::collections::HashMap;
+
+// ── Intermediate representation ───────────────────────────────────────────────
+
+/// Visibility of a Noir function parameter or return value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Visibility {
+    /// Marked `pub` — included in the proof's public inputs.
+    Public,
+    /// No `pub` annotation — part of the witness (private input).
+    Private,
+}
+
+/// A single parameter in a Noir function signature.
+#[derive(Debug, Clone)]
+pub struct NoirParam {
+    pub name: String,
+    pub ty: String,
+    pub visibility: Visibility,
+}
+
+/// A parsed Noir function.
+#[derive(Debug, Clone)]
+pub struct NoirFunction {
+    pub name: String,
+    pub params: Vec<NoirParam>,
+    pub return_type: Option<String>,
+    pub return_visibility: Visibility,
+    /// Flat list of statement kinds found in the body (order-preserving).
+    pub body: Vec<NoirStatement>,
+}
+
+/// A simplified statement in a Noir function body.
+#[derive(Debug, Clone)]
+pub enum NoirStatement {
+    /// `assert(expr)` or `assert(expr, "msg")`
+    Assert { expr: String },
+    /// `assert_eq(lhs, rhs)` or `assert_eq(lhs, rhs, "msg")`
+    AssertEq { lhs: String, rhs: String },
+    /// A call whose callee contains "hash" (e.g. `pedersen_hash`, `sha256`).
+    HashCall { callee: String, args: Vec<String> },
+    /// A storage read: `storage.field.get()`
+    StorageRead { field: String },
+    /// A storage write: `storage.field.write(value)` / `.insert(value)`
+    StorageWrite { field: String, value: String },
+    /// Any other expression statement, preserved verbatim for context.
+    Other { raw: String },
+}
+
+/// The top-level IR produced by parsing a single `.nr` file.
+#[derive(Debug, Default)]
+pub struct NoirModule {
+    /// All top-level functions defined in the file, keyed by name.
+    pub functions: HashMap<String, NoirFunction>,
+    /// Raw source lines that could not be attributed to any construct.
+    pub unparsed: Vec<String>,
+}
+
+// ── Parser ────────────────────────────────────────────────────────────────────
+
+/// Errors returned by [`parse_noir`].
+#[derive(Debug)]
+pub enum NoirParseError {
+    /// The source string is empty.
+    EmptySource,
+    /// Source is too large to analyse safely (> 512 KiB).
+    SourceTooLarge { bytes: usize },
+    /// A function signature could not be parsed.
+    MalformedFunction { line: usize, snippet: String },
+}
+
+impl std::fmt::Display for NoirParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptySource => write!(f, "empty Noir source"),
+            Self::SourceTooLarge { bytes } => {
+                write!(f, "source too large: {bytes} bytes (limit 524288)")
+            }
+            Self::MalformedFunction { line, snippet } => {
+                write!(f, "malformed function at line {line}: {snippet:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NoirParseError {}
+
+const MAX_SOURCE_BYTES: usize = 512 * 1024;
+
+/// Parse `source` (a `.nr` file's contents) into a [`NoirModule`].
+///
+/// This is a line-oriented best-effort parser. It extracts enough structure
+/// for Z-rule analysis without implementing a full Noir grammar.
+pub fn parse_noir(source: &str) -> Result<NoirModule, NoirParseError> {
+    if source.is_empty() {
+        return Err(NoirParseError::EmptySource);
+    }
+    if source.len() > MAX_SOURCE_BYTES {
+        return Err(NoirParseError::SourceTooLarge { bytes: source.len() });
+    }
+
+    let mut module = NoirModule::default();
+    let lines: Vec<&str> = source.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if trimmed.starts_with("fn ") || trimmed.starts_with("pub fn ") {
+            match parse_function(&lines, i) {
+                Ok((func, consumed)) => {
+                    module.functions.insert(func.name.clone(), func);
+                    i += consumed;
+                    continue;
+                }
+                Err(e) => {
+                    module.unparsed.push(format!("line {i}: {e}"));
+                }
+            }
+        } else if !trimmed.is_empty() && !trimmed.starts_with("//") {
+            module.unparsed.push(trimmed.to_string());
+        }
+
+        i += 1;
+    }
+
+    Ok(module)
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Parse a function starting at `lines[start]`. Returns `(function, lines_consumed)`.
+fn parse_function(lines: &[&str], start: usize) -> Result<(NoirFunction, usize), String> {
+    let header = lines[start].trim();
+
+    let name = extract_fn_name(header)
+        .ok_or_else(|| format!("cannot extract name from: {header:?}"))?;
+
+    let (params, return_type, return_visibility) = parse_signature(header);
+
+    // Collect body lines between the opening `{` and the matching `}`.
+    let mut body_lines: Vec<&str> = Vec::new();
+    let mut depth = 0usize;
+    let mut consumed = 1;
+
+    for line in &lines[start..] {
+        for ch in line.chars() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    if depth > 0 {
+                        depth -= 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if consumed > 1 {
+            body_lines.push(line);
+        }
+        consumed += 1;
+        if depth == 0 && consumed > 1 {
+            break;
+        }
+    }
+
+    let body = body_lines.iter().map(|l| parse_statement(l.trim())).collect();
+
+    Ok((
+        NoirFunction { name, params, return_type, return_visibility, body },
+        consumed.saturating_sub(1),
+    ))
+}
+
+fn extract_fn_name(header: &str) -> Option<String> {
+    // Match `fn name(` or `pub fn name(`
+    let after_fn = header.split("fn ").nth(1)?;
+    let name = after_fn.split('(').next()?.trim().to_string();
+    if name.is_empty() { None } else { Some(name) }
+}
+
+fn parse_signature(header: &str) -> (Vec<NoirParam>, Option<String>, Visibility) {
+    let params_str = header
+        .split('(')
+        .nth(1)
+        .and_then(|s| s.split(')').next())
+        .unwrap_or("");
+
+    let params = params_str
+        .split(',')
+        .filter_map(|p| {
+            let p = p.trim();
+            if p.is_empty() {
+                return None;
+            }
+            let (visibility, rest) = if p.starts_with("pub ") {
+                (Visibility::Public, p.trim_start_matches("pub "))
+            } else {
+                (Visibility::Private, p)
+            };
+            let mut parts = rest.splitn(2, ':');
+            let name = parts.next()?.trim().to_string();
+            let ty = parts.next().unwrap_or("Field").trim().to_string();
+            Some(NoirParam { name, ty, visibility })
+        })
+        .collect();
+
+    // Return type: `-> pub ReturnType` or `-> ReturnType`
+    let (return_type, return_visibility) = if let Some(after_arrow) = header.split("->").nth(1) {
+        let after_arrow = after_arrow.trim().trim_end_matches('{').trim();
+        if after_arrow.starts_with("pub ") {
+            (Some(after_arrow.trim_start_matches("pub ").trim().to_string()), Visibility::Public)
+        } else {
+            (Some(after_arrow.to_string()), Visibility::Private)
+        }
+    } else {
+        (None, Visibility::Private)
+    };
+
+    (params, return_type, return_visibility)
+}
+
+fn parse_statement(line: &str) -> NoirStatement {
+    if line.starts_with("assert_eq(") {
+        let inner = line.trim_start_matches("assert_eq(").trim_end_matches(';');
+        let inner = inner.rsplit(')').nth(1).unwrap_or(inner);
+        let mut parts = inner.splitn(2, ',');
+        let lhs = parts.next().unwrap_or("").trim().to_string();
+        let rhs = parts.next().unwrap_or("").trim().to_string();
+        return NoirStatement::AssertEq { lhs, rhs };
+    }
+
+    if line.starts_with("assert(") {
+        let inner = line
+            .trim_start_matches("assert(")
+            .split(',')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_end_matches(')')
+            .to_string();
+        return NoirStatement::Assert { expr: inner };
+    }
+
+    if line.contains("hash") && line.contains('(') {
+        let callee = line.split('(').next().unwrap_or("").trim().to_string();
+        let args_str = line.split('(').nth(1).and_then(|s| s.split(')').next()).unwrap_or("");
+        let args = args_str.split(',').map(|a| a.trim().to_string()).collect();
+        return NoirStatement::HashCall { callee, args };
+    }
+
+    if line.contains("storage.") {
+        if line.contains(".get()") || line.contains(".read()") {
+            let field = extract_storage_field(line);
+            return NoirStatement::StorageRead { field };
+        }
+        if line.contains(".write(") || line.contains(".insert(") {
+            let field = extract_storage_field(line);
+            let value = line.split('(').nth(1).and_then(|s| s.split(')').next()).unwrap_or("").to_string();
+            return NoirStatement::StorageWrite { field, value };
+        }
+    }
+
+    NoirStatement::Other { raw: line.to_string() }
+}
+
+fn extract_storage_field(line: &str) -> String {
+    line.split("storage.")
+        .nth(1)
+        .and_then(|s| s.split('.').next())
+        .unwrap_or("")
+        .to_string()
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_source_returns_error() {
+        assert!(matches!(parse_noir(""), Err(NoirParseError::EmptySource)));
+    }
+
+    #[test]
+    fn oversized_source_returns_error() {
+        let big = "x".repeat(MAX_SOURCE_BYTES + 1);
+        assert!(matches!(parse_noir(&big), Err(NoirParseError::SourceTooLarge { .. })));
+    }
+
+    #[test]
+    fn parses_simple_function_name() {
+        let src = r#"
+fn verify_membership(leaf: pub Field, root: pub Field) -> bool {
+    assert(leaf != 0);
+    true
+}
+"#;
+        let module = parse_noir(src).unwrap();
+        assert!(module.functions.contains_key("verify_membership"));
+    }
+
+    #[test]
+    fn detects_public_params() {
+        let src = r#"
+fn claim(nullifier: pub Field, amount: u64) -> bool {
+    assert(nullifier != 0);
+    true
+}
+"#;
+        let module = parse_noir(src).unwrap();
+        let func = &module.functions["claim"];
+        assert_eq!(func.params[0].visibility, Visibility::Public);
+        assert_eq!(func.params[1].visibility, Visibility::Private);
+    }
+
+    #[test]
+    fn parses_assert_statement() {
+        let src = r#"
+fn check(x: pub Field) {
+    assert(x != 0);
+}
+"#;
+        let module = parse_noir(src).unwrap();
+        let func = &module.functions["check"];
+        let has_assert = func.body.iter().any(|s| matches!(s, NoirStatement::Assert { .. }));
+        assert!(has_assert);
+    }
+
+    #[test]
+    fn parses_hash_call() {
+        let src = r#"
+fn commit(secret: Field, blinding: Field) -> Field {
+    std::hash::pedersen_hash([secret, blinding])
+}
+"#;
+        let module = parse_noir(src).unwrap();
+        let func = &module.functions["commit"];
+        let has_hash = func.body.iter().any(|s| matches!(s, NoirStatement::HashCall { .. }));
+        assert!(has_hash);
+    }
+
+    #[test]
+    fn parses_storage_read() {
+        let src = r#"
+fn get_root(storage: Storage) -> Field {
+    storage.root.get()
+}
+"#;
+        let module = parse_noir(src).unwrap();
+        let func = &module.functions["get_root"];
+        let has_read = func.body.iter().any(|s| matches!(s, NoirStatement::StorageRead { .. }));
+        assert!(has_read);
+    }
+}


### PR DESCRIPTION
## Summary

- **#1245** — 14 rule documentation pages (`docs/rules/Z001.md` through `Z014.md`), each following the exact section structure of existing S-rule docs: what the rule detects, why it matters, vulnerable example, safe example, references. Cross-linked to the security guide and Z-rule issue numbers.

- **#1244** — `docs/zk-security-guide.md`: comprehensive end-to-end guide for developers building ZK features on Soroban. Covers secure design patterns (nullifiers, commitments, public-input binding, trusted-setup key management, domain separation, Merkle membership), a full Z-rule catalog table (Z001–Z014 with severity and category), and a pre-deployment checklist organized by risk area. Cross-linked from individual rule docs and `docs/SECURITY-CHECKLIST.md`.

- **#1243** — `data/vulnerability-db.json`: 14 new ZK entries (`ZK-2026-001` through `ZK-2026-014`), one per Z-rule class, following the existing schema (`id`, `name`, `description`, `severity`, `category`, `rule`, `pattern`, `recommendation`, `references`). DB version bumped `1.0.0 → 1.1.0`; `last_updated` set to `2026-07-26`.

- **#1228** — `tooling/sanctifier-core/src/noir_parser.rs`: line-oriented Noir (`.nr`) parser front-end mapping circuit source onto the shared `NoirModule` / `NoirFunction` / `NoirStatement` IR. Covers the subset needed for Z-rule analysis (function signatures, `pub`/private params, `assert`/`assert_eq`, hash calls, storage reads/writes). Documented gaps (traits, closures, generics). Registered in `lib.rs`. 5 unit tests included.

## Changed files

| File | Change |
|------|--------|
| `docs/rules/Z001.md` – `Z014.md` | New — 14 ZK rule documentation pages |
| `docs/zk-security-guide.md` | New — comprehensive ZK security guide |
| `data/vulnerability-db.json` | 14 ZK entries added, version bumped to 1.1.0 |
| `tooling/sanctifier-core/src/noir_parser.rs` | New — Noir parser front-end with IR + tests |
| `tooling/sanctifier-core/src/lib.rs` | `pub mod noir_parser` registered |

Closes #1243
Closes #1244
Closes #1245
Closes #1228