### PR TITLE
feat(zk): implement Z003/Z004/Z005 rules and publish the ZK roadmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5322,6 +5322,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "zk-verifier"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Every finding has a stable code — `S001..S012` — so you can filter, suppress
 
 Plus the community **vulnerability database** matches known CVE-style patterns (`SOL-2024-*`) against your AST — so a published exploit anywhere becomes a finding everywhere.
 
+### Zero-knowledge contracts — the `Z001..Z014` series
+
+If your contract verifies ZK proofs on-chain, Sanctifier checks the ways those integrations keep breaking: nullifiers that are never recorded, public inputs that don't commit to the transaction, verifying keys with no ceremony provenance or trusted straight out of storage.
+
+**→ [docs/zk-roadmap.md](docs/zk-roadmap.md)** is the scope summary: which Z-rules have detectors today, which are documented but not yet wired, and what is deliberately deferred. Start there before reading the 62 individual issues. The full catalogue lives in [docs/rules/](docs/rules/), with the vulnerability classes and secure patterns explained in the [ZK Security Guide](docs/zk-security-guide.md).
+
 ---
 
 ## Live on Soroban testnet — right now
@@ -289,6 +295,7 @@ Sanctifier is shipping in waves. What's done, what's next, what's wishlist:
 - Streaming `--ndjson` output for incremental piping
 - GitHub PR comment formatter with delta vs base
 - 20+ new engine rules (allowance race, TTL bumps, cross-contract `try_call`, taint through destructures, …)
+- ZK integration — `Z001..Z014` rule catalogue, circom/Noir parsing, shielded-contract fixtures, dashboard ZK panel. Scope and status: **[docs/zk-roadmap.md](docs/zk-roadmap.md)**
 
 **Wishlist**
 - Hosted REST API, Stellar Laboratory plugin, cargo-sanctify subcommand shim, anomaly-detection rules engine for recorded runtime calls
@@ -339,6 +346,7 @@ in a single terminal session.
 | **Get started (tutorial)** | **[docs/getting-started.md](docs/getting-started.md)** |
 | Browse the API reference | [API Documentation](https://hypersafed.github.io/Sanctifier/) |
 | Understand every finding code | [docs/error-codes.md](docs/error-codes.md) |
+| **Analyse a ZK contract** | **[docs/zk-roadmap.md](docs/zk-roadmap.md)** (scope) · [ZK Security Guide](docs/zk-security-guide.md) · [ZK Integration Guide](docs/ZK-INTEGRATION-GUIDE.md) |
 | Wire the runtime guard into your contract | [docs/runtime-guards-integration.md](docs/runtime-guards-integration.md) |
 | Set up CI | [docs/ci-cd-setup.md](docs/ci-cd-setup.md) |
 | Deploy to testnet | [docs/soroban-deployment.md](docs/soroban-deployment.md) |

--- a/contracts/fixtures/finding-codes/README.md
+++ b/contracts/fixtures/finding-codes/README.md
@@ -51,13 +51,22 @@ future fixture.
 | ------------ | -------------------------------------------- | ----------------------- |
 | `Z001`       | `z001_missing_nullifier.rs`                  | Triggering only         |
 | `Z002`       | `z002_insecure_randomness.rs`                | Triggering + clean      |
+| `Z003`       | `z003_missing_public_input_binding.rs`        | Triggering + clean      |
+| `Z004`       | `z004_unverified_trusted_setup.rs`            | Triggering + clean      |
+| `Z005`       | `z005_missing_vk_integrity_check.rs`          | Triggering + clean      |
 | `Z009`       | `z009_unbounded_verify_loop.rs`               | Triggering + clean      |
 | `Z010`       | `z010_missing_vk_rotation_access_control.rs`  | Triggering + clean      |
 
+The `Z003`–`Z005` fixtures are exercised directly by the snapshot suite
+(`tooling/sanctifier-core/tests/sarif_snapshots.rs`), which asserts the exact set
+of functions or constants each rule flags — so a fixture and its rule cannot drift
+apart silently.
+
 Rule definitions live under [`docs/rules/`](../../../docs/rules/); see
-`Z001.md`–`Z014.md` for the full Z-rule catalog. This table is updated
-incrementally as each Z-rule fixture lands (see #1197–#1210, #1217, #1218,
-#1222, #1223).
+`Z001.md`–`Z014.md` for the full Z-rule catalog, and
+[`docs/zk-roadmap.md`](../../../docs/zk-roadmap.md) for what ships in this wave.
+This table is updated incrementally as each Z-rule fixture lands (see #1197–#1210,
+#1217, #1218, #1222, #1223).
 
 ## Usage
 

--- a/contracts/fixtures/finding-codes/z003_missing_public_input_binding.rs
+++ b/contracts/fixtures/finding-codes/z003_missing_public_input_binding.rs
@@ -1,0 +1,85 @@
+//! ⚠️  VULNERABLE FIXTURE — FOR TESTING PURPOSES ONLY. DO NOT DEPLOY.
+//!
+//! Z003 — Missing Public-Input Binding (Proof Malleability)
+//!
+//! A ZK proof attests only to the statement encoded in its public inputs. When a
+//! withdrawal path verifies a proof over `[amount]` but then transfers to a
+//! caller-supplied `recipient`, that recipient was never part of what the proof
+//! proved. An observer can lift a valid proof out of the mempool, resubmit it with
+//! their own address, and redirect the payout — the proof still verifies, because
+//! nothing in it ever mentioned the original recipient.
+//!
+//! Rule Z003 must flag `withdraw_vulnerable` and must NOT flag
+//! `withdraw_safe` (recipient bound via a hash) or `withdraw_safe_direct`
+//! (recipient passed straight to the verifier).
+//!
+//! See: docs/rules/Z003.md
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
+
+#[contract]
+pub struct PublicInputBindingFixture;
+
+#[contractimpl]
+impl PublicInputBindingFixture {
+    // -------------------------------------------------------------------------
+    // ❌ VULNERABLE: `recipient` drives the transfer but never enters the public
+    // inputs, so the proof does not commit to it. Z003 must flag this function.
+    // -------------------------------------------------------------------------
+    pub fn withdraw_vulnerable(env: Env, proof: BytesN<256>, recipient: Address, amount: i128) {
+        // Only the amount is bound — the destination is free for the taker.
+        let public_inputs = Vec::from_array(&env, [amount as u64]);
+        verify_proof(&env, &proof, &public_inputs);
+
+        transfer_out(&env, &recipient, amount);
+    }
+
+    // -------------------------------------------------------------------------
+    // ✅ SAFE: the recipient is hashed into a field element and included in the
+    // public inputs, so the circuit commits to this exact destination.
+    // Z003 must NOT flag this function.
+    // -------------------------------------------------------------------------
+    pub fn withdraw_safe(env: Env, proof: BytesN<256>, recipient: Address, amount: i128) {
+        let recipient_hash = hash_address(&env, &recipient);
+        let public_inputs = Vec::from_array(&env, [recipient_hash, amount as u64]);
+        verify_proof(&env, &proof, &public_inputs);
+
+        transfer_out(&env, &recipient, amount);
+    }
+
+    // -------------------------------------------------------------------------
+    // ✅ SAFE: the verifier receives the recipient and amount directly.
+    // Z003 must NOT flag this function.
+    // -------------------------------------------------------------------------
+    pub fn withdraw_safe_direct(env: Env, proof: BytesN<256>, recipient: Address, amount: i128) {
+        groth16_verify(&env, &proof, &recipient, &amount);
+
+        transfer_out(&env, &recipient, amount);
+    }
+
+    // -------------------------------------------------------------------------
+    // ✅ SAFE: nothing security-relevant survives the verification, so there is
+    // no value an attacker could redirect. Z003 must NOT flag this function.
+    // -------------------------------------------------------------------------
+    pub fn attest(env: Env, proof: BytesN<256>, recipient: Address) {
+        let public_inputs = Vec::from_array(&env, [1u64]);
+        verify_proof(&env, &proof, &public_inputs);
+    }
+}
+
+// ── Stubs so the fixture is self-contained ───────────────────────────────────
+
+fn verify_proof(_env: &Env, _proof: &BytesN<256>, _inputs: &Vec<u64>) -> bool {
+    true
+}
+
+fn groth16_verify(_env: &Env, _proof: &BytesN<256>, _recipient: &Address, _amount: &i128) -> bool {
+    true
+}
+
+fn hash_address(_env: &Env, _addr: &Address) -> u64 {
+    0
+}
+
+fn transfer_out(_env: &Env, _to: &Address, _amount: i128) {}

--- a/contracts/fixtures/finding-codes/z004_unverified_trusted_setup.rs
+++ b/contracts/fixtures/finding-codes/z004_unverified_trusted_setup.rs
@@ -1,0 +1,79 @@
+//! ⚠️  VULNERABLE FIXTURE — FOR TESTING PURPOSES ONLY. DO NOT DEPLOY.
+//!
+//! Z004 — Unverified or Hardcoded Trusted-Setup Parameters ("Toxic Waste")
+//!
+//! Groth16 and comparable schemes derive their verifying key from a trusted setup
+//! whose secret randomness — the "toxic waste" — must be provably destroyed.
+//! Whoever retains it can forge a proof for any false statement. A verifying key
+//! pasted into contract source with no pointer to a public ceremony transcript is
+//! therefore unauditable: nobody outside the deploying team can tell whether the
+//! trapdoor still exists.
+//!
+//! Rule Z004 flags *provenance*, not cryptography. It must flag
+//! `VK_ALPHA_G1_UNDOCUMENTED` and `TRUSTED_SETUP_PARAMS`, and must NOT flag the
+//! documented keys below or the unrelated constants.
+//!
+//! See: docs/rules/Z004.md
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, BytesN, Env};
+
+// -----------------------------------------------------------------------------
+// ❌ VULNERABLE: key material with no ceremony reference anywhere near it.
+// Z004 must flag this constant.
+// -----------------------------------------------------------------------------
+const VK_ALPHA_G1_UNDOCUMENTED: [u8; 8] = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33];
+
+// -----------------------------------------------------------------------------
+// ❌ VULNERABLE: a multi-line setup blob, still undocumented.
+// Z004 must flag this constant.
+// -----------------------------------------------------------------------------
+const TRUSTED_SETUP_PARAMS: [u8; 12] = [
+    0xaa, 0xbb, 0xcc, 0xdd, //
+    0xee, 0xff, 0x01, 0x02, //
+    0x03, 0x04, 0x05, 0x06,
+];
+
+// -----------------------------------------------------------------------------
+// ✅ SAFE: provenance recorded immediately above the constant — which ceremony,
+// which contribution, the transcript hash, and where to fetch it.
+// Z004 must NOT flag this constant.
+// -----------------------------------------------------------------------------
+// ceremony: perpetual powers-of-tau, phase2 contribution #47
+// transcript sha256: 3f7a1c04e5b28d9f6a1103bb77c4e2d5081aa93cf4be6710d2ac5f38e91b7c19
+// https://ceremony.example.org/transcripts/47.json
+const VK_BETA_G2_DOCUMENTED: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+/// Verifying key produced by the Hermez `powersOfTau28_hez` ceremony;
+/// attestation and contribution hash published with the circuit release.
+/// Z004 must NOT flag this constant.
+pub const VERIFYING_KEY: &[u8] = &[0x11, 0x22, 0x33, 0x44];
+
+// -----------------------------------------------------------------------------
+// ✅ SAFE: not setup material at all — a storage key and a limit.
+// Z004 must NOT flag these.
+// -----------------------------------------------------------------------------
+const VK_STORAGE_KEY: &str = "VK";
+const MAX_PUBLIC_INPUTS: u32 = 16;
+
+#[contract]
+pub struct TrustedSetupFixture;
+
+#[contractimpl]
+impl TrustedSetupFixture {
+    /// Verify against the undocumented key — the reason Z004 exists.
+    pub fn verify_undocumented(env: Env, proof: BytesN<256>) -> bool {
+        groth16_verify(&env, &VK_ALPHA_G1_UNDOCUMENTED, &proof)
+    }
+
+    /// Verify against a key whose ceremony provenance is on record.
+    pub fn verify_documented(env: Env, proof: BytesN<256>) -> bool {
+        groth16_verify(&env, &VK_BETA_G2_DOCUMENTED, &proof)
+    }
+}
+
+// ── Stub so the fixture is self-contained ────────────────────────────────────
+
+fn groth16_verify(_env: &Env, _vk: &[u8], _proof: &BytesN<256>) -> bool {
+    true
+}

--- a/contracts/fixtures/finding-codes/z005_missing_vk_integrity_check.rs
+++ b/contracts/fixtures/finding-codes/z005_missing_vk_integrity_check.rs
@@ -1,0 +1,128 @@
+//! ⚠️  VULNERABLE FIXTURE — FOR TESTING PURPOSES ONLY. DO NOT DEPLOY.
+//!
+//! Z005 — Missing Verifying-Key Integrity Check Before Use
+//!
+//! Once a contract supports verifying-key rotation, the key lives in mutable
+//! storage. Access control on the rotation function (Z010) answers "who may write
+//! the key" — it does not answer "is the key sitting there right now the one we
+//! vetted". A storage-key collision, an unrelated migration, or a compromised
+//! admin can leave a hostile key in place, and every later `verify` silently
+//! accepts proofs forged under it.
+//!
+//! The defence costs one hash comparison against a reference committed at
+//! deployment.
+//!
+//! Rule Z005 must flag `verify_vulnerable` and `verify_inline_vulnerable`, and
+//! must NOT flag `verify_safe` (hash asserted) or `verify_constant_key`
+//! (immutable key — nothing to tamper with at runtime).
+//!
+//! See: docs/rules/Z005.md
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Bytes, BytesN, Env, Vec};
+
+// ceremony: perpetual powers-of-tau phase2 contribution #47,
+// transcript sha256 3f7a1c04e5b28d9f6a1103bb77c4e2d5081aa93cf4be6710d2ac5f38e91b7c19
+const IMMUTABLE_VERIFYING_KEY: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+#[contracttype]
+pub enum DataKey {
+    /// The rotatable verifying key.
+    VerifyingKey,
+    /// sha256 of the verifying key that governance last approved.
+    VkHash,
+}
+
+#[contract]
+pub struct VkIntegrityFixture;
+
+#[contractimpl]
+impl VkIntegrityFixture {
+    // -------------------------------------------------------------------------
+    // ❌ VULNERABLE: the key is read out of mutable storage and handed straight
+    // to the verifier. Z005 must flag this function.
+    // -------------------------------------------------------------------------
+    pub fn verify_vulnerable(env: Env, proof: BytesN<256>, inputs: Vec<u64>) -> bool {
+        let vk: BytesN<64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VerifyingKey)
+            .expect("verifying key not set");
+
+        groth16_verify(&env, &vk, &proof, &inputs)
+    }
+
+    // -------------------------------------------------------------------------
+    // ❌ VULNERABLE: same defect, with the storage read inlined into the call.
+    // Z005 must flag this function.
+    // -------------------------------------------------------------------------
+    pub fn verify_inline_vulnerable(env: Env, proof: BytesN<256>, inputs: Vec<u64>) -> bool {
+        groth16_verify(
+            &env,
+            &env.storage()
+                .persistent()
+                .get(&DataKey::VerifyingKey)
+                .expect("verifying key not set"),
+            &proof,
+            &inputs,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // ✅ SAFE: the stored key is hashed and compared against the reference hash
+    // before it is trusted. Z005 must NOT flag this function.
+    // -------------------------------------------------------------------------
+    pub fn verify_safe(env: Env, proof: BytesN<256>, inputs: Vec<u64>) -> bool {
+        let vk: BytesN<64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VerifyingKey)
+            .expect("verifying key not set");
+        let expected_vk_hash: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VkHash)
+            .expect("verifying key hash not set");
+
+        // Integrity gate: abort if the stored key is not the vetted one.
+        assert_eq!(
+            env.crypto()
+                .sha256(&Bytes::from_slice(&env, &vk.to_array()))
+                .to_bytes(),
+            expected_vk_hash,
+            "verifying key integrity check failed"
+        );
+
+        groth16_verify(&env, &vk, &proof, &inputs)
+    }
+
+    // -------------------------------------------------------------------------
+    // ✅ SAFE: an immutable constant cannot be swapped at runtime, so a runtime
+    // integrity check is redundant. Z005 must NOT flag this function.
+    // (Provenance of a constant key is Z004's concern instead.)
+    // -------------------------------------------------------------------------
+    pub fn verify_constant_key(env: Env, proof: BytesN<256>, inputs: Vec<u64>) -> bool {
+        groth16_verify_raw(&env, &IMMUTABLE_VERIFYING_KEY, &proof, &inputs)
+    }
+
+    // -------------------------------------------------------------------------
+    // ✅ SAFE: reads the key but never verifies anything with it.
+    // Z005 must NOT flag this function.
+    // -------------------------------------------------------------------------
+    pub fn get_verifying_key(env: Env) -> BytesN<64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VerifyingKey)
+            .expect("verifying key not set")
+    }
+}
+
+// ── Stubs so the fixture is self-contained ───────────────────────────────────
+
+fn groth16_verify(_env: &Env, _vk: &BytesN<64>, _proof: &BytesN<256>, _inputs: &Vec<u64>) -> bool {
+    true
+}
+
+fn groth16_verify_raw(_env: &Env, _vk: &[u8], _proof: &BytesN<256>, _inputs: &Vec<u64>) -> bool {
+    true
+}

--- a/data/sarif/rule-metadata.yaml
+++ b/data/sarif/rule-metadata.yaml
@@ -20,82 +20,84 @@ rules:
   # ── ZK / Zero-Knowledge rules (Z001-Z014) ────────────────────────────────
 
   - id: Z001
-    name: Unconstrained Signal Input
-    shortDescription: Detects circuit inputs that are never constrained, allowing arbitrary witness assignment
+    name: Missing Nullifier / Double-Spend Check
+    shortDescription: Detects proof-based claim flows that consume a verified proof without recording a nullifier, enabling double-spend
     helpUri: https://docs.sanctifier.dev/rules/Z001
     defaultSeverity: critical
     tags:
       - zk
-      - soundness
-      - circom
+      - nullifier
+      - double-spend
 
   - id: Z002
-    name: Missing Public Input Binding
-    shortDescription: Detects public inputs not bound to any constraint, enabling proof forgery
+    name: Insecure or Predictable Randomness as Circuit Input
+    shortDescription: Detects on-chain pseudo-randomness (ledger timestamp, sequence) used as entropy for a circuit input
     helpUri: https://docs.sanctifier.dev/rules/Z002
+    defaultSeverity: high
+    tags:
+      - zk
+      - randomness
+
+  - id: Z003
+    name: Missing Public-Input Binding (Proof Malleability)
+    shortDescription: Detects verifier calls whose public inputs omit a security-relevant value used after verification, letting a valid proof be paired with attacker-chosen inputs
+    helpUri: https://docs.sanctifier.dev/rules/Z003
     defaultSeverity: critical
     tags:
       - zk
-      - soundness
+      - malleability
+      - proof-integrity
 
-  - id: Z003
-    name: Trusted Setup Parameter Exposure
-    shortDescription: Detects use of toxic waste or hard-coded toxic parameters from a trusted setup
-    helpUri: https://docs.sanctifier.dev/rules/Z003
+  - id: Z004
+    name: Unverified Trusted-Setup Parameters
+    shortDescription: Detects hardcoded verifying-key material with no adjacent reference to an auditable ceremony transcript
+    helpUri: https://docs.sanctifier.dev/rules/Z004
     defaultSeverity: critical
     tags:
       - zk
       - trusted-setup
 
-  - id: Z004
-    name: Soundness Violation via Under-constrained Output
-    shortDescription: Detects circuit outputs reachable by multiple distinct witnesses, breaking soundness
-    helpUri: https://docs.sanctifier.dev/rules/Z004
-    defaultSeverity: critical
-    tags:
-      - zk
-      - soundness
-
   - id: Z005
-    name: Witness Arithmetic Overflow
-    shortDescription: Detects arithmetic operations in witness generation that can overflow the field modulus
+    name: Missing Verifying-Key Integrity Check
+    shortDescription: Detects verifier calls using a storage-loaded verifying key without checking it against a known-good hash
     helpUri: https://docs.sanctifier.dev/rules/Z005
     defaultSeverity: high
     tags:
       - zk
-      - arithmetic
-      - overflow
+      - trusted-setup
+      - verifying-key
 
   - id: Z006
-    name: Under-constrained Circuit Component
-    shortDescription: Detects reusable sub-circuits or templates missing necessary constraints
+    name: Missing Proof Nonce / Uniqueness Enforcement
+    shortDescription: Detects verifiers that accept previously-used proofs without a nonce or domain-separating context binding
     helpUri: https://docs.sanctifier.dev/rules/Z006
     defaultSeverity: high
+    tags:
+      - zk
+      - replay
+
+  - id: Z007
+    name: Under-Constrained Circuit Inputs
+    shortDescription: Detects circuit inputs that are never range-checked against the scalar field modulus, allowing arbitrary witness assignment
+    helpUri: https://docs.sanctifier.dev/rules/Z007
+    defaultSeverity: critical
     tags:
       - zk
       - soundness
       - circom
 
-  - id: Z007
-    name: Proof Malleability
-    shortDescription: Detects proof systems or verifiers that accept mutated proofs as valid
-    helpUri: https://docs.sanctifier.dev/rules/Z007
-    defaultSeverity: high
-    tags:
-      - zk
-      - malleability
-
   - id: Z008
-    name: Verifying Key Mismatch
-    shortDescription: Detects verifiers loading a VK that does not match the proving key in use
+    name: Curve / Field Mismatch
+    shortDescription: Detects an on-chain verifier whose curve or field parameters do not match the off-chain circuit
     helpUri: https://docs.sanctifier.dev/rules/Z008
-    defaultSeverity: high
+    defaultSeverity: critical
     tags:
       - zk
+      - soundness
       - verifying-key
 
   - id: Z009
-    name: Unbounded Proof Verification Loop
+    name: Unbounded Proof-Verification Loop
     shortDescription: Detects proof-verification loops over caller-supplied unbounded collections, enabling DoS
     helpUri: https://docs.sanctifier.dev/rules/Z009
     defaultSeverity: high
@@ -105,7 +107,7 @@ rules:
       - resource-exhaustion
 
   - id: Z010
-    name: Verifying Key Rotation Without Access Control
+    name: Verifying-Key Rotation Without Access Control
     shortDescription: Detects VK-rotation functions callable by any account, allowing an attacker to swap the verifying key
     helpUri: https://docs.sanctifier.dev/rules/Z010
     defaultSeverity: critical
@@ -115,38 +117,40 @@ rules:
       - verifying-key
 
   - id: Z011
-    name: Non-deterministic Witness Generation
-    shortDescription: Detects witness-generation paths that depend on external mutable state, producing different proofs for the same input
+    name: Commitment Reuse Without Domain Separation
+    shortDescription: Detects a commitment scheme reused across distinct domains without a separating tag, allowing cross-domain confusion
     helpUri: https://docs.sanctifier.dev/rules/Z011
+    defaultSeverity: high
+    tags:
+      - zk
+      - cryptography
+      - domain-separation
+
+  - id: Z012
+    name: ZK Property Leak via Public-Output Over-Exposure
+    shortDescription: Detects shielded contracts that publish more on-chain data than their stated privacy model allows
+    helpUri: https://docs.sanctifier.dev/rules/Z012
     defaultSeverity: medium
     tags:
       - zk
-      - determinism
+      - privacy
 
-  - id: Z012
-    name: Missing Nullifier Uniqueness Check
-    shortDescription: Detects proof-based claim flows that do not enforce nullifier uniqueness, enabling double-spend
-    helpUri: https://docs.sanctifier.dev/rules/Z012
+  - id: Z013
+    name: Insufficient Batch-Validation in ZK-Rollup Transitions
+    shortDescription: Detects rollup-style batch state transitions that are applied without validating every proof in the batch
+    helpUri: https://docs.sanctifier.dev/rules/Z013
     defaultSeverity: critical
     tags:
       - zk
-      - nullifier
-      - double-spend
-
-  - id: Z013
-    name: Proof Replay Attack
-    shortDescription: Detects verifiers that accept previously-used proofs without a domain-separating context binding
-    helpUri: https://docs.sanctifier.dev/rules/Z013
-    defaultSeverity: high
-    tags:
-      - zk
-      - replay
+      - rollup
+      - proof-integrity
 
   - id: Z014
-    name: Insecure Randomness in Circuit
-    shortDescription: Detects use of on-chain pseudo-randomness (block hash, timestamp) as a circuit random input
+    name: Missing Merkle-Root Inclusion-Proof Verification
+    shortDescription: Detects membership claims accepted without verifying the Merkle inclusion proof against the contract's committed root
     helpUri: https://docs.sanctifier.dev/rules/Z014
-    defaultSeverity: high
+    defaultSeverity: critical
     tags:
       - zk
-      - randomness
+      - merkle
+      - proof-integrity

--- a/docs/ZK-INTEGRATION-GUIDE.md
+++ b/docs/ZK-INTEGRATION-GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide shows how to wire `sanctifier zk lint` and `sanctifier verify-circuit` into an existing **circom + snarkjs** or **Noir** project's development workflow and CI pipeline.
 
-> **See also:** [INTEGRATION-GUIDE.md](./INTEGRATION-GUIDE.md) for generic SARIF pipeline patterns and [ZK-SECURITY-GUIDE.md](./ZK-SECURITY-GUIDE.md) for a reference on ZK vulnerability classes.
+> **See also:** [INTEGRATION-GUIDE.md](./INTEGRATION-GUIDE.md) for generic SARIF pipeline patterns and [zk-security-guide.md](./zk-security-guide.md) for a reference on ZK vulnerability classes.
 
 ---
 
@@ -24,20 +24,24 @@ Sanctifier applies its **Z-rules** (Z001–Z014) to ZK circuits and their on-cha
 
 | Rule | Finding | Severity |
 |------|---------|----------|
-| Z001 | Unconstrained signal input | critical |
-| Z002 | Missing public input binding | critical |
-| Z003 | Trusted setup parameter exposure | critical |
-| Z004 | Soundness violation via under-constrained output | critical |
-| Z005 | Witness arithmetic overflow | high |
-| Z006 | Under-constrained circuit component | high |
-| Z007 | Proof malleability | high |
-| Z008 | Verifying key mismatch | high |
+| Z001 | Missing nullifier / double-spend check | critical |
+| Z002 | Insecure or predictable randomness as circuit input | high |
+| Z003 | Missing public-input binding (proof malleability) | critical |
+| Z004 | Unverified trusted-setup parameters | critical |
+| Z005 | Missing verifying-key integrity check | high |
+| Z006 | Missing proof nonce / uniqueness enforcement | high |
+| Z007 | Under-constrained circuit inputs | critical |
+| Z008 | Curve / field mismatch | critical |
 | Z009 | Unbounded proof-verification loop (DoS) | high |
-| Z010 | Verifying key rotation without access control | critical |
-| Z011 | Non-deterministic witness generation | medium |
-| Z012 | Missing nullifier uniqueness check | critical |
-| Z013 | Proof replay attack | high |
-| Z014 | Insecure randomness in circuit | high |
+| Z010 | Verifying-key rotation without access control | critical |
+| Z011 | Commitment reuse without domain separation | high |
+| Z012 | ZK property leak via public-output over-exposure | medium |
+| Z013 | Insufficient batch-validation in ZK-rollup transitions | critical |
+| Z014 | Missing Merkle-root inclusion-proof verification | critical |
+
+> The canonical catalogue lives in [`docs/rules/`](rules/) (`Z001.md`–`Z014.md`) and is
+> mirrored by `data/vulnerability-db.json` and `data/sarif/rule-metadata.yaml`.
+> See [zk-roadmap.md](zk-roadmap.md) for which of these ship as implemented rules today.
 
 ---
 

--- a/docs/rules/Z003.md
+++ b/docs/rules/Z003.md
@@ -46,7 +46,55 @@ pub fn withdraw(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
 
 ---
 
+## How the check works
+
+The rule is a contract-side heuristic, not a proof of circuit correctness. For each
+function that calls a verifier it:
+
+1. collects the expressions handed to the verifier as public inputs;
+2. expands those expressions transitively through local `let` bindings, so
+   `let h = hash_address(&env, &recipient);` counts as binding `recipient`;
+3. collects the security-relevant parameters still *used after* the verifier call —
+   any `Address`-typed parameter, plus names containing `recipient`, `receiver`,
+   `beneficiary`, `amount`, `value`, `caller`, `destination`, `payee`; and
+4. reports the ones that never reached the public inputs.
+
+Step 3 is what keeps the rule quiet: a value that is not used after verification
+cannot be redirected, so it is not reported.
+
+### What it will not catch
+
+- Whether the *circuit* actually constrains the input you passed. Binding the value
+  on-chain and constraining it in-circuit are two separate obligations; this rule
+  can only see the first.
+- Encoding mismatches — passing a truncated or differently-hashed address than the
+  circuit expects still counts as bound here.
+
+---
+
+## Remediation
+
+Include every security-relevant value in the public-input vector. Values that are
+not field elements (an `Address`, a 32-byte hash) must be folded into one first, and
+with the same encoding the circuit uses:
+
+```rust
+let recipient_hash = hash_address(&env, &recipient);
+let public_inputs = vec![&env, recipient_hash, amount as u64];
+```
+
+---
+
+## Fixture
+
+`contracts/fixtures/finding-codes/z003_missing_public_input_binding.rs` — covers the
+triggering case plus three clean cases (hash-bound, directly bound, and a value never
+used after verification).
+
+---
+
 ## References
 
 - [Proof malleability — ZKP security considerations](https://eprint.iacr.org/2019/099.pdf)
 - [Z003 implementation issue #1199](https://github.com/HyperSafeD/Sanctifier/issues/1199)
+- Related: [Z001](Z001.md) (nullifier replay), [Z007](Z007.md) (input range checks)

--- a/docs/rules/Z004.md
+++ b/docs/rules/Z004.md
@@ -8,26 +8,52 @@
 
 ## What it detects
 
-A verifying key or trusted-setup parameter (Common Reference String, SRS, or proving key hash) that is hardcoded as a literal in contract source rather than being loaded from a governance-controlled storage key and validated against a known hash.
+A verifying key or trusted-setup parameter (Common Reference String, SRS, proving-key
+material) hardcoded as a byte literal in contract source **with no adjacent comment
+referencing a verifiable, publicly auditable ceremony transcript**.
+
+The check is about *provenance*, not about the constant being hardcoded per se. A
+hardcoded key whose ceremony is documented immediately above it does not fire.
 
 ---
 
 ## Why it matters
 
-Most practical ZK proof systems (Groth16, PLONK) require a trusted setup ceremony. The output — the verifying key — must be authentic. If the verifying key is hardcoded, an attacker who compromises the build pipeline can substitute a key they control, generating valid proofs for false statements. Additionally, a hardcoded key cannot be rotated after a ceremony compromise is discovered.
+Groth16 and comparable schemes derive their verifying key from a trusted setup whose
+secret randomness — the "toxic waste" — must be provably destroyed. Whoever retains
+it can forge a proof for any false statement: mint tokens, drain a shielded pool,
+prove ownership of assets they never held. The proof verifies, because the trapdoor
+lets you produce one for a statement that is not true.
+
+The only defence available to an outside reviewer is the ceremony transcript: a
+public record of every contribution, letting anyone confirm that at least one
+participant was honest. A verifying key with no transcript reference cannot be
+audited by anyone outside the deploying team, and so cannot be trusted with mainnet
+value.
 
 ---
 
 ## Vulnerable example
 
 ```rust
-// Z004: verifying key baked into source. Cannot be updated after deployment;
-// a build-time compromise is undetectable at runtime.
+// Z004: key material with no pointer to a ceremony transcript. Nobody outside the
+// deploying team can tell whether the trapdoor still exists.
 const VK_ALPHA: &[u8] = &[0xde, 0xad, 0xbe, 0xef, /* ... */];
 
 pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
     groth16_verify(VK_ALPHA, &proof, &inputs)
 }
+```
+
+---
+
+## Documented example (does not fire)
+
+```rust
+// ceremony: perpetual powers-of-tau, phase2 contribution #47
+// transcript sha256: 3f7a1c04e5b28d9f6a1103bb77c4e2d5081aa93cf4be6710d2ac5f38e91b7c19
+// https://ceremony.example.org/transcripts/47.json
+const VK_ALPHA: &[u8] = &[0xde, 0xad, 0xbe, 0xef, /* ... */];
 ```
 
 ---
@@ -49,7 +75,89 @@ pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
 
 ---
 
+## How the check works
+
+Detection runs over raw source text rather than the parsed AST, because ordinary `//`
+comments — the very thing carrying the provenance — are discarded during parsing.
+
+A finding is raised when all three hold:
+
+1. **The name looks like setup material.** `VERIFYING_KEY`, `VERIFICATION_KEY`,
+   `PROVING_KEY`, `TRUSTED_SETUP`, `SETUP_PARAMS`, `ALPHA_G1`, `BETA_G2`, `GAMMA_G2`,
+   `DELTA_G2`, `GAMMA_ABC`, `POWERS_OF_TAU`, or a `VK`/`SRS`/`CRS`/`TAU` fragment.
+2. **The initializer looks like key material.** A byte-array or hex literal, not a
+   storage-key string or a numeric limit. `const VK_STORAGE_KEY: &str = "VK";` is not
+   a key and does not fire.
+3. **The preceding comment block carries no provenance.** The contiguous run of
+   comments and attributes directly above the declaration is searched for `ceremony`,
+   `transcript`, `attestation`, `powers of tau` / `powersoftau` / `ptau`, `phase2`,
+   `perpetual powers`, `mpc`, or `contribution hash`.
+
+A marker that is negated on its own line — `// no ceremony transcript for this key` —
+does not count as provenance. Saying the documentation is missing is not documentation.
+
+### What it will not catch
+
+Whether a referenced transcript is cryptographically valid. Establishing that means
+replaying the ceremony and checking every contribution, which no static analyser can
+do from contract source. This rule tells you whether a reviewer *has something to
+check*; it does not check it for you.
+
+---
+
+## Guidance: what provenance to record
+
+Put a comment block directly above the constant. Anyone reviewing the contract should
+be able to go from that comment to the transcript without asking you for anything.
+Record:
+
+| Field | Why | Example |
+|---|---|---|
+| Ceremony name and phase | Identifies which setup produced the key | `perpetual powers-of-tau, phase2` |
+| Contribution index | Pins the exact point in the transcript | `contribution #47` |
+| Transcript digest | Lets a reviewer confirm they fetched the same file | `sha256: 3f7a…c19e` |
+| Public URL | Where to fetch it | `https://ceremony.example.org/transcripts/47.json` |
+| Circuit identity | Ties the key to the circuit it verifies | `circuit: transfer.circom, r1cs sha256 9b2e…` |
+
+### Common transcript formats
+
+- **`snarkjs` `.ptau`** — the phase-1 (powers-of-tau) accumulator. Verify with
+  `snarkjs powersoftau verify pot.ptau`, which walks and checks every contribution.
+- **`snarkjs` `.zkey`** — the circuit-specific phase-2 output that the verifying key
+  is extracted from. Verify with `snarkjs zkey verify circuit.r1cs pot.ptau final.zkey`.
+  Export the key with `snarkjs zkey export verificationkey`, and record the `.zkey`
+  hash alongside it.
+- **Perpetual Powers of Tau attestations** — signed, human-readable statements from
+  each contributor, published per contribution. Link the specific attestation, not
+  just the ceremony's landing page.
+- **`phase2-bn254` / MPC ceremony logs** — a contribution hash chain. Record the
+  final contribution hash; it commits to the entire chain before it.
+
+A single honest contributor is enough for the setup to be sound, so the point of the
+transcript is breadth: the more independent, publicly attested contributors, the less
+plausible it is that all of them colluded.
+
+### The alternative: don't hardcode it
+
+Loading the key from governance-controlled storage instead sidesteps this rule and
+buys rotation. It also takes on two obligations of its own: guard the rotation path
+with admin auth ([Z010](Z010.md)) and check the stored key's integrity before every
+use ([Z005](Z005.md)).
+
+---
+
+## Fixture
+
+`contracts/fixtures/finding-codes/z004_unverified_trusted_setup.rs` — two triggering
+constants (single-line and multi-line literals) alongside ceremony-documented keys, a
+storage-key string, and an unrelated limit.
+
+---
+
 ## References
 
 - [Zcash Sprout trusted setup](https://z.cash/technology/paramgen/)
+- [Perpetual Powers of Tau](https://github.com/privacy-scaling-explorations/perpetualpowersoftau)
+- [snarkjs — setup and verification workflow](https://github.com/iden3/snarkjs)
 - [Z004 implementation issue #1200](https://github.com/HyperSafeD/Sanctifier/issues/1200)
+- Related: [Z005](Z005.md) (VK integrity), [Z010](Z010.md) (VK rotation auth)

--- a/docs/rules/Z005.md
+++ b/docs/rules/Z005.md
@@ -50,6 +50,55 @@ pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
 
 ---
 
+## How the check works
+
+Within each function the rule walks statements in order and tracks three things:
+
+1. **A verifying key loaded from storage** — a `let` binding whose initializer reads
+   contract storage and whose name or key mentions a verifying key, or the same read
+   inlined directly into the verifier call.
+2. **An integrity gate** — a statement that both applies a hash or signature primitive
+   (`sha256`, `keccak256`, `blake2`, `ed25519_verify`, …) to the key *and* compares or
+   asserts on the result (`assert_eq!`, `==`, `!=`, `panic!`, `require`).
+3. **The verifier call** — `verify_proof`, `groth16_verify`, `snark_verify`,
+   `plonk_verify`, and their variants.
+
+A finding is raised when (1) reaches (3) with no (2) in between.
+
+Merely *reading* the reference hash out of storage is not a gate — the comparison has
+to happen. `let expected = storage.get(&DataKey::VkHash).unwrap();` on its own leaves
+the finding in place.
+
+### Out of scope by construction
+
+Verifying keys held in `const` or `static` items. They cannot be mutated at runtime,
+so a runtime integrity check would be checking a value against itself. Their distinct
+risk — undocumented provenance — is [Z004](Z004.md)'s concern.
+
+---
+
+## Relationship to Z010
+
+[Z010](Z010.md) asks *who may write the key*. Z005 asks *is the key sitting there
+right now the one we vetted*. Passing Z010 does not answer Z005's question: a storage
+key collision, an unrelated migration, or a compromised admin account can all leave a
+hostile key in place through a perfectly access-controlled rotation function. The two
+rules are complementary, and a rotatable-key design needs both.
+
+When you do rotate, update the reference hash in the same transaction as the key —
+otherwise the integrity gate rejects the new, legitimate key.
+
+---
+
+## Fixture
+
+`contracts/fixtures/finding-codes/z005_missing_vk_integrity_check.rs` — two triggering
+functions (bound and inlined storage reads) plus three clean cases (hash asserted,
+immutable constant key, and a getter that never verifies).
+
+---
+
 ## References
 
 - [Z005 implementation issue #1201](https://github.com/HyperSafeD/Sanctifier/issues/1201)
+- Related: [Z004](Z004.md) (setup provenance), [Z010](Z010.md) (rotation auth)

--- a/docs/zk-roadmap.md
+++ b/docs/zk-roadmap.md
@@ -1,0 +1,207 @@
+# ZK Feature Roadmap
+
+**Milestone:** [ZK Integration](https://github.com/HyperSafeD/Sanctifier/milestones?q=ZK+Integration)
+**Status of this document:** scope summary for the current ZK wave. Updated as the wave lands.
+
+Sixty-two ZK issues are landing in a single wave. Reading all of them to find out what
+Sanctifier can actually do for a zero-knowledge contract today is not reasonable, so
+this page is the short version: what ships now, what is documented but not yet wired,
+and what is deliberately out of scope for this wave.
+
+This is the ZK-feature counterpart to the [mainnet readiness checklist](../RELEASE_CHECKLIST.md) (#1115).
+
+---
+
+## Contents
+
+- [The one-paragraph version](#the-one-paragraph-version)
+- [In scope for this wave](#in-scope-for-this-wave)
+  - [Z-rule catalogue](#z-rule-catalogue)
+  - [Toolchain support](#toolchain-support)
+  - [Example contracts and fixtures](#example-contracts-and-fixtures)
+  - [CLI and output](#cli-and-output)
+  - [Dashboard](#dashboard)
+  - [Documentation](#documentation)
+- [Deferred to a future wave](#deferred-to-a-future-wave)
+- [Known gaps in this wave](#known-gaps-in-this-wave)
+- [How to read a Z-finding](#how-to-read-a-z-finding)
+
+---
+
+## The one-paragraph version
+
+This wave gives Sanctifier a **contract-side** ZK analysis capability: it reads the Rust
+contract that verifies proofs on-chain — and, to a lesser degree, the circom or Noir
+circuit behind it — and flags the recurring ways ZK integrations get broken. Nullifiers
+that are never recorded. Public inputs that don't commit to the transaction. Verifying
+keys with no ceremony provenance, or loaded from storage and trusted without a check.
+It does **not** prove your circuit correct, and it does not replace a ZK audit. Treat it
+the way you treat the S-rules: a fast, cheap pass that catches the classes of bug that
+keep recurring, run on every commit, well before an auditor sees the code.
+
+---
+
+## In scope for this wave
+
+### Z-rule catalogue
+
+The canonical catalogue is **Z001–Z014**, defined by [`docs/rules/Z001.md`–`Z014.md`](rules/)
+and mirrored in `data/vulnerability-db.json` and `data/sarif/rule-metadata.yaml`.
+
+All fourteen are **specified and documented**. Not all fourteen have a detector yet —
+the table below is the honest status, because a documented rule with no implementation
+finds nothing:
+
+| Code | Rule | Severity | Detector | Fixture |
+|------|------|----------|----------|---------|
+| [Z001](rules/Z001.md) | Missing nullifier / double-spend check | Critical | ✅ `zk_double_spend_risk` | ✅ |
+| [Z002](rules/Z002.md) | Insecure or predictable randomness as circuit input | High | ⏳ documented | ✅ |
+| [Z003](rules/Z003.md) | Missing public-input binding (proof malleability) | Critical | ✅ `missing_public_input_binding` | ✅ |
+| [Z004](rules/Z004.md) | Unverified trusted-setup parameters ("toxic waste") | Critical | ✅ `hardcoded_trusted_setup` | ✅ |
+| [Z005](rules/Z005.md) | Missing verifying-key integrity check | High | ✅ `missing_vk_integrity_check` | ✅ |
+| [Z006](rules/Z006.md) | Missing proof nonce / uniqueness enforcement | High | ⏳ documented | — |
+| [Z007](rules/Z007.md) | Under-constrained circuit inputs | Critical | ◐ `arkworks_circuit_missing_range_check` (arkworks only) | — |
+| [Z008](rules/Z008.md) | Curve / field mismatch | Critical | ⏳ documented | — |
+| [Z009](rules/Z009.md) | Unbounded proof-verification loop | High | ⏳ documented | ✅ |
+| [Z010](rules/Z010.md) | Verifying-key rotation without access control | Critical | ⏳ documented | ✅ |
+| [Z011](rules/Z011.md) | Commitment reuse without domain separation | High | ⏳ documented | — |
+| [Z012](rules/Z012.md) | ZK property leak via public-output over-exposure | Medium | ⏳ documented | — |
+| [Z013](rules/Z013.md) | Insufficient batch-validation in ZK-rollup transitions | Critical | ⏳ documented | — |
+| [Z014](rules/Z014.md) | Missing Merkle-root inclusion-proof verification | Critical | ⏳ documented | — |
+
+✅ implemented and registered · ◐ partial · ⏳ specified, detector not yet landed
+
+Three further ZK detectors ship without a canonical Z-code, covering patterns found
+while building the above: `zk_missing_constraint` (a ZK entry point that never asserts
+anything), `zk_verifier_skippable` (a verifier call reachable only through one branch of
+an `if`/`else`), and `zk_verification_result_ignored` (a discarded verification result).
+Assigning them stable codes is tracked for the next wave.
+
+### Toolchain support
+
+| Toolchain | Support in this wave |
+|---|---|
+| **Soroban contracts (Rust)** | Full — this is where every Z-rule detector runs |
+| **circom** | Parser for templates, signals, constraint operators, and component instantiation; unconstrained-signal analysis |
+| **Noir** | Parser for functions, parameter visibility (`pub`), and assert statements |
+| **arkworks** (`ConstraintSynthesizer`) | Range-check analysis on `generate_constraints`, via the existing `syn` pipeline |
+
+### Example contracts and fixtures
+
+- **`contracts/private-transfer/`** — a shielded transfer contract (shield / private
+  transfer / unshield) with commitments and a nullifier set. Its proof verification is a
+  **placeholder**, not a real pairing check; it exists to exercise the analysis, not to
+  be deployed.
+- **`contracts/zk-verifier/`** — a reusable nullifier set with explicit state tracking.
+- **`contracts/fixtures/finding-codes/z0NN_*.rs`** — per-rule fixtures, each annotated
+  inline with which functions trigger (❌) and which are clean (✅). The Z003–Z005
+  fixtures are asserted against directly by the snapshot suite, so a fixture and its
+  rule cannot drift apart silently.
+
+### CLI and output
+
+Z-findings flow through the existing pipeline with no new commands: `sanctifier analyze`
+reports them, `--format sarif` and `--format json` emit them, `sanctifier explain Z003`
+prints the code's description and remediation, and the SARIF rule metadata in
+`data/sarif/rule-metadata.yaml` carries their names, severities, and help URIs.
+
+Because the ZK rules do not need Z3, they work in a Z3-free build:
+
+```bash
+cargo install sanctifier-cli --locked --no-default-features
+sanctifier analyze contracts/private-transfer --format sarif
+```
+
+### Dashboard
+
+A dedicated ZK view (`frontend/app/playground/zk/`) with a Z-findings panel and a
+constraint-graph visualisation of the parsed circuit.
+
+### Documentation
+
+- [ZK Security Guide](zk-security-guide.md) — the vulnerability classes and the secure
+  patterns that avoid them, with the Z-rules that check each one.
+- [ZK Integration Guide](ZK-INTEGRATION-GUIDE.md) — wiring Sanctifier into a circom +
+  snarkjs or Noir project and its CI.
+- [`docs/rules/Z001.md`–`Z014.md`](rules/) — one page per rule: what it detects, why it
+  matters, vulnerable and safe examples, and what the check cannot see.
+- [ADR: ZK feature integration](adr/) — the design decisions behind the above.
+
+---
+
+## Deferred to a future wave
+
+Explicitly **not** shipping now. No dates are attached to any of these — they are
+sequenced by contributor interest and by what the first wave's users actually hit.
+
+**Additional toolchains**
+- Halo2, plonky2/plonky3, gnark, and Leo/Aleo circuits.
+- Non-Soroban on-chain verifiers (Solidity/EVM Groth16 verifiers, Solana programs).
+- Direct `.r1cs` / `.zkey` / `.ptau` artifact inspection. Today the analysis reads
+  source, not compiled setup artifacts.
+
+**Deeper circuit analysis**
+- Full constraint-system soundness analysis — proving a circuit is not
+  under-constrained, rather than pattern-matching the common ways it goes wrong.
+- Formal verification for circuits. The Z3-backed pass (S011) covers contract
+  invariants; extending it to constraint systems is a substantially larger problem and
+  is not attempted here.
+- Witness-generation analysis (non-determinism, side channels in the prover).
+
+**Circuit visualisation depth**
+- The constraint graph renders structure. Interactive constraint-level debugging,
+  signal tracing, and diffing two versions of a circuit are future work.
+
+**Ceremony verification**
+- Z004 checks that a verifying key *cites* a ceremony transcript. Actually fetching that
+  transcript and replaying the contribution chain is out of scope — it needs network
+  access and a full MPC verifier, neither of which belongs in a static analyser.
+
+**Proof-system-specific verifier correctness**
+- Checking that a hand-written on-chain pairing check is a correct Groth16 verifier.
+  This wave's rules check how a verifier is *used*, not whether its arithmetic is right.
+
+---
+
+## Known gaps in this wave
+
+Stated plainly so nobody discovers them the hard way:
+
+1. **Nine of the fourteen Z-rules are documentation-only today.** See the table above.
+   A clean `sanctifier analyze` run does not mean those nine classes are absent from
+   your contract.
+2. **Every Z-rule is a heuristic.** They pattern-match names, call shapes, and local
+   dataflow. They will miss code that achieves the same thing by a different route, and
+   they can fire on code that is safe for a reason the analyser cannot see. Read the
+   "what it will not catch" section on each rule page.
+3. **Circuit-side coverage is much thinner than contract-side coverage.** The circom and
+   Noir parsers exist and are used, but most detectors run on the Rust contract.
+4. **The example contracts do not implement real proof verification.** They are analysis
+   fixtures. Do not copy their `verify_proof` into anything that holds value.
+5. **Rule-code drift is still being cleaned up.** The canonical numbering is
+   `docs/rules/` + `data/vulnerability-db.json` + `data/sarif/rule-metadata.yaml` +
+   `finding_codes.rs`, all now aligned. If you find a stale Z-number anywhere else in
+   the tree, it is a bug — please open an issue.
+
+---
+
+## How to read a Z-finding
+
+A Z-finding says "this is a shape that has caused real losses". It does not say "your
+contract is exploitable". The sequence that works:
+
+1. Open the rule page (`docs/rules/Z0NN.md`) and read **why it matters** — the finding
+   text is a summary, the page is the argument.
+2. Check the **what it will not catch** section. It tells you what you still have to
+   verify yourself, and often that is the more important half.
+3. Compare against the fixture in `contracts/fixtures/finding-codes/`, which shows the
+   triggering and clean forms side by side.
+4. If it is a false positive, say so in an issue with the snippet. Every Z-rule
+   heuristic in this wave was tightened by exactly that feedback.
+
+---
+
+**Related:** [ZK Security Guide](zk-security-guide.md) ·
+[ZK Integration Guide](ZK-INTEGRATION-GUIDE.md) ·
+[Rule catalogue](rules/) ·
+[Wave dependencies](WAVE_DEPENDENCIES.md)

--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -303,8 +303,8 @@ pub(crate) fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
             .iter()
             .map(|(file, v)| {
                 let level = match format!("{:?}", v.severity).as_str() {
-                    "Error" => "error",
-                    "Warning" => "warning",
+                    "Critical" | "Error" => "error",
+                    "High" | "Warning" => "warning",
                     _ => "note",
                 };
                 let msg = match &v.suggestion {

--- a/tooling/sanctifier-core/src/circom_parser.rs
+++ b/tooling/sanctifier-core/src/circom_parser.rs
@@ -12,8 +12,6 @@
 //! - Known gaps: `pragma` versions, `include` directives, and `function`
 //!   blocks are parsed but not deeply analysed.
 
-use std::collections::HashMap;
-
 /// A parsed circom template.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CircomTemplate {
@@ -151,7 +149,10 @@ fn parse_template<'a>(
         let params: Vec<String> = if params_str.trim().is_empty() {
             vec![]
         } else {
-            params_str.split(',').map(|p| p.trim().to_string()).collect()
+            params_str
+                .split(',')
+                .map(|p| p.trim().to_string())
+                .collect()
         };
         (name, params)
     } else {
@@ -168,7 +169,10 @@ fn parse_template<'a>(
     let mut constraint_body = String::new();
 
     for (_ln, raw) in lines.by_ref() {
-        let line = raw.trim();
+        // Strip line comments before anything else: a comment must not affect
+        // brace depth, and — critically — must not be mistaken for a constraint
+        // mentioning a signal (`// inter is never constrained`).
+        let line = raw.split("//").next().unwrap_or(raw).trim();
 
         // Track brace depth to know when the template closes.
         for ch in line.chars() {
@@ -187,9 +191,6 @@ fn parse_template<'a>(
         if depth == 0 {
             break;
         }
-
-        constraint_body.push(' ');
-        constraint_body.push_str(line);
 
         // Signal declaration
         if line.starts_with("signal") {
@@ -211,13 +212,16 @@ fn parse_template<'a>(
         if line.contains("===") || line.contains("<==") || line.contains("==>") {
             raw_constraints.push(line.to_string());
         }
+
+        // Only executable lines feed the constrained-signal scan; declarations
+        // and comments were skipped above.
+        constraint_body.push(' ');
+        constraint_body.push_str(line);
     }
 
     // Mark signals that appear in a constraint.
     for signal in signals.iter_mut() {
-        if raw_constraints
-            .iter()
-            .any(|c| c.contains(&signal.name))
+        if raw_constraints.iter().any(|c| c.contains(&signal.name))
             || constraint_body.contains(&format!(" {} ", signal.name))
         {
             signal.is_constrained = true;
@@ -240,9 +244,15 @@ fn parse_signal_decl(line: &str) -> Option<Signal> {
     //   signal inter;
     let rest = line.trim_start_matches("signal").trim();
     let (direction, rest) = if rest.starts_with("input ") {
-        (SignalDirection::Input, rest.trim_start_matches("input").trim())
+        (
+            SignalDirection::Input,
+            rest.trim_start_matches("input").trim(),
+        )
     } else if rest.starts_with("output ") {
-        (SignalDirection::Output, rest.trim_start_matches("output").trim())
+        (
+            SignalDirection::Output,
+            rest.trim_start_matches("output").trim(),
+        )
     } else {
         (SignalDirection::Intermediate, rest)
     };
@@ -349,7 +359,11 @@ template LeakyMult() {
         let f = parse(MULTIPLIER).unwrap();
         let t = &f.templates[0];
         for sig in &t.signals {
-            assert!(sig.is_constrained, "signal {} must be constrained", sig.name);
+            assert!(
+                sig.is_constrained,
+                "signal {} must be constrained",
+                sig.name
+            );
         }
     }
 

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -87,35 +87,39 @@ pub const REQUIRE_AUTH_FOR_ARGS: &str = "S030";
 pub const GAS_EXHAUSTION_RISK: &str = "S031";
 
 // ── Z-series: ZK / circom integration rules ──────────────────────────────────
+//
+// The canonical Z-rule catalogue is `docs/rules/Z001.md` – `docs/rules/Z014.md`,
+// mirrored by `data/vulnerability-db.json` and `docs/zk-security-guide.md`.
+// Keep these constants in lock-step with those documents.
 
-/// ZK circuit function has no constraint assertions — proof may be unsound.
-pub const ZK_MISSING_CONSTRAINT: &str = "Z001";
-/// Signal declared in circom template is never used in a constraint expression.
-pub const ZK_UNCONSTRAINED_SIGNAL: &str = "Z002";
-/// ZK proof input used in contract logic without on-chain validation.
-pub const ZK_PROOF_INPUT_NOT_VALIDATED: &str = "Z003";
-/// Groth16/SNARK verifier call can be bypassed by a conditional branch.
-pub const ZK_VERIFIER_SKIPPABLE: &str = "Z004";
-/// Nullifier set not checked before processing a proof — double-spend possible.
-pub const ZK_DOUBLE_SPEND_RISK: &str = "Z005";
-/// Public inputs to the verifier are not bound to on-chain state.
-pub const ZK_PUBLIC_INPUT_NOT_BOUND: &str = "Z006";
-/// Circom constraint system has under-constrained intermediate signals.
-pub const ZK_UNDER_CONSTRAINED_SIGNAL: &str = "Z007";
-/// Circom template instantiation uses an unchecked component output.
-pub const ZK_UNCHECKED_COMPONENT_OUTPUT: &str = "Z008";
-/// Trusted setup ceremony parameters are hardcoded in source.
-pub const ZK_HARDCODED_TRUSTED_SETUP: &str = "Z009";
-/// Proof system uses non-standard curve parameters without documentation.
-pub const ZK_NONSTANDARD_CURVE: &str = "Z010";
-/// Verifier does not emit an event after successful proof verification.
-pub const ZK_MISSING_VERIFICATION_EVENT: &str = "Z011";
+/// Verified proof is consumed without recording a nullifier — double-spend possible.
+pub const ZK_MISSING_NULLIFIER: &str = "Z001";
+/// Predictable on-chain entropy (timestamp, ledger sequence) used as a circuit input.
+pub const ZK_INSECURE_RANDOMNESS: &str = "Z002";
+/// Public inputs passed to the verifier are not bound to the transaction context.
+pub const ZK_MISSING_PUBLIC_INPUT_BINDING: &str = "Z003";
+/// Trusted-setup / verifying-key material is hardcoded without ceremony provenance.
+pub const ZK_HARDCODED_TRUSTED_SETUP: &str = "Z004";
+/// Verifying key is loaded from storage and used without an integrity check.
+pub const ZK_MISSING_VK_INTEGRITY_CHECK: &str = "Z005";
+/// Proof accepted without a nonce / uniqueness check — replayable.
+pub const ZK_MISSING_PROOF_NONCE: &str = "Z006";
+/// Circuit inputs are not range-checked against the scalar field modulus.
+pub const ZK_UNDER_CONSTRAINED_INPUTS: &str = "Z007";
+/// On-chain verifier curve/field does not match the off-chain circuit.
+pub const ZK_CURVE_FIELD_MISMATCH: &str = "Z008";
+/// Proof-verification loop is bounded by an unbounded caller-supplied value.
+pub const ZK_UNBOUNDED_VERIFY_LOOP: &str = "Z009";
+/// Verifying-key rotation / upgrade path is missing an admin auth check.
+pub const ZK_UNPROTECTED_VK_ROTATION: &str = "Z010";
+/// Commitment scheme reused across domains without domain separation.
+pub const ZK_COMMITMENT_REUSE_NO_DOMAIN_SEP: &str = "Z011";
 /// Shielded contract exposes more on-chain data than the privacy model claims.
-pub const ZK_OVER_EXPOSURE: &str = "Z012";
-/// Zero-knowledge proof verification result is not checked (ignored return value).
-pub const ZK_VERIFICATION_RESULT_IGNORED: &str = "Z013";
-/// Contract mixes ZK and non-ZK execution paths without clear separation.
-pub const ZK_MIXED_EXECUTION_PATHS: &str = "Z014";
+pub const ZK_PUBLIC_OUTPUT_OVEREXPOSURE: &str = "Z012";
+/// ZK-rollup style batch state transition is insufficiently validated.
+pub const ZK_INSUFFICIENT_BATCH_VALIDATION: &str = "Z013";
+/// Merkle inclusion proof is not verified against the contract's committed root.
+pub const ZK_MISSING_MERKLE_INCLUSION: &str = "Z014";
 
 /// A single finding-code entry with machine-readable code, category, and
 /// human-readable description.
@@ -445,6 +449,33 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             remediation: "Cap the iteration count with a fixed maximum (e.g. .take(MAX_ITEMS) or an explicit length check before the loop) so the gas cost cannot scale unbounded with caller-supplied input",
             doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/gas-exhaustion-risk.md",
         },
+        FindingCode {
+            code: ZK_MISSING_PUBLIC_INPUT_BINDING,
+            category: "zk-proof-integrity",
+            description: "Security-relevant runtime values (recipient, amount, caller) are used after proof verification but are not among the public inputs passed to the verifier, allowing a valid proof to be paired with attacker-chosen inputs",
+            title: "Missing Public-Input Binding (Proof Malleability)",
+            severity: FindingSeverity::Critical,
+            remediation: "Include every security-relevant value in the public-input vector passed to the verifier (hashing addresses into a field element where needed) so the circuit commits to the transaction context",
+            doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z003.md",
+        },
+        FindingCode {
+            code: ZK_HARDCODED_TRUSTED_SETUP,
+            category: "zk-trusted-setup",
+            description: "Verifying-key or trusted-setup material is hardcoded in contract source with no adjacent reference to a publicly auditable ceremony transcript or attestation",
+            title: "Unverified Trusted-Setup Parameters (Toxic Waste)",
+            severity: FindingSeverity::Critical,
+            remediation: "Document the ceremony provenance immediately above the constant with a `// ceremony:` comment naming the transcript, its hash, and a public URL, or load the key from governance-controlled storage",
+            doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z004.md",
+        },
+        FindingCode {
+            code: ZK_MISSING_VK_INTEGRITY_CHECK,
+            category: "zk-trusted-setup",
+            description: "A verifying key read from mutable contract storage is passed to the verifier without first being checked against a known-good hash or signature",
+            title: "Missing Verifying-Key Integrity Check",
+            severity: FindingSeverity::High,
+            remediation: "Hash the storage-loaded verifying key and assert it equals a reference hash committed at deployment before using it to verify any proof",
+            doc_url: "https://github.com/HyperSafeD/Sanctifier/blob/main/docs/rules/Z005.md",
+        },
     ]
 }
 
@@ -520,5 +551,30 @@ mod tests {
         assert!(codes.iter().any(|c| c.code == TIMESTAMP_RANDOMNESS));
         assert!(codes.iter().any(|c| c.code == REQUIRE_AUTH_FOR_ARGS));
         assert!(codes.iter().any(|c| c.code == GAS_EXHAUSTION_RISK));
+    }
+
+    #[test]
+    fn includes_expected_zk_codes() {
+        let codes = all_finding_codes();
+        assert!(codes
+            .iter()
+            .any(|c| c.code == ZK_MISSING_PUBLIC_INPUT_BINDING));
+        assert!(codes.iter().any(|c| c.code == ZK_HARDCODED_TRUSTED_SETUP));
+        assert!(codes
+            .iter()
+            .any(|c| c.code == ZK_MISSING_VK_INTEGRITY_CHECK));
+    }
+
+    #[test]
+    fn zk_codes_match_the_canonical_catalogue() {
+        // The Z-series numbering is defined by docs/rules/Z0NN.md and mirrored in
+        // data/vulnerability-db.json. Guard against silent renumbering drift.
+        assert_eq!(ZK_MISSING_NULLIFIER, "Z001");
+        assert_eq!(ZK_INSECURE_RANDOMNESS, "Z002");
+        assert_eq!(ZK_MISSING_PUBLIC_INPUT_BINDING, "Z003");
+        assert_eq!(ZK_HARDCODED_TRUSTED_SETUP, "Z004");
+        assert_eq!(ZK_MISSING_VK_INTEGRITY_CHECK, "Z005");
+        assert_eq!(ZK_UNPROTECTED_VK_ROTATION, "Z010");
+        assert_eq!(ZK_MISSING_MERKLE_INCLUSION, "Z014");
     }
 }

--- a/tooling/sanctifier-core/src/noir_parser.rs
+++ b/tooling/sanctifier-core/src/noir_parser.rs
@@ -122,7 +122,9 @@ pub fn parse_noir(source: &str) -> Result<NoirModule, NoirParseError> {
         return Err(NoirParseError::EmptySource);
     }
     if source.len() > MAX_SOURCE_BYTES {
-        return Err(NoirParseError::SourceTooLarge { bytes: source.len() });
+        return Err(NoirParseError::SourceTooLarge {
+            bytes: source.len(),
+        });
     }
 
     let mut module = NoirModule::default();
@@ -159,15 +161,15 @@ pub fn parse_noir(source: &str) -> Result<NoirModule, NoirParseError> {
 fn parse_function(lines: &[&str], start: usize) -> Result<(NoirFunction, usize), String> {
     let header = lines[start].trim();
 
-    let name = extract_fn_name(header)
-        .ok_or_else(|| format!("cannot extract name from: {header:?}"))?;
+    let name =
+        extract_fn_name(header).ok_or_else(|| format!("cannot extract name from: {header:?}"))?;
 
     let (params, return_type, return_visibility) = parse_signature(header);
 
     // Collect body lines between the opening `{` and the matching `}`.
     let mut body_lines: Vec<&str> = Vec::new();
     let mut depth = 0usize;
-    let mut consumed = 1;
+    let mut consumed: usize = 1;
 
     for line in &lines[start..] {
         for ch in line.chars() {
@@ -190,10 +192,19 @@ fn parse_function(lines: &[&str], start: usize) -> Result<(NoirFunction, usize),
         }
     }
 
-    let body = body_lines.iter().map(|l| parse_statement(l.trim())).collect();
+    let body = body_lines
+        .iter()
+        .map(|l| parse_statement(l.trim()))
+        .collect();
 
     Ok((
-        NoirFunction { name, params, return_type, return_visibility, body },
+        NoirFunction {
+            name,
+            params,
+            return_type,
+            return_visibility,
+            body,
+        },
         consumed.saturating_sub(1),
     ))
 }
@@ -202,7 +213,11 @@ fn extract_fn_name(header: &str) -> Option<String> {
     // Match `fn name(` or `pub fn name(`
     let after_fn = header.split("fn ").nth(1)?;
     let name = after_fn.split('(').next()?.trim().to_string();
-    if name.is_empty() { None } else { Some(name) }
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
 }
 
 fn parse_signature(header: &str) -> (Vec<NoirParam>, Option<String>, Visibility) {
@@ -219,15 +234,20 @@ fn parse_signature(header: &str) -> (Vec<NoirParam>, Option<String>, Visibility)
             if p.is_empty() {
                 return None;
             }
-            let (visibility, rest) = if p.starts_with("pub ") {
-                (Visibility::Public, p.trim_start_matches("pub "))
-            } else {
-                (Visibility::Private, p)
-            };
-            let mut parts = rest.splitn(2, ':');
+            // Noir marks visibility on the *type*, not the binding:
+            // `fn claim(nullifier: pub Field, amount: u64)`.
+            let mut parts = p.splitn(2, ':');
             let name = parts.next()?.trim().to_string();
-            let ty = parts.next().unwrap_or("Field").trim().to_string();
-            Some(NoirParam { name, ty, visibility })
+            let ty = parts.next().unwrap_or("Field").trim();
+            let (visibility, ty) = match ty.strip_prefix("pub ") {
+                Some(stripped) => (Visibility::Public, stripped.trim()),
+                None => (Visibility::Private, ty),
+            };
+            Some(NoirParam {
+                name,
+                ty: ty.to_string(),
+                visibility,
+            })
         })
         .collect();
 
@@ -235,7 +255,10 @@ fn parse_signature(header: &str) -> (Vec<NoirParam>, Option<String>, Visibility)
     let (return_type, return_visibility) = if let Some(after_arrow) = header.split("->").nth(1) {
         let after_arrow = after_arrow.trim().trim_end_matches('{').trim();
         if after_arrow.starts_with("pub ") {
-            (Some(after_arrow.trim_start_matches("pub ").trim().to_string()), Visibility::Public)
+            (
+                Some(after_arrow.trim_start_matches("pub ").trim().to_string()),
+                Visibility::Public,
+            )
         } else {
             (Some(after_arrow.to_string()), Visibility::Private)
         }
@@ -270,7 +293,11 @@ fn parse_statement(line: &str) -> NoirStatement {
 
     if line.contains("hash") && line.contains('(') {
         let callee = line.split('(').next().unwrap_or("").trim().to_string();
-        let args_str = line.split('(').nth(1).and_then(|s| s.split(')').next()).unwrap_or("");
+        let args_str = line
+            .split('(')
+            .nth(1)
+            .and_then(|s| s.split(')').next())
+            .unwrap_or("");
         let args = args_str.split(',').map(|a| a.trim().to_string()).collect();
         return NoirStatement::HashCall { callee, args };
     }
@@ -282,12 +309,19 @@ fn parse_statement(line: &str) -> NoirStatement {
         }
         if line.contains(".write(") || line.contains(".insert(") {
             let field = extract_storage_field(line);
-            let value = line.split('(').nth(1).and_then(|s| s.split(')').next()).unwrap_or("").to_string();
+            let value = line
+                .split('(')
+                .nth(1)
+                .and_then(|s| s.split(')').next())
+                .unwrap_or("")
+                .to_string();
             return NoirStatement::StorageWrite { field, value };
         }
     }
 
-    NoirStatement::Other { raw: line.to_string() }
+    NoirStatement::Other {
+        raw: line.to_string(),
+    }
 }
 
 fn extract_storage_field(line: &str) -> String {
@@ -312,7 +346,10 @@ mod tests {
     #[test]
     fn oversized_source_returns_error() {
         let big = "x".repeat(MAX_SOURCE_BYTES + 1);
-        assert!(matches!(parse_noir(&big), Err(NoirParseError::SourceTooLarge { .. })));
+        assert!(matches!(
+            parse_noir(&big),
+            Err(NoirParseError::SourceTooLarge { .. })
+        ));
     }
 
     #[test]
@@ -350,7 +387,10 @@ fn check(x: pub Field) {
 "#;
         let module = parse_noir(src).unwrap();
         let func = &module.functions["check"];
-        let has_assert = func.body.iter().any(|s| matches!(s, NoirStatement::Assert { .. }));
+        let has_assert = func
+            .body
+            .iter()
+            .any(|s| matches!(s, NoirStatement::Assert { .. }));
         assert!(has_assert);
     }
 
@@ -363,7 +403,10 @@ fn commit(secret: Field, blinding: Field) -> Field {
 "#;
         let module = parse_noir(src).unwrap();
         let func = &module.functions["commit"];
-        let has_hash = func.body.iter().any(|s| matches!(s, NoirStatement::HashCall { .. }));
+        let has_hash = func
+            .body
+            .iter()
+            .any(|s| matches!(s, NoirStatement::HashCall { .. }));
         assert!(has_hash);
     }
 
@@ -376,7 +419,10 @@ fn get_root(storage: Storage) -> Field {
 "#;
         let module = parse_noir(src).unwrap();
         let func = &module.functions["get_root"];
-        let has_read = func.body.iter().any(|s| matches!(s, NoirStatement::StorageRead { .. }));
+        let has_read = func
+            .body
+            .iter()
+            .any(|s| matches!(s, NoirStatement::StorageRead { .. }));
         assert!(has_read);
     }
 }

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -3,10 +3,10 @@
 //! Implement the [`Rule`] trait to create a custom check, then register it
 //! with [`RuleRegistry::register`].
 
-/// Arkworks ConstraintSynthesizer circuit detection with Z007-adapted range-check analysis.
-pub mod arkworks_circuit;
 /// Unchecked arithmetic detection.
 pub mod arithmetic_overflow;
+/// Arkworks ConstraintSynthesizer circuit detection with Z007-adapted range-check analysis.
+pub mod arkworks_circuit;
 /// Missing authorization checks.
 pub mod auth_gap;
 /// Gas exhaustion risk from unbounded user-controlled loops (S031).
@@ -60,14 +60,20 @@ pub mod transfer_from_no_allowance;
 pub mod variable_shadowing;
 
 // ── Z-series: ZK / circom integration rules ──────────────────────────────────
-/// Z001 — ZK function with no constraint assertions (proof never checked).
-pub mod zk_missing_constraint;
-/// Z004 — Groth16/SNARK verifier call inside a skippable if/else branch.
-pub mod zk_verifier_skippable;
 /// Z005 — No nullifier-set check before processing a proof (double-spend risk).
 pub mod zk_double_spend_risk;
+/// Z004 — hardcoded trusted-setup material without ceremony provenance.
+pub mod zk_hardcoded_trusted_setup;
+/// Z001 — ZK function with no constraint assertions (proof never checked).
+pub mod zk_missing_constraint;
+/// Z003 — verifier public inputs omit a security-relevant value (proof malleability).
+pub mod zk_missing_public_input_binding;
+/// Z005 — storage-loaded verifying key used without an integrity check.
+pub mod zk_missing_vk_integrity_check;
 /// Z013 — ZK proof verification result discarded (ignored return value).
 pub mod zk_verification_result_ignored;
+/// Z004 — Groth16/SNARK verifier call inside a skippable if/else branch.
+pub mod zk_verifier_skippable;
 
 use serde::Serialize;
 use std::any::Any;
@@ -131,8 +137,12 @@ pub struct RuleViolation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub enum Severity {
+    /// Immediate, exploitable security risk — blocks CI.
+    Critical,
     /// Hard error — blocks CI.
     Error,
+    /// Significant security concern that should be fixed before mainnet.
+    High,
     /// Warning — should be addressed.
     Warning,
     /// Informational.
@@ -245,6 +255,10 @@ impl RuleRegistry {
         registry.register(zk_verifier_skippable::ZkVerifierSkippableRule::new());
         registry.register(zk_double_spend_risk::ZkDoubleSpendRiskRule::new());
         registry.register(zk_verification_result_ignored::ZkVerificationResultIgnoredRule::new());
+        // ── Z003 / Z004 / Z005 (#1199, #1200, #1201) ─────────────────────────
+        registry.register(zk_missing_public_input_binding::ZkMissingPublicInputBindingRule::new());
+        registry.register(zk_hardcoded_trusted_setup::ZkHardcodedTrustedSetupRule::new());
+        registry.register(zk_missing_vk_integrity_check::ZkMissingVkIntegrityCheckRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/src/rules/zk_hardcoded_trusted_setup.rs
+++ b/tooling/sanctifier-core/src/rules/zk_hardcoded_trusted_setup.rs
@@ -1,0 +1,366 @@
+//! Z004 — Unverified or hardcoded trusted-setup parameters ("toxic waste").
+//!
+//! Groth16 and comparable schemes require a trusted setup whose secret randomness
+//! — the "toxic waste" — must be provably destroyed. A verifying key baked into
+//! contract source with no pointer to a public ceremony transcript cannot be
+//! audited: nobody outside the deploying team can tell whether the trapdoor still
+//! exists. This rule flags *undocumented* setup material.
+//!
+//! It deliberately checks provenance only. Whether a referenced transcript is
+//! cryptographically sound is out of scope — that requires replaying the ceremony,
+//! not reading the contract.
+//!
+//! Detection runs over raw source text rather than the `syn` AST because ordinary
+//! `//` comments — the very thing that carries the provenance — are discarded
+//! during parsing.
+//!
+//! See `docs/rules/Z004.md`.
+
+use crate::rules::{Rule, RuleViolation, Severity};
+
+/// Uppercased fragments of constant names that denote trusted-setup material.
+const SETUP_NAME_FRAGMENTS: &[&str] = &[
+    "VERIFYING_KEY",
+    "VERIFICATION_KEY",
+    "VK_",
+    "_VK",
+    "PROVING_KEY",
+    "TRUSTED_SETUP",
+    "SETUP_PARAMS",
+    "ALPHA_G1",
+    "BETA_G2",
+    "GAMMA_G2",
+    "DELTA_G2",
+    "GAMMA_ABC",
+    "SRS_",
+    "_SRS",
+    "CRS_",
+    "_CRS",
+    "TAU_",
+    "POWERS_OF_TAU",
+];
+
+/// Lowercased markers that establish ceremony provenance in a comment block.
+const PROVENANCE_MARKERS: &[&str] = &[
+    "ceremony",
+    "transcript",
+    "attestation",
+    "powers of tau",
+    "powersoftau",
+    "ptau",
+    "phase2",
+    "phase 2",
+    "perpetual powers",
+    "trusted setup:",
+    "setup ceremony",
+    "mpc",
+    "contribution hash",
+];
+
+/// Z004 — hardcoded verifying-key material without ceremony provenance.
+pub struct ZkHardcodedTrustedSetupRule;
+
+impl ZkHardcodedTrustedSetupRule {
+    /// Create the rule.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ZkHardcodedTrustedSetupRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Does this line declare a `const`/`static` item?
+fn declaration_name(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let rest = trimmed
+        .strip_prefix("pub const ")
+        .or_else(|| trimmed.strip_prefix("pub static "))
+        .or_else(|| trimmed.strip_prefix("const "))
+        .or_else(|| trimmed.strip_prefix("static "))
+        .or_else(|| {
+            trimmed
+                .strip_prefix("pub(crate) const ")
+                .or_else(|| trimmed.strip_prefix("pub(crate) static "))
+        })?;
+    let name = rest.split(':').next()?.trim();
+    let name = name.split('=').next()?.trim();
+    if name.is_empty() || name.contains(char::is_whitespace) {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+/// Does the constant's name look like trusted-setup material?
+fn is_setup_name(name: &str) -> bool {
+    let upper = name.to_uppercase();
+    // Bare `VK` is a common shorthand and would not match the `VK_`/`_VK`
+    // fragments, so allow it explicitly.
+    if upper == "VK" || upper == "SRS" || upper == "CRS" {
+        return true;
+    }
+    SETUP_NAME_FRAGMENTS
+        .iter()
+        .any(|fragment| upper.contains(fragment))
+}
+
+/// Does the initializer look like raw key material (a byte/hex literal)?
+///
+/// `value` is the text from the `=` up to and including the terminating `;`,
+/// which may span several lines.
+fn looks_like_key_material(value: &str) -> bool {
+    let has_hex = value.contains("0x") || value.contains("0X");
+    let has_array = value.contains('[');
+    let long_hex_string = value
+        .split('"')
+        .any(|chunk| chunk.len() >= 32 && chunk.chars().all(|c| c.is_ascii_hexdigit()));
+
+    (has_array && (has_hex || value.matches(',').count() >= 3)) || long_hex_string
+}
+
+/// Walk backwards from `idx` collecting the contiguous comment/attribute block
+/// that immediately precedes the declaration.
+fn preceding_comment_block(lines: &[&str], idx: usize) -> String {
+    let mut block = Vec::new();
+    let mut cursor = idx;
+    while cursor > 0 {
+        cursor -= 1;
+        let trimmed = lines[cursor].trim();
+        if trimmed.starts_with("//")
+            || trimmed.starts_with("#[")
+            || trimmed.starts_with("*")
+            || trimmed.starts_with("/*")
+            || trimmed.ends_with("*/")
+        {
+            block.push(trimmed);
+        } else if trimmed.is_empty() && !block.is_empty() {
+            // A blank line inside a doc block is still part of it; a blank line
+            // before any comment means there is no adjacent documentation.
+            block.push(trimmed);
+        } else {
+            break;
+        }
+    }
+    block.reverse();
+    block.join("\n")
+}
+
+/// Phrases that turn a provenance marker into a statement that provenance is
+/// *absent*. "no ceremony transcript" must not read as documented provenance.
+const NEGATIONS: &[&str] = &[
+    "no ",
+    "not ",
+    "never ",
+    "without ",
+    "missing ",
+    "lacks ",
+    "lacking ",
+    "undocumented",
+    "unverified",
+    "absent",
+];
+
+/// Does a comment block carry ceremony provenance?
+///
+/// A marker only counts when it is not negated earlier on the same line, so a
+/// comment explaining that the key has *no* transcript does not suppress the
+/// finding.
+fn has_provenance(block: &str) -> bool {
+    block.lines().any(|line| {
+        let lower = line.to_lowercase();
+        PROVENANCE_MARKERS.iter().any(|marker| {
+            let Some(pos) = lower.find(marker) else {
+                return false;
+            };
+            let preceding = &lower[..pos];
+            !NEGATIONS.iter().any(|neg| preceding.contains(neg))
+        })
+    })
+}
+
+impl Rule for ZkHardcodedTrustedSetupRule {
+    fn name(&self) -> &str {
+        "hardcoded_trusted_setup"
+    }
+
+    fn description(&self) -> &str {
+        "Detects hardcoded verifying-key / trusted-setup material with no reference to an auditable ceremony transcript"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let lines: Vec<&str> = source.lines().collect();
+        let mut violations = Vec::new();
+
+        for (idx, line) in lines.iter().enumerate() {
+            let Some(name) = declaration_name(line) else {
+                continue;
+            };
+            if !is_setup_name(name) {
+                continue;
+            }
+
+            // Gather the initializer, which frequently wraps across many lines
+            // for a 256-byte key. Start after the `=` so that the `;` inside an
+            // array type such as `[u8; 32]` does not terminate the scan early.
+            let Some((_, first)) = line.split_once('=') else {
+                continue;
+            };
+            let mut value = String::from(first);
+            value.push('\n');
+            if !first.contains(';') {
+                for candidate in lines.iter().skip(idx + 1) {
+                    value.push_str(candidate);
+                    value.push('\n');
+                    if candidate.contains(';') {
+                        break;
+                    }
+                    // Guard against a runaway scan on a malformed file.
+                    if value.len() > 20_000 {
+                        break;
+                    }
+                }
+            }
+
+            if !looks_like_key_material(&value) {
+                continue;
+            }
+
+            let block = preceding_comment_block(&lines, idx);
+            if has_provenance(&block) {
+                continue;
+            }
+
+            violations.push(
+                RuleViolation::new(
+                    self.name(),
+                    Severity::Critical,
+                    format!(
+                        "Trusted-setup constant '{}' is hardcoded at line {} with no reference to a \
+                         public ceremony transcript. Without documented provenance there is no way \
+                         to audit whether the setup's toxic waste was destroyed, so the key cannot \
+                         be trusted for mainnet value.",
+                        name,
+                        idx + 1
+                    ),
+                    format!("{}:{}", name, idx + 1),
+                )
+                .with_suggestion(
+                    "Add a comment directly above the constant recording the ceremony provenance, \
+                     e.g. `// ceremony: perpetual powers-of-tau phase2, contribution #47, \
+                     transcript sha256 <hash>, https://ceremony.example/transcript.json`. \
+                     Alternatively load the verifying key from governance-controlled storage so it \
+                     can be rotated (Z010) and integrity-checked at each use (Z005)."
+                        .to_string(),
+                ),
+            );
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_undocumented_hardcoded_verifying_key() {
+        let rule = ZkHardcodedTrustedSetupRule::new();
+        let source = r#"
+const VK_ALPHA_G1: [u8; 8] = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33];
+
+impl Verifier {
+    pub fn verify(env: Env, proof: Vec<u8>) -> bool {
+        groth16_verify(&VK_ALPHA_G1, &proof)
+    }
+}
+"#;
+        let v = rule.check(source);
+        assert_eq!(v.len(), 1, "undocumented VK must fire once: {v:?}");
+        assert!(v[0].message.contains("VK_ALPHA_G1"));
+    }
+
+    #[test]
+    fn no_violation_when_ceremony_is_documented() {
+        let rule = ZkHardcodedTrustedSetupRule::new();
+        let source = r#"
+// ceremony: perpetual powers-of-tau phase2, contribution #47
+// transcript sha256: 3f7a...c19e
+// https://ceremony.example.org/transcripts/47.json
+const VK_ALPHA_G1: [u8; 8] = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33];
+"#;
+        assert!(
+            rule.check(source).is_empty(),
+            "documented ceremony must not fire"
+        );
+    }
+
+    #[test]
+    fn doc_comment_provenance_is_accepted() {
+        let rule = ZkHardcodedTrustedSetupRule::new();
+        let source = r#"
+/// Verifying key from the Hermez powersOfTau28 ceremony transcript.
+pub const VERIFYING_KEY: &[u8] = &[0x01, 0x02, 0x03, 0x04];
+"#;
+        assert!(rule.check(source).is_empty());
+    }
+
+    #[test]
+    fn ignores_unrelated_constants() {
+        let rule = ZkHardcodedTrustedSetupRule::new();
+        let source = r#"
+const MAX_ENTRIES: u32 = 100;
+const DEFAULT_SALT: [u8; 4] = [0x00, 0x01, 0x02, 0x03];
+"#;
+        assert!(rule.check(source).is_empty());
+    }
+
+    #[test]
+    fn ignores_setup_names_without_key_material() {
+        let rule = ZkHardcodedTrustedSetupRule::new();
+        // A storage key symbol, not the key itself.
+        let source = r#"
+const VK_STORAGE_KEY: &str = "VK";
+"#;
+        assert!(rule.check(source).is_empty());
+    }
+
+    #[test]
+    fn handles_multi_line_key_literals() {
+        let rule = ZkHardcodedTrustedSetupRule::new();
+        let source = r#"
+const TRUSTED_SETUP_PARAMS: [u8; 6] = [
+    0xaa, 0xbb,
+    0xcc, 0xdd,
+    0xee, 0xff,
+];
+"#;
+        let v = rule.check(source);
+        assert_eq!(v.len(), 1, "multi-line literal must still fire: {v:?}");
+    }
+
+    #[test]
+    fn negated_provenance_does_not_suppress_the_finding() {
+        let rule = ZkHardcodedTrustedSetupRule::new();
+        // A comment stating that provenance is missing is not provenance.
+        let source = r#"
+// VULNERABLE: key material with no ceremony reference anywhere near it.
+const VK_ALPHA_G1: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+"#;
+        let v = rule.check(source);
+        assert_eq!(v.len(), 1, "negated marker must still fire: {v:?}");
+    }
+
+    #[test]
+    fn empty_source_is_safe() {
+        assert!(ZkHardcodedTrustedSetupRule::new().check("").is_empty());
+    }
+}

--- a/tooling/sanctifier-core/src/rules/zk_missing_public_input_binding.rs
+++ b/tooling/sanctifier-core/src/rules/zk_missing_public_input_binding.rs
@@ -1,0 +1,453 @@
+//! Z003 — Missing public-input binding (proof malleability).
+//!
+//! A ZK proof only attests to the statement encoded in its *public inputs*. If a
+//! verifier call site passes a public-input vector that omits a security-relevant
+//! runtime value — the recipient address, the transfer amount, the caller — then a
+//! proof that was valid for one transaction is equally valid for another. An
+//! attacker replays the proof with an attacker-favourable value for the unbound
+//! parameter and redirects the effect.
+//!
+//! Detection is a heuristic, contract-side dataflow check. For each function that
+//! calls a verifier we:
+//!
+//! 1. collect the expressions passed to the verifier as public inputs,
+//! 2. transitively expand any local `let` bindings those expressions reference,
+//!    so `let h = hash_address(&env, &recipient); verify(.., &vec![h])` counts as
+//!    binding `recipient`,
+//! 3. collect security-relevant function parameters that are still *used* after
+//!    the verifier call, and
+//! 4. flag the ones that never made it into the public inputs.
+//!
+//! See `docs/rules/Z003.md`.
+
+use std::collections::{BTreeSet, HashMap};
+
+use crate::rules::{Rule, RuleViolation, Severity};
+use syn::{parse_str, punctuated::Punctuated, token::Comma, Expr, File, FnArg, Item, Pat, Stmt};
+
+/// Function names that perform on-chain proof verification.
+const VERIFIER_FNS: &[&str] = &[
+    "verify_proof",
+    "groth16_verify",
+    "verify_groth16",
+    "snark_verify",
+    "verify_snark",
+    "plonk_verify",
+    "verify_plonk",
+    "verify_zk_proof",
+];
+
+/// Parameter-name fragments that denote a value an attacker would want to swap.
+/// Matching is done on the lowercased parameter name.
+const SECURITY_RELEVANT: &[&str] = &[
+    "recipient",
+    "receiver",
+    "beneficiary",
+    "amount",
+    "value",
+    "caller",
+    "destination",
+    "to_account",
+    "payee",
+];
+
+/// Parameter names that are plumbing, never a binding target.
+const IGNORED_PARAMS: &[&str] = &["env", "e", "proof", "public_inputs", "pub_inputs", "inputs"];
+
+/// Z003 — verifier call whose public inputs omit a security-relevant value.
+pub struct ZkMissingPublicInputBindingRule;
+
+impl ZkMissingPublicInputBindingRule {
+    /// Create the rule.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ZkMissingPublicInputBindingRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Lowercase token soup for an arbitrary syn node.
+fn tokens_of<T: quote::ToTokens>(node: &T) -> String {
+    quote::quote!(#node).to_string()
+}
+
+/// Split a token string into bare identifiers.
+fn identifiers(tokens: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut current = String::new();
+    for ch in tokens.chars() {
+        if ch.is_alphanumeric() || ch == '_' {
+            current.push(ch);
+        } else if !current.is_empty() {
+            out.insert(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        out.insert(current);
+    }
+    out
+}
+
+/// True when this call expression targets one of the known verifier functions.
+fn verifier_call_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Call(call) => {
+            let path = tokens_of(&*call.func);
+            VERIFIER_FNS
+                .iter()
+                .find(|name| path.contains(*name))
+                .map(|name| (*name).to_string())
+        }
+        Expr::MethodCall(mc) => {
+            let name = mc.method.to_string();
+            VERIFIER_FNS
+                .iter()
+                .find(|candidate| name.contains(*candidate))
+                .map(|candidate| (*candidate).to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Find the first verifier call anywhere inside an expression, returning its
+/// argument list.
+fn find_verifier_args(expr: &Expr) -> Option<(String, Punctuated<Expr, Comma>)> {
+    if let Some(name) = verifier_call_name(expr) {
+        let args = match expr {
+            Expr::Call(call) => call.args.clone(),
+            Expr::MethodCall(mc) => mc.args.clone(),
+            _ => Punctuated::new(),
+        };
+        return Some((name, args));
+    }
+
+    // Recurse through the common wrappers: `verify(..).expect(..)`, `!verify(..)`,
+    // `if verify(..) { .. }`, `let ok = verify(..);`.
+    match expr {
+        Expr::MethodCall(mc) => find_verifier_args(&mc.receiver),
+        Expr::Try(t) => find_verifier_args(&t.expr),
+        Expr::Unary(u) => find_verifier_args(&u.expr),
+        Expr::Paren(p) => find_verifier_args(&p.expr),
+        Expr::Reference(r) => find_verifier_args(&r.expr),
+        Expr::Binary(b) => find_verifier_args(&b.left).or_else(|| find_verifier_args(&b.right)),
+        Expr::Macro(m) => {
+            // assert!(verify_proof(..)) — fall back to a token scan.
+            let toks = tokens_of(m);
+            if VERIFIER_FNS.iter().any(|f| toks.contains(f)) {
+                Some((
+                    VERIFIER_FNS
+                        .iter()
+                        .find(|f| toks.contains(*f))
+                        .map(|f| (*f).to_string())
+                        .unwrap_or_default(),
+                    Punctuated::new(),
+                ))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Collect `let name = <expr>;` bindings from a statement list, keyed by name.
+fn local_bindings(stmts: &[Stmt]) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for stmt in stmts {
+        if let Stmt::Local(local) = stmt {
+            let name = match &local.pat {
+                Pat::Ident(id) => id.ident.to_string(),
+                Pat::Type(pt) => match &*pt.pat {
+                    Pat::Ident(id) => id.ident.to_string(),
+                    _ => continue,
+                },
+                _ => continue,
+            };
+            if let Some(init) = &local.init {
+                map.insert(name, tokens_of(&*init.expr));
+            }
+        }
+    }
+    map
+}
+
+/// Expand `seed` identifiers through local `let` bindings, up to a fixed depth,
+/// so indirect binding (`let h = hash(&recipient)`) still counts.
+fn expand_through_bindings(
+    seed: BTreeSet<String>,
+    bindings: &HashMap<String, String>,
+) -> BTreeSet<String> {
+    let mut resolved = seed;
+    // Depth cap keeps this linear on pathological inputs; 8 hops is far beyond
+    // anything a readable verifier entry point needs.
+    for _ in 0..8 {
+        let mut added = BTreeSet::new();
+        for ident in &resolved {
+            if let Some(init) = bindings.get(ident) {
+                for nested in identifiers(init) {
+                    if !resolved.contains(&nested) {
+                        added.insert(nested);
+                    }
+                }
+            }
+        }
+        if added.is_empty() {
+            break;
+        }
+        resolved.extend(added);
+    }
+    resolved
+}
+
+/// Security-relevant parameters of a function signature, in declaration order.
+fn security_relevant_params(sig: &syn::Signature) -> Vec<String> {
+    let mut params = Vec::new();
+    for arg in &sig.inputs {
+        let FnArg::Typed(pt) = arg else { continue };
+        let Pat::Ident(id) = &*pt.pat else { continue };
+        let name = id.ident.to_string();
+        let lower = name.to_lowercase();
+
+        if IGNORED_PARAMS.contains(&lower.as_str()) {
+            continue;
+        }
+
+        let ty = tokens_of(&*pt.ty);
+        let name_matches = SECURITY_RELEVANT
+            .iter()
+            .any(|fragment| lower.contains(fragment));
+        // An `Address` parameter is a binding target regardless of its name —
+        // it is the classic redirect vector.
+        let type_matches = ty.contains("Address");
+
+        if name_matches || type_matches {
+            params.push(name);
+        }
+    }
+    params
+}
+
+/// Analyse one function body, returning the unbound parameter names (if any).
+fn unbound_params(sig: &syn::Signature, stmts: &[Stmt]) -> Vec<String> {
+    let candidates = security_relevant_params(sig);
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    // Locate the verifier call and capture its arguments.
+    let mut verify_idx = None;
+    let mut verifier_args: Punctuated<Expr, Comma> = Punctuated::new();
+    for (idx, stmt) in stmts.iter().enumerate() {
+        let expr = match stmt {
+            Stmt::Expr(e, _) => Some(e.clone()),
+            Stmt::Local(local) => local.init.as_ref().map(|i| (*i.expr).clone()),
+            _ => None,
+        };
+        if let Some(expr) = expr {
+            if let Some((_, args)) = find_verifier_args(&expr) {
+                verify_idx = Some(idx);
+                verifier_args = args;
+                break;
+            }
+        }
+    }
+
+    let Some(verify_idx) = verify_idx else {
+        return Vec::new();
+    };
+
+    let bindings = local_bindings(stmts);
+
+    // Everything reachable from the verifier's arguments is "bound".
+    let mut bound_seed = BTreeSet::new();
+    for arg in &verifier_args {
+        bound_seed.extend(identifiers(&tokens_of(arg)));
+    }
+    let bound = expand_through_bindings(bound_seed, &bindings);
+
+    // A parameter only matters if the function still acts on it after the proof
+    // was checked — that is where the redirect happens.
+    let mut used_after = BTreeSet::new();
+    for stmt in stmts.iter().skip(verify_idx + 1) {
+        used_after.extend(identifiers(&tokens_of(stmt)));
+    }
+
+    candidates
+        .into_iter()
+        .filter(|param| used_after.contains(param) && !bound.contains(param))
+        .collect()
+}
+
+impl Rule for ZkMissingPublicInputBindingRule {
+    fn name(&self) -> &str {
+        "missing_public_input_binding"
+    }
+
+    fn description(&self) -> &str {
+        "Detects verifier calls whose public inputs omit a security-relevant value used after verification (proof malleability)"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file: File = match parse_str(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+
+        for item in &file.items {
+            let Item::Impl(impl_block) = item else {
+                continue;
+            };
+            for impl_item in &impl_block.items {
+                let syn::ImplItem::Fn(f) = impl_item else {
+                    continue;
+                };
+                let unbound = unbound_params(&f.sig, &f.block.stmts);
+                if unbound.is_empty() {
+                    continue;
+                }
+
+                let fn_name = f.sig.ident.to_string();
+                violations.push(
+                    RuleViolation::new(
+                        self.name(),
+                        Severity::Critical,
+                        format!(
+                            "Function '{}' verifies a ZK proof but does not bind {} to the public \
+                             inputs. A valid proof can be replayed with a different value for {}, \
+                             redirecting the operation.",
+                            fn_name,
+                            quoted_list(&unbound),
+                            if unbound.len() == 1 { "it" } else { "them" },
+                        ),
+                        fn_name,
+                    )
+                    .with_suggestion(format!(
+                        "Include {} in the public-input vector passed to the verifier so the \
+                         circuit commits to this transaction's context. Hash non-field values \
+                         (e.g. an Address) into a field element first, and use the same encoding \
+                         the circuit expects.",
+                        quoted_list(&unbound)
+                    )),
+                );
+            }
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Render `["a", "b"]` as `'a', 'b'` for message text.
+fn quoted_list(items: &[String]) -> String {
+    items
+        .iter()
+        .map(|i| format!("'{i}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_recipient_used_after_verify_but_not_in_public_inputs() {
+        let rule = ZkMissingPublicInputBindingRule::new();
+        let source = r#"
+            impl Shielded {
+                pub fn withdraw(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
+                    let public_inputs = vec![&env, amount as u64];
+                    verify_proof(&env, &proof, &public_inputs);
+                    token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert_eq!(v.len(), 1, "unbound recipient must fire exactly once");
+        assert!(v[0].message.contains("withdraw"));
+        assert!(v[0].message.contains("recipient"));
+    }
+
+    #[test]
+    fn no_violation_when_recipient_is_bound_indirectly() {
+        let rule = ZkMissingPublicInputBindingRule::new();
+        let source = r#"
+            impl Shielded {
+                pub fn withdraw(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
+                    let recipient_hash = hash_address(&env, &recipient);
+                    let public_inputs = vec![&env, recipient_hash, amount as u64];
+                    verify_proof(&env, &proof, &public_inputs);
+                    token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert!(
+            v.is_empty(),
+            "indirect binding via a hash must not fire: {v:?}"
+        );
+    }
+
+    #[test]
+    fn no_violation_when_value_passed_directly_to_verifier() {
+        let rule = ZkMissingPublicInputBindingRule::new();
+        let source = r#"
+            impl Shielded {
+                pub fn claim(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
+                    groth16_verify(&env, &proof, &recipient, &amount);
+                    do_transfer(&env, &recipient, &amount);
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert!(v.is_empty(), "direct binding must not fire: {v:?}");
+    }
+
+    #[test]
+    fn no_violation_when_value_is_unused_after_verification() {
+        let rule = ZkMissingPublicInputBindingRule::new();
+        let source = r#"
+            impl Shielded {
+                pub fn attest(env: Env, proof: Vec<u64>, recipient: Address) {
+                    let public_inputs = vec![&env, 1u64];
+                    verify_proof(&env, &proof, &public_inputs);
+                    env.events().publish((symbol_short!("OK"),), 1u32);
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert!(
+            v.is_empty(),
+            "a value never used after verification cannot be redirected: {v:?}"
+        );
+    }
+
+    #[test]
+    fn no_violation_without_a_verifier_call() {
+        let rule = ZkMissingPublicInputBindingRule::new();
+        let source = r#"
+            impl Plain {
+                pub fn transfer(env: Env, recipient: Address, amount: i128) {
+                    token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+                }
+            }
+        "#;
+        assert!(rule.check(source).is_empty());
+    }
+
+    #[test]
+    fn empty_and_unparseable_source_is_safe() {
+        let rule = ZkMissingPublicInputBindingRule::new();
+        assert!(rule.check("").is_empty());
+        assert!(rule.check("this is not rust {{{").is_empty());
+    }
+}

--- a/tooling/sanctifier-core/src/rules/zk_missing_vk_integrity_check.rs
+++ b/tooling/sanctifier-core/src/rules/zk_missing_vk_integrity_check.rs
@@ -1,0 +1,334 @@
+//! Z005 — Missing verifying-key integrity check before use.
+//!
+//! Where the verifying key lives in mutable contract storage — because the design
+//! supports rotation — access control on the rotation function (Z010) is only half
+//! the defence. It answers "who may write the key", not "is the key currently
+//! stored the one we vetted". A storage-collision bug, an unrelated migration, or
+//! a compromised admin can leave a hostile key in place, and every subsequent
+//! `verify` silently accepts proofs forged under it.
+//!
+//! This rule flags verifier call sites that read the key from storage without a
+//! preceding hash comparison or signature check.
+//!
+//! Verifying keys held in `const`/`static` items are out of scope: they cannot be
+//! mutated at runtime, so a runtime integrity check is redundant by construction.
+//! (Their own risk — undocumented provenance — is Z004's job.)
+//!
+//! See `docs/rules/Z005.md`.
+
+use crate::rules::{Rule, RuleViolation, Severity};
+use syn::{parse_str, File, Item, Local, Pat, Stmt};
+
+/// Function names that perform on-chain proof verification.
+const VERIFIER_FNS: &[&str] = &[
+    "verify_proof",
+    "groth16_verify",
+    "verify_groth16",
+    "snark_verify",
+    "verify_snark",
+    "plonk_verify",
+    "verify_plonk",
+    "verify_zk_proof",
+];
+
+/// Lowercased fragments identifying a verifying-key value.
+const VK_FRAGMENTS: &[&str] = &[
+    "verifying_key",
+    "verification_key",
+    "verifyingkey",
+    "verificationkey",
+    "vk",
+];
+
+/// Hash / signature primitives that can implement an integrity gate.
+const INTEGRITY_PRIMITIVES: &[&str] = &[
+    "sha256",
+    "keccak256",
+    "blake2",
+    "hash",
+    "ed25519_verify",
+    "secp256k1_verify",
+    "verify_sig",
+];
+
+/// Tokens that indicate the hash is being *compared*, not merely computed.
+///
+/// Loading a reference hash out of storage is not a check — only an actual
+/// comparison or abort is. `.expect()` on a storage read is deliberately absent.
+/// Both spaced and unspaced punctuation forms are listed because token-stream
+/// rendering of `==` / `!=` is not guaranteed to be joint.
+const COMPARISON_TOKENS: &[&str] = &[
+    "assert_eq",
+    "assert_ne",
+    "assert !",
+    "assert!",
+    "==",
+    "= =",
+    "!=",
+    "! =",
+    "panic",
+    "require",
+];
+
+/// Z005 — storage-loaded verifying key used without an integrity check.
+pub struct ZkMissingVkIntegrityCheckRule;
+
+impl ZkMissingVkIntegrityCheckRule {
+    /// Create the rule.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ZkMissingVkIntegrityCheckRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Lowercased token soup for an arbitrary syn node.
+fn tokens_lower<T: quote::ToTokens>(node: &T) -> String {
+    quote::quote!(#node).to_string().to_lowercase()
+}
+
+/// Name bound by a `let` statement, if it is a simple identifier pattern.
+fn binding_name(local: &Local) -> Option<String> {
+    match &local.pat {
+        Pat::Ident(id) => Some(id.ident.to_string()),
+        Pat::Type(pt) => match &*pt.pat {
+            Pat::Ident(id) => Some(id.ident.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Does this text mention a verifying key?
+fn mentions_vk(text: &str) -> bool {
+    VK_FRAGMENTS.iter().any(|fragment| text.contains(fragment))
+}
+
+/// Does this text read from contract storage?
+fn reads_storage(text: &str) -> bool {
+    text.contains("storage")
+        && (text.contains(". get") || text.contains(".get") || text.contains("get ("))
+}
+
+/// Does this statement constitute an integrity gate — a hash/signature check whose
+/// result is actually compared or asserted?
+fn is_integrity_gate(text: &str) -> bool {
+    let has_primitive = INTEGRITY_PRIMITIVES.iter().any(|p| text.contains(p));
+    if !has_primitive {
+        return false;
+    }
+    let compares = COMPARISON_TOKENS
+        .iter()
+        .any(|token| text.contains(&token.to_lowercase()));
+    compares && mentions_vk(text)
+}
+
+/// Analyse one function body. Returns `true` when a storage-loaded verifying key
+/// reaches a verifier call with no integrity gate in between.
+fn is_vulnerable(stmts: &[Stmt]) -> bool {
+    let mut vk_from_storage: Option<String> = None;
+    let mut checked = false;
+
+    for stmt in stmts {
+        let text = tokens_lower(stmt);
+
+        // 1. Does this statement load the VK out of storage?
+        if vk_from_storage.is_none() {
+            if let Stmt::Local(local) = stmt {
+                let init_text = local
+                    .init
+                    .as_ref()
+                    .map(|i| tokens_lower(&*i.expr))
+                    .unwrap_or_default();
+                let name = binding_name(local).unwrap_or_default();
+                let name_lower = name.to_lowercase();
+                if reads_storage(&init_text)
+                    && (mentions_vk(&init_text) || mentions_vk(&name_lower))
+                {
+                    vk_from_storage = Some(name_lower);
+                    continue;
+                }
+            }
+        }
+
+        // 2. Is there an integrity gate before the verifier runs?
+        if vk_from_storage.is_some() && !checked && is_integrity_gate(&text) {
+            checked = true;
+            continue;
+        }
+
+        // 3. Does the verifier run on that key?
+        let calls_verifier = VERIFIER_FNS.iter().any(|f| text.contains(f));
+        if calls_verifier {
+            if let Some(vk_name) = &vk_from_storage {
+                // Inline load: `groth16_verify(env.storage()...get(&VK), ..)`.
+                let uses_vk = vk_name.is_empty() || text.contains(vk_name.as_str());
+                if uses_vk && !checked {
+                    return true;
+                }
+            } else if reads_storage(&text) && mentions_vk(&text) && !checked {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+impl Rule for ZkMissingVkIntegrityCheckRule {
+    fn name(&self) -> &str {
+        "missing_vk_integrity_check"
+    }
+
+    fn description(&self) -> &str {
+        "Detects verifier calls that use a storage-loaded verifying key without checking its integrity against a known-good hash"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file: File = match parse_str(source) {
+            Ok(f) => f,
+            Err(_) => return vec![],
+        };
+
+        let mut violations = Vec::new();
+
+        for item in &file.items {
+            let Item::Impl(impl_block) = item else {
+                continue;
+            };
+            for impl_item in &impl_block.items {
+                let syn::ImplItem::Fn(f) = impl_item else {
+                    continue;
+                };
+                if !is_vulnerable(&f.block.stmts) {
+                    continue;
+                }
+
+                let fn_name = f.sig.ident.to_string();
+                violations.push(
+                    RuleViolation::new(
+                        self.name(),
+                        Severity::High,
+                        format!(
+                            "Function '{}' loads the verifying key from mutable storage and passes it \
+                             to the verifier without checking its integrity. If the stored key is ever \
+                             swapped — by a compromised admin, a storage-key collision, or a migration \
+                             bug — every proof verified here is forgeable.",
+                            fn_name
+                        ),
+                        fn_name,
+                    )
+                    .with_suggestion(
+                        "Commit a reference hash of the vetted verifying key at deployment, then hash \
+                         the storage-loaded key and assert equality before calling the verifier, e.g. \
+                         `assert_eq!(env.crypto().sha256(&vk_bytes), expected_vk_hash);`. Update the \
+                         reference hash in the same transaction as any authorised rotation (Z010)."
+                            .to_string(),
+                    ),
+                );
+            }
+        }
+
+        violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flags_storage_loaded_vk_without_check() {
+        let rule = ZkMissingVkIntegrityCheckRule::new();
+        let source = r#"
+            impl Verifier {
+                pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+                    let vk: BytesN<64> = env.storage().persistent().get(&DataKey::VerifyingKey).unwrap();
+                    groth16_verify(vk.as_ref(), &proof, &inputs)
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert_eq!(v.len(), 1, "unchecked storage VK must fire: {v:?}");
+        assert!(v[0].message.contains("verify"));
+    }
+
+    #[test]
+    fn no_violation_when_hash_is_asserted() {
+        let rule = ZkMissingVkIntegrityCheckRule::new();
+        let source = r#"
+            impl Verifier {
+                pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+                    let vk: BytesN<64> = env.storage().persistent().get(&DataKey::VerifyingKey).unwrap();
+                    let expected: BytesN<32> = env.storage().persistent().get(&DataKey::VkHash).unwrap();
+                    assert_eq!(env.crypto().sha256(&Bytes::from_slice(&env, vk.as_ref())), expected, "vk integrity");
+                    groth16_verify(vk.as_ref(), &proof, &inputs)
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert!(v.is_empty(), "checked storage VK must not fire: {v:?}");
+    }
+
+    #[test]
+    fn no_violation_for_constant_vk() {
+        let rule = ZkMissingVkIntegrityCheckRule::new();
+        let source = r#"
+            impl Verifier {
+                pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+                    groth16_verify(VERIFYING_KEY, &proof, &inputs)
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert!(
+            v.is_empty(),
+            "an immutable constant key needs no runtime check: {v:?}"
+        );
+    }
+
+    #[test]
+    fn flags_inline_storage_read_in_verifier_call() {
+        let rule = ZkMissingVkIntegrityCheckRule::new();
+        let source = r#"
+            impl Verifier {
+                pub fn verify_inline(env: Env, proof: Vec<u8>) -> bool {
+                    groth16_verify(
+                        env.storage().persistent().get(&DataKey::VerifyingKey).unwrap(),
+                        &proof,
+                    )
+                }
+            }
+        "#;
+        let v = rule.check(source);
+        assert_eq!(v.len(), 1, "inline storage read must fire: {v:?}");
+    }
+
+    #[test]
+    fn no_violation_without_verifier_call() {
+        let rule = ZkMissingVkIntegrityCheckRule::new();
+        let source = r#"
+            impl Verifier {
+                pub fn get_vk(env: Env) -> BytesN<64> {
+                    env.storage().persistent().get(&DataKey::VerifyingKey).unwrap()
+                }
+            }
+        "#;
+        assert!(rule.check(source).is_empty());
+    }
+
+    #[test]
+    fn empty_and_unparseable_source_is_safe() {
+        let rule = ZkMissingVkIntegrityCheckRule::new();
+        assert!(rule.check("").is_empty());
+        assert!(rule.check("not rust @@@").is_empty());
+    }
+}

--- a/tooling/sanctifier-core/tests/rule_engine_orchestration_test.rs
+++ b/tooling/sanctifier-core/tests/rule_engine_orchestration_test.rs
@@ -226,8 +226,14 @@ fn every_violation_has_a_valid_severity() {
     let reg = registry();
     let violations = reg.run_all(MULTI_ISSUE_CONTRACT);
     // The point here is that no violation has an unrecognised/panicking severity.
-    // Asserting all three variants are representable.
-    let valid = [Severity::Error, Severity::Warning, Severity::Info];
+    // Asserting all variants are representable.
+    let valid = [
+        Severity::Critical,
+        Severity::Error,
+        Severity::High,
+        Severity::Warning,
+        Severity::Info,
+    ];
     for v in &violations {
         assert!(
             valid.contains(&v.severity),

--- a/tooling/sanctifier-core/tests/sarif_snapshots.rs
+++ b/tooling/sanctifier-core/tests/sarif_snapshots.rs
@@ -23,10 +23,12 @@ use sanctifier_core::rules::{
     unhandled_result::UnhandledResultRule, unsafe_prng::UnsafePrngRule,
     unused_variable::UnusedVariableRule, variable_shadowing::VariableShadowingRule,
     zk_double_spend_risk::ZkDoubleSpendRiskRule,
+    zk_hardcoded_trusted_setup::ZkHardcodedTrustedSetupRule,
     zk_missing_constraint::ZkMissingConstraintRule,
+    zk_missing_public_input_binding::ZkMissingPublicInputBindingRule,
+    zk_missing_vk_integrity_check::ZkMissingVkIntegrityCheckRule,
     zk_verification_result_ignored::ZkVerificationResultIgnoredRule,
-    zk_verifier_skippable::ZkVerifierSkippableRule, Rule,
-    RuleViolation,
+    zk_verifier_skippable::ZkVerifierSkippableRule, Rule, RuleViolation,
 };
 
 // ── Helper ────────────────────────────────────────────────────────────────────
@@ -493,7 +495,10 @@ fn sarif_zk_verification_result_ignored_trigger() {
     "#;
     let rule = ZkVerificationResultIgnoredRule::new();
     let violations = rule.check(source);
-    assert!(!violations.is_empty(), "zk_verification_result_ignored must fire");
+    assert!(
+        !violations.is_empty(),
+        "zk_verification_result_ignored must fire"
+    );
     with_settings!({ sort_maps => true }, {
         insta::assert_json_snapshot!("zk_verification_result_ignored_trigger", violations_json(&violations));
     });
@@ -513,5 +518,159 @@ fn sarif_zk_verification_result_ignored_clean() {
     let violations = rule.check(source);
     with_settings!({ sort_maps => true }, {
         insta::assert_json_snapshot!("zk_verification_result_ignored_clean", violations_json(&violations));
+    });
+}
+
+// ── Z003 / Z004 / Z005 (#1199, #1200, #1201) ─────────────────────────────────
+//
+// These run against the checked-in fixtures rather than inline snippets, so a
+// fixture and its rule cannot drift apart silently.
+
+/// Load a fixture from `contracts/fixtures/finding-codes/`.
+fn fixture(name: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../contracts/fixtures/finding-codes")
+        .join(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read fixture {}: {e}", path.display()))
+}
+
+/// The function names a rule fired on, sorted for stable comparison.
+fn flagged_fns(violations: &[RuleViolation]) -> Vec<String> {
+    let mut names: Vec<String> = violations
+        .iter()
+        .map(|v| v.location.split(':').next().unwrap_or("").to_string())
+        .collect();
+    names.sort();
+    names
+}
+
+// ── Z003: missing_public_input_binding ───────────────────────────────────────
+
+#[test]
+fn sarif_z003_missing_public_input_binding_fixture() {
+    let source = fixture("z003_missing_public_input_binding.rs");
+    let violations = ZkMissingPublicInputBindingRule::new().check(&source);
+
+    // Only the unbound-recipient function may fire; the three safe variants
+    // (hash-bound, directly bound, and value-unused-after-verify) must not.
+    assert_eq!(
+        flagged_fns(&violations),
+        vec!["withdraw_vulnerable"],
+        "Z003 flagged the wrong set of functions: {violations:?}"
+    );
+
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!(
+            "z003_missing_public_input_binding_trigger",
+            violations_json(&violations)
+        );
+    });
+}
+
+#[test]
+fn sarif_z003_clean() {
+    let source = r#"
+        impl Shielded {
+            pub fn withdraw(env: Env, proof: Vec<u64>, recipient: Address, amount: i128) {
+                let recipient_hash = hash_address(&env, &recipient);
+                let public_inputs = vec![&env, recipient_hash, amount as u64];
+                verify_proof(&env, &proof, &public_inputs);
+                token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+            }
+        }
+    "#;
+    let violations = ZkMissingPublicInputBindingRule::new().check(source);
+    assert!(violations.is_empty(), "bound inputs must not fire");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!(
+            "z003_missing_public_input_binding_clean",
+            violations_json(&violations)
+        );
+    });
+}
+
+// ── Z004: hardcoded_trusted_setup ────────────────────────────────────────────
+
+#[test]
+fn sarif_z004_unverified_trusted_setup_fixture() {
+    let source = fixture("z004_unverified_trusted_setup.rs");
+    let violations = ZkHardcodedTrustedSetupRule::new().check(&source);
+
+    // The two undocumented constants fire; the ceremony-documented keys, the
+    // storage-key string, and the unrelated limit must not.
+    assert_eq!(
+        flagged_fns(&violations),
+        vec!["TRUSTED_SETUP_PARAMS", "VK_ALPHA_G1_UNDOCUMENTED"],
+        "Z004 flagged the wrong set of constants: {violations:?}"
+    );
+
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!(
+            "z004_unverified_trusted_setup_trigger",
+            violations_json(&violations)
+        );
+    });
+}
+
+#[test]
+fn sarif_z004_clean() {
+    let source = "\
+// ceremony: perpetual powers-of-tau phase2, contribution #47
+// transcript sha256: 3f7a1c04e5b28d9f6a1103bb77c4e2d5081aa93cf4be6710d2ac5f38e91b7c19
+const VERIFYING_KEY: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
+";
+    let violations = ZkHardcodedTrustedSetupRule::new().check(source);
+    assert!(violations.is_empty(), "documented ceremony must not fire");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!(
+            "z004_unverified_trusted_setup_clean",
+            violations_json(&violations)
+        );
+    });
+}
+
+// ── Z005: missing_vk_integrity_check ─────────────────────────────────────────
+
+#[test]
+fn sarif_z005_missing_vk_integrity_check_fixture() {
+    let source = fixture("z005_missing_vk_integrity_check.rs");
+    let violations = ZkMissingVkIntegrityCheckRule::new().check(&source);
+
+    // Both unchecked storage-loaded paths fire; the hash-asserted path, the
+    // immutable constant key, and the plain getter must not.
+    assert_eq!(
+        flagged_fns(&violations),
+        vec!["verify_inline_vulnerable", "verify_vulnerable"],
+        "Z005 flagged the wrong set of functions: {violations:?}"
+    );
+
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!(
+            "z005_missing_vk_integrity_check_trigger",
+            violations_json(&violations)
+        );
+    });
+}
+
+#[test]
+fn sarif_z005_clean() {
+    let source = r#"
+        impl Verifier {
+            pub fn verify(env: Env, proof: Vec<u8>, inputs: Vec<u64>) -> bool {
+                let vk: BytesN<64> = env.storage().persistent().get(&DataKey::VerifyingKey).unwrap();
+                let expected: BytesN<32> = env.storage().persistent().get(&DataKey::VkHash).unwrap();
+                assert_eq!(env.crypto().sha256(&Bytes::from_slice(&env, vk.as_ref())), expected, "vk integrity");
+                groth16_verify(vk.as_ref(), &proof, &inputs)
+            }
+        }
+    "#;
+    let violations = ZkMissingVkIntegrityCheckRule::new().check(source);
+    assert!(violations.is_empty(), "checked VK must not fire");
+    with_settings!({ sort_maps => true }, {
+        insta::assert_json_snapshot!(
+            "z005_missing_vk_integrity_check_clean",
+            violations_json(&violations)
+        );
     });
 }

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z003_missing_public_input_binding_clean.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z003_missing_public_input_binding_clean.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z003_missing_public_input_binding_trigger.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z003_missing_public_input_binding_trigger.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[
+  {
+    "location": "withdraw_vulnerable",
+    "message": "Function 'withdraw_vulnerable' verifies a ZK proof but does not bind 'recipient' to the public inputs. A valid proof can be replayed with a different value for it, redirecting the operation.",
+    "rule_name": "missing_public_input_binding",
+    "severity": "Critical",
+    "suggestion": "Include 'recipient' in the public-input vector passed to the verifier so the circuit commits to this transaction's context. Hash non-field values (e.g. an Address) into a field element first, and use the same encoding the circuit expects."
+  }
+]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z004_unverified_trusted_setup_clean.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z004_unverified_trusted_setup_clean.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z004_unverified_trusted_setup_trigger.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z004_unverified_trusted_setup_trigger.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[
+  {
+    "location": "VK_ALPHA_G1_UNDOCUMENTED",
+    "message": "Trusted-setup constant 'VK_ALPHA_G1_UNDOCUMENTED' is hardcoded at line 25 with no reference to a public ceremony transcript. Without documented provenance there is no way to audit whether the setup's toxic waste was destroyed, so the key cannot be trusted for mainnet value.",
+    "rule_name": "hardcoded_trusted_setup",
+    "severity": "Critical",
+    "suggestion": "Add a comment directly above the constant recording the ceremony provenance, e.g. `// ceremony: perpetual powers-of-tau phase2, contribution #47, transcript sha256 <hash>, https://ceremony.example/transcript.json`. Alternatively load the verifying key from governance-controlled storage so it can be rotated (Z010) and integrity-checked at each use (Z005)."
+  },
+  {
+    "location": "TRUSTED_SETUP_PARAMS",
+    "message": "Trusted-setup constant 'TRUSTED_SETUP_PARAMS' is hardcoded at line 31 with no reference to a public ceremony transcript. Without documented provenance there is no way to audit whether the setup's toxic waste was destroyed, so the key cannot be trusted for mainnet value.",
+    "rule_name": "hardcoded_trusted_setup",
+    "severity": "Critical",
+    "suggestion": "Add a comment directly above the constant recording the ceremony provenance, e.g. `// ceremony: perpetual powers-of-tau phase2, contribution #47, transcript sha256 <hash>, https://ceremony.example/transcript.json`. Alternatively load the verifying key from governance-controlled storage so it can be rotated (Z010) and integrity-checked at each use (Z005)."
+  }
+]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z005_missing_vk_integrity_check_clean.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z005_missing_vk_integrity_check_clean.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z005_missing_vk_integrity_check_trigger.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__z005_missing_vk_integrity_check_trigger.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[
+  {
+    "location": "verify_vulnerable",
+    "message": "Function 'verify_vulnerable' loads the verifying key from mutable storage and passes it to the verifier without checking its integrity. If the stored key is ever swapped — by a compromised admin, a storage-key collision, or a migration bug — every proof verified here is forgeable.",
+    "rule_name": "missing_vk_integrity_check",
+    "severity": "High",
+    "suggestion": "Commit a reference hash of the vetted verifying key at deployment, then hash the storage-loaded key and assert equality before calling the verifier, e.g. `assert_eq!(env.crypto().sha256(&vk_bytes), expected_vk_hash);`. Update the reference hash in the same transaction as any authorised rotation (Z010)."
+  },
+  {
+    "location": "verify_inline_vulnerable",
+    "message": "Function 'verify_inline_vulnerable' loads the verifying key from mutable storage and passes it to the verifier without checking its integrity. If the stored key is ever swapped — by a compromised admin, a storage-key collision, or a migration bug — every proof verified here is forgeable.",
+    "rule_name": "missing_vk_integrity_check",
+    "severity": "High",
+    "suggestion": "Commit a reference hash of the vetted verifying key at deployment, then hash the storage-loaded key and assert equality before calling the verifier, e.g. `assert_eq!(env.crypto().sha256(&vk_bytes), expected_vk_hash);`. Update the reference hash in the same transaction as any authorised rotation (Z010)."
+  }
+]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_double_spend_risk_clean.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_double_spend_risk_clean.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_double_spend_risk_trigger.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_double_spend_risk_trigger.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[
+  {
+    "location": "withdraw",
+    "message": "Function 'withdraw' verifies a ZK proof but never checks a nullifier set. The same valid proof can be replayed to drain funds multiple times.",
+    "rule_name": "zk_double_spend_risk",
+    "severity": "Critical",
+    "suggestion": "Before processing a proof, load the nullifier from storage and assert it has not been used. After successful verification, mark the nullifier as spent. Use persistent storage so the nullifier set survives ledger compaction."
+  }
+]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_missing_constraint_clean.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_missing_constraint_clean.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_missing_constraint_trigger.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_missing_constraint_trigger.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[
+  {
+    "location": "withdraw",
+    "message": "Function 'withdraw' accepts a ZK proof parameter but has no constraint assertions. Without constraint checks the proof is never verified and the function is trivially exploitable.",
+    "rule_name": "zk_missing_constraint",
+    "severity": "Critical",
+    "suggestion": "Call verify_proof() or assert the proof is valid before processing any state changes. Every ZK-gated function must verify the proof on-chain before trusting its public inputs."
+  }
+]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verification_result_ignored_clean.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verification_result_ignored_clean.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verification_result_ignored_trigger.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verification_result_ignored_trigger.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[
+  {
+    "location": "execute",
+    "message": "Function 'execute' calls a ZK verifier but discards the result. A failing proof is silently ignored and execution continues.",
+    "rule_name": "zk_verification_result_ignored",
+    "severity": "Critical",
+    "suggestion": "Always propagate the verifier result with `.expect(\"invalid proof\")`, the `?` operator, or an explicit match that panics or returns an error on verification failure."
+  }
+]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verifier_skippable_clean.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verifier_skippable_clean.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verifier_skippable_trigger.snap
+++ b/tooling/sanctifier-core/tests/snapshots/sarif_snapshots__zk_verifier_skippable_trigger.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/sanctifier-core/tests/sarif_snapshots.rs
+expression: violations_json(&violations)
+---
+[
+  {
+    "location": "transfer",
+    "message": "Function 'transfer' calls the ZK verifier inside an if-branch that has an else path — an attacker can route execution around proof verification.",
+    "rule_name": "zk_verifier_skippable",
+    "severity": "Critical",
+    "suggestion": "Move the verifier call unconditionally before any branching logic. The proof must always be verified; use early-return on failure rather than an if/else that skips verification entirely."
+  }
+]


### PR DESCRIPTION


Rules
-----
Z003 missing_public_input_binding — flags verifier call sites where a security-relevant runtime value (recipient, amount, caller, or any Address parameter) is used after verification but never reaches the public inputs, so a valid proof can be replayed with attacker-chosen inputs. Public-input expressions are expanded transitively through local `let` bindings, so binding via a hash (`let h = hash_address(&env, &recipient)`) counts.

Z004 hardcoded_trusted_setup — flags hardcoded verifying-key / trusted-setup material with no adjacent comment referencing a ceremony transcript. Runs over raw source rather than the AST, because `//` comments — the thing carrying the provenance — are dropped during parsing. A negated marker ("no ceremony transcript for this key") does not count as provenance.

Z005 missing_vk_integrity_check — flags a verifying key read from mutable storage and passed to the verifier with no hash comparison in between. Constant keys are out of scope by construction; merely reading the reference hash is not a gate, the comparison has to happen.

Each ships with a fixture under contracts/fixtures/finding-codes/ and snapshot tests that assert the exact set of functions/constants flagged, so a fixture and its rule cannot drift apart silently.

Roadmap (#1196)
---------------
docs/zk-roadmap.md summarises the wave's ZK scope: per-rule detector status (five of fourteen have detectors today, the rest are documented), toolchain support, example contracts, CLI/dashboard coverage, and what is explicitly deferred — additional toolchains, deeper circuit analysis, formal verification for circuits, ceremony verification. Linked from README and cross-referenced from the fixtures index and the ZK integration guide.

Incidental fixes required to get here
-------------------------------------
main did not compile: the Z-rules merged in 3e9a8bc reference Severity::Critical and Severity::High, which the enum did not have. Added both variants (the enum is already #[non_exhaustive]) and extended the SARIF level mapping and the orchestration test's valid-severity set. Also fixed an ambiguous integer type in noir_parser.

Two tests from that merge had never run and were failing:
- noir_parser read visibility as `pub name: Type`; Noir writes `name: pub Type`.
- circom_parser fed comments into the constrained-signal scan, so the comment "// inter is never constrained" marked `inter` as constrained.

Z-code numbering had drifted three ways. docs/rules/, vulnerability-db.json and the security guide agreed; finding_codes.rs and data/sarif/rule-metadata.yaml each had a different scheme, which would have mislabelled the findings these rules now emit. Realigned both onto the docs/rules catalogue and added a test pinning the numbering.

## Summary

Describe the change, the motivation behind it, and any important implementation details.

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Maintenance or refactor

## Testing

List the commands you ran and the scope of validation.

```text
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p sanctifier-core --all-features
cargo test -p sanctifier-cli
cd frontend && npm test
```

## Checklist

- [ ] I ran the relevant tests locally, or explained why they were not needed.
- [ ] I updated documentation for any user-facing behavior changes.
- [ ] I added or updated tests for the change when appropriate.
- [ ] I added a changelog or release-notes entry when needed, or confirmed none is required.
- [ ] I verified this branch is up to date with `main` and merge conflicts are resolved.

Closes #1199
Closes #1200
Closes #1201 
Closes #1196