### PR TITLE
feat: automate CHANGELOG generation for mainnet release notes (#1139)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,81 @@ jobs:
             exit 1
           fi
 
+  generate-changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Generate changelog section for this tag
+        id: git-cliff
+        run: |
+          # Generate changelog section for the current tag only
+          git-cliff --config cliff.toml \
+            --tag "${{ github.ref_name }}" \
+            --strip header \
+            --output changelog-section.md
+          echo "Generated changelog section:"
+          cat changelog-section.md
+
+      - name: Upload changelog section artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: changelog-section
+          path: changelog-section.md
+          retention-days: 7
+
+      - name: Prepend new section to CHANGELOG.md
+        run: |
+          if [ -s changelog-section.md ]; then
+            # Create updated CHANGELOG.md with new section prepended
+            HEADER_LINE=$(grep -n "^# " CHANGELOG.md | head -1 | cut -d: -f1)
+            # Extract the header (lines before first version section) and insert new section after it
+            if [ -n "$HEADER_LINE" ]; then
+              head -n $HEADER_LINE CHANGELOG.md > updated-changelog.md
+              echo "" >> updated-changelog.md
+              cat changelog-section.md >> updated-changelog.md
+              echo "" >> updated-changelog.md
+              tail -n +$((HEADER_LINE + 1)) CHANGELOG.md >> updated-changelog.md
+            else
+              cat changelog-section.md > updated-changelog.md
+              echo "" >> updated-changelog.md
+              cat CHANGELOG.md >> updated-changelog.md
+            fi
+            mv updated-changelog.md CHANGELOG.md
+            echo "CHANGELOG.md updated successfully"
+          else
+            echo "No changelog section generated; skipping CHANGELOG.md update"
+          fi
+
+      - name: Commit updated CHANGELOG.md
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          if ! git diff --staged --quiet; then
+            git commit -m "chore(release): update CHANGELOG.md for ${{ github.ref_name }}
+            
+            [skip ci]"
+            git push
+            echo "Committed and pushed updated CHANGELOG.md"
+          else
+            echo "CHANGELOG.md unchanged; nothing to commit"
+          fi
+
   build-and-release:
     name: Build (${{ matrix.target }})
-    needs: mainnet-readiness-gate
+    needs: [mainnet-readiness-gate, generate-changelog]
     if: always() && needs.mainnet-readiness-gate.result != 'failure'
     runs-on: ${{ matrix.os }}
     permissions:
@@ -121,13 +193,19 @@ jobs:
           path: ${{ matrix.artifact_name }}
           retention-days: 7
 
+      - name: Download changelog section
+        uses: actions/download-artifact@v6
+        with:
+          name: changelog-section
+          path: .
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             ${{ matrix.artifact_name }}
             ${{ matrix.artifact_name }}.sha256
-          body_path: CHANGELOG.md
+          body_path: changelog-section.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,82 @@
+# git-cliff ~ changelog generator configuration
+# https://git-cliff.org/docs/configuration
+#
+# Aligned with .commitlintrc.json conventional-commit types:
+# feat, fix, docs, style, refactor, perf, test, chore, revert, ci
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\n
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+
+### {{ group }}
+{% for commit in commits %}
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+{% if commit.breaking %}[**breaking**] {% endif %}\
+{{ commit.message | upper_first }}{% if commit.id %} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/HyperSafeD/Sanctifier/commit/{{ commit.id }})){% endif %}
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+postprocessor = [
+  { pattern = "^\\[unreleased\\]", replace = "" },
+]
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+require_conventional = false
+split_commits = false
+
+# Commit type → changelog section mapping
+# Order controls the output order of groups
+commit_parsers = [
+  # Breaking changes always come first
+  { message = "^.*", body = "BREAKING CHANGE", group = "⚠️ Breaking Changes" },
+  # Feature additions
+  { message = "^feat", group = "### Added" },
+  # Security-scoped fixes (must come before generic fix)
+  { message = "^fix", scope = "^security", group = "### Security" },
+  # Bug fixes
+  { message = "^fix", group = "### Fixed" },
+  # Performance
+  { message = "^perf", group = "### Performance" },
+  # Refactoring
+  { message = "^refactor", group = "### Changed" },
+  # Documentation
+  { message = "^docs", group = "### Documentation" },
+  # Styling
+  { message = "^style", group = "### Styles" },
+  # Tests
+  { message = "^test", group = "### Tests" },
+  # CI/CD
+  { message = "^ci", group = "### CI/CD" },
+  # Reverts
+  { message = "^revert", group = "### Reverts" },
+  # Chores (build tooling, dependencies, etc.)
+  { message = "^chore", group = "### Miscellaneous" },
+  # Deprecations (conventional commit scope detection)
+  { message = ".*", scope = "^deprecat", group = "### Deprecated" },
+  # Removals
+  { message = ".*", scope = "^remov", group = "### Removed" },
+  # Security (general scope detection)
+  { message = ".*", scope = "^security", group = "### Security" },
+  # Catch-all for unconventional commits (when filter_unconventional = false)
+  { message = ".*", group = "### Other" },
+]
+
+filter_commits = false
+tag_pattern = "v[0-9]*"
+skip_tags = "v[0-9]+-[a-z]+"
+topo_order = false
+sort_commits = "oldest"


### PR DESCRIPTION
## Summary
 
Adds automated changelog generation to the release pipeline using `git-cliff`, driven by the existing conventional-commit conventions in `.commitlintrc.json`.
 
## Changes
 
- Added `cliff.toml` — git-cliff config mapping commit types (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `revert`, `ci`) to Keep a Changelog sections
- Added `generate-changelog` job to the release workflow that:
  - Generates a changelog section for the current tag
  - Attaches it as the GitHub Release body
  - Prepends the new section into `CHANGELOG.md` and commits it back
- `build-and-release` now uses the generated section (`body_path: changelog-section.md`) instead of dumping the entire `CHANGELOG.md`
 
Closes #1139