### PR TITLE
chore: fix Soroban SDK v20/v21 breaking changes in zk-verifier

### DIFF
--- a/contracts/zk-verifier/src/groth16.rs
+++ b/contracts/zk-verifier/src/groth16.rs
@@ -28,38 +28,48 @@ pub enum ProofError {
 }
 
 impl Proof {
-    pub fn from_bytes(env: &Env, bytes: &[u8]) -> Result<Self, ProofError> {
+    /// Parse a `Proof` out of a Soroban `Bytes` buffer.
+    ///
+    /// `Bytes` is a host-managed object rather than a native Rust slice, so
+    /// sub-ranges are extracted with `Bytes::slice` instead of indexing into
+    /// a `&[u8]`.
+    pub fn from_bytes(_env: &Env, bytes: &Bytes) -> Result<Self, ProofError> {
         if bytes.len() != 192 {
             return Err(ProofError::InvalidProofLength);
         }
-        let a = Bytes::from_slice(env, &bytes[0..48]);
-        let b = Bytes::from_slice(env, &bytes[48..144]);
-        let c = Bytes::from_slice(env, &bytes[144..192]);
+        let a = bytes.slice(0..48);
+        let b = bytes.slice(48..144);
+        let c = bytes.slice(144..192);
         Ok(Self { a, b, c })
     }
 }
 
 impl VerifyingKey {
-    pub fn from_bytes(env: &Env, bytes: &[u8]) -> Result<Self, ProofError> {
-        if bytes.len() < 340 {
+    /// Parse a `VerifyingKey` out of a Soroban `Bytes` buffer.
+    pub fn from_bytes(env: &Env, bytes: &Bytes) -> Result<Self, ProofError> {
+        let len = bytes.len();
+        if len < 340 {
             return Err(ProofError::InvalidVkLength);
         }
-        let alpha_g1 = Bytes::from_slice(env, &bytes[0..48]);
-        let beta_g2 = Bytes::from_slice(env, &bytes[48..144]);
-        let gamma_g2 = Bytes::from_slice(env, &bytes[144..240]);
-        let delta_g2 = Bytes::from_slice(env, &bytes[240..336]);
+        let alpha_g1 = bytes.slice(0..48);
+        let beta_g2 = bytes.slice(48..144);
+        let gamma_g2 = bytes.slice(144..240);
+        let delta_g2 = bytes.slice(240..336);
 
         let num_inputs = u32::from_le_bytes([
-            bytes[336], bytes[337], bytes[338], bytes[339],
-        ]) as usize;
+            bytes.get(336).unwrap_or(0),
+            bytes.get(337).unwrap_or(0),
+            bytes.get(338).unwrap_or(0),
+            bytes.get(339).unwrap_or(0),
+        ]);
 
         let mut gamma_abc: Vec<G1Point> = Vec::new(env);
-        let mut offset = 340;
+        let mut offset: u32 = 340;
         for _ in 0..num_inputs {
-            if offset + 48 > bytes.len() {
+            if offset + 48 > len {
                 return Err(ProofError::InvalidVkLength);
             }
-            gamma_abc.push_back(Bytes::from_slice(env, &bytes[offset..offset + 48]));
+            gamma_abc.push_back(bytes.slice(offset..offset + 48));
             offset += 48;
         }
         Ok(Self { alpha_g1, beta_g2, gamma_g2, delta_g2, gamma_abc })
@@ -133,8 +143,9 @@ mod tests {
         buf[0] = 0xAB;
         buf[48] = 0xCD;
         buf[144] = 0xEF;
+        let bytes = Bytes::from_slice(&env, &buf);
 
-        let proof = Proof::from_bytes(&env, &buf).unwrap();
+        let proof = Proof::from_bytes(&env, &bytes).unwrap();
         assert_eq!(proof.a, Bytes::from_slice(&env, &buf[0..48]));
         assert_eq!(proof.b, Bytes::from_slice(&env, &buf[48..144]));
         assert_eq!(proof.c, Bytes::from_slice(&env, &buf[144..192]));
@@ -143,7 +154,8 @@ mod tests {
     #[test]
     fn proof_from_bytes_rejects_wrong_length() {
         let env = Env::default();
-        let result = Proof::from_bytes(&env, &[0u8; 10]);
+        let bytes = Bytes::from_slice(&env, &[0u8; 10]);
+        let result = Proof::from_bytes(&env, &bytes);
         assert_eq!(result, Err(ProofError::InvalidProofLength));
     }
 

--- a/contracts/zk-verifier/src/lib.rs
+++ b/contracts/zk-verifier/src/lib.rs
@@ -6,15 +6,15 @@ pub mod vk_storage;
 
 use groth16::{bind_public_inputs, verify, Proof, VerifyingKey, G1Point, G2Point};
 use nullifier_set::{NullifierKey, NullifierSet, NullifierState};
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, symbol_short, Address, Bytes, BytesN, Env, Vec};
 use vk_storage::{read_rotation_state, DataKey, RotationState};
 
 /// TTL thresholds (matching nullifier_set.rs).
 const TTL_BUMP_THRESHOLD: u32 = 100_000;
 const TTL_BUMP_TO: u32 = 6_307_200;
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum VerifierError {
     AlreadyInitialized = 1,
     NotInitialized = 2,
@@ -116,7 +116,7 @@ impl ZkVerifier {
 
         let pi_vec_final: Vec<BytesN<32>> = pi_ref;
 
-        let pi_len = pi_vec_final.len() as usize;
+        let pi_len = pi_vec_final.len();
         let mut pi_flat: Vec<BytesN<32>> = Vec::new(&env);
         for i in 0..pi_len {
             pi_flat.push_back(pi_vec_final.get(i).unwrap_or(BytesN::from_array(&env, &[0u8; 32])));
@@ -245,9 +245,12 @@ impl ZkVerifier {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use super::*;
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, Env};
+    use std::vec;
 
     fn make_vk_bytes(env: &Env) -> Bytes {
         let mut buf = vec![0u8; 340 + 96];
@@ -278,7 +281,7 @@ mod tests {
         let env = Env::default();
         env.mock_all_auths();
         let admin = Address::generate(&env);
-        let contract_id = env.register(ZkVerifier, ());
+        let contract_id = env.register_contract(None, ZkVerifier);
         let client = ZkVerifierClient::new(&env, &contract_id);
 
         let vk_bytes = make_vk_bytes(&env);
@@ -308,7 +311,7 @@ mod tests {
         let mut public_inputs: Vec<BytesN<32>> = Vec::new(&env);
         public_inputs.push_back(BytesN::from_array(&env, &[0x10; 32]));
 
-        let result = client.verify_proof(&proof_bytes, &public_inputs, &context, &nullifier);
+        let result = client.try_verify_proof(&proof_bytes, &public_inputs, &context, &nullifier);
         assert!(result.is_ok());
     }
 
@@ -324,9 +327,9 @@ mod tests {
         let mut public_inputs: Vec<BytesN<32>> = Vec::new(&env);
         public_inputs.push_back(BytesN::from_array(&env, &[0x10; 32]));
 
-        client.verify_proof(&proof_bytes, &public_inputs, &context, &nullifier).unwrap();
+        client.verify_proof(&proof_bytes, &public_inputs, &context, &nullifier);
 
-        let result = client.verify_proof(&proof_bytes, &public_inputs, &context, &nullifier);
+        let result = client.try_verify_proof(&proof_bytes, &public_inputs, &context, &nullifier);
         assert!(result.is_err());
     }
 
@@ -383,7 +386,7 @@ mod tests {
         let mut public_inputs: Vec<BytesN<32>> = Vec::new(&env);
         public_inputs.push_back(BytesN::from_array(&env, &[0x10; 32]));
 
-        client.verify_proof(&proof_bytes, &public_inputs, &context, &nullifier).unwrap();
+        client.verify_proof(&proof_bytes, &public_inputs, &context, &nullifier);
 
         assert!(client.is_nullifier_spent(&context, &nullifier));
     }

--- a/contracts/zk-verifier/src/nullifier_set.rs
+++ b/contracts/zk-verifier/src/nullifier_set.rs
@@ -121,7 +121,8 @@ impl NullifierSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Env as _, Bytes, Env};
+    use crate::ZkVerifier;
+    use soroban_sdk::{Bytes, Env};
 
     fn ctx(env: &Env) -> Bytes {
         Bytes::from_slice(env, b"test-campaign")
@@ -131,46 +132,58 @@ mod tests {
         Bytes::from_slice(env, &[n; 32])
     }
 
+    /// Storage operations require an active contract execution frame, so
+    /// unit tests exercise `NullifierSet` inside `Env::as_contract`.
+    fn with_contract<F: FnOnce(&Env)>(f: F) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ZkVerifier);
+        env.as_contract(&contract_id, || f(&env));
+    }
+
     #[test]
     fn unspent_nullifier_is_not_spent() {
-        let env = Env::default();
-        let ns = NullifierSet::new();
-        assert!(!ns.is_spent(&env, &ctx(&env), &null(&env, 0x01)));
+        with_contract(|env| {
+            let ns = NullifierSet::new();
+            assert!(!ns.is_spent(env, &ctx(env), &null(env, 0x01)));
+        });
     }
 
     #[test]
     fn mark_spent_records_nullifier() {
-        let env = Env::default();
-        let ns = NullifierSet::new();
-        let nullifier = null(&env, 0x02);
-        ns.mark_spent(&env, &ctx(&env), &nullifier);
-        assert!(ns.is_spent(&env, &ctx(&env), &nullifier));
+        with_contract(|env| {
+            let ns = NullifierSet::new();
+            let nullifier = null(env, 0x02);
+            ns.mark_spent(env, &ctx(env), &nullifier);
+            assert!(ns.is_spent(env, &ctx(env), &nullifier));
+        });
     }
 
     #[test]
     #[should_panic(expected = "nullifier already spent")]
     fn assert_unspent_panics_on_spent() {
-        let env = Env::default();
-        let ns = NullifierSet::new();
-        let nullifier = null(&env, 0x03);
-        ns.mark_spent(&env, &ctx(&env), &nullifier);
-        ns.assert_unspent(&env, &ctx(&env), &nullifier);
+        with_contract(|env| {
+            let ns = NullifierSet::new();
+            let nullifier = null(env, 0x03);
+            ns.mark_spent(env, &ctx(env), &nullifier);
+            ns.assert_unspent(env, &ctx(env), &nullifier);
+        });
     }
 
     #[test]
     #[should_panic(expected = "nullifier absent (possibly evicted) — failing closed")]
     fn assert_unspent_panics_on_absent_entry_fail_closed() {
-        let env = Env::default();
-        let ns = NullifierSet::new();
-        // Simulate eviction: write then manually remove the key so the entry
-        // appears absent to storage, then assert_unspent must panic (fail closed).
-        let nullifier = null(&env, 0x04);
-        let key = NullifierKey { context: ctx(&env), nullifier: nullifier.clone() };
-        env.storage()
-            .persistent()
-            .set::<NullifierKey, NullifierState>(&key, &NullifierState::Spent);
-        env.storage().persistent().remove(&key);
-        // Now the entry is absent — as if it had been evicted.
-        ns.assert_unspent(&env, &ctx(&env), &nullifier);
+        with_contract(|env| {
+            let ns = NullifierSet::new();
+            // Simulate eviction: write then manually remove the key so the entry
+            // appears absent to storage, then assert_unspent must panic (fail closed).
+            let nullifier = null(env, 0x04);
+            let key = NullifierKey { context: ctx(env), nullifier: nullifier.clone() };
+            env.storage()
+                .persistent()
+                .set::<NullifierKey, NullifierState>(&key, &NullifierState::Spent);
+            env.storage().persistent().remove(&key);
+            // Now the entry is absent — as if it had been evicted.
+            ns.assert_unspent(env, &ctx(env), &nullifier);
+        });
     }
 }


### PR DESCRIPTION
## Summary

Resolves #38 — "chore: Update dependencies to Soroban SDK v20".

The workspace root `Cargo.toml` was already pinned to `soroban-sdk = "21.7.0"` (a superset of v20) from an earlier migration, so no dependency bump was required there.

However, auditing the full workspace with `cargo check`/`cargo test` revealed that **`contracts/zk-verifier`** (added after that earlier migration) did not actually compile or pass its tests against the pinned SDK — exactly the class of "breaking changes in the AST or types" this issue calls out. This PR fixes all of them.

## Changes

All changes are scoped to `contracts/zk-verifier`:

- **`groth16.rs`** — `Proof::from_bytes` / `VerifyingKey::from_bytes` previously took `&[u8]`, but callers passed `soroban_sdk::Bytes` (a host-managed object, not a native Rust slice). Changed both to accept `&Bytes` and use `Bytes::slice()` / `Bytes::get()` instead of indexing into a raw slice.
- **`lib.rs`** — `VerifierError` used `#[contracttype]` but is returned from a fallible contract function; switched to `#[contracterror]` and added `Copy` (required by `#[contractimpl]`/`#[contractclient]` for `Result<_, E>` conversions to/from `soroban_sdk::Error`).
- Fixed a `u32`/`usize` type mismatch in a `Vec::get()` call.
- Replaced `env.register(ZkVerifier, ())` (not present in `soroban-sdk` 21.x) with `env.register_contract(None, ZkVerifier)`.
- Updated a test to use the generated `try_verify_proof` client method (the fallible variant) instead of expecting `Result` from the auto-unwrapping `verify_proof`.
- Fixed inline `#[cfg(test)]` modules referencing `std::vec!` / `std::panic` inside a `#![no_std]` crate without `extern crate std;`.
- Removed a stale `soroban_sdk::testutils::Env` import that no longer exists in this SDK version.
- **`nullifier_set.rs`** — wrapped unit tests in `Env::as_contract(...)`, since this SDK version enforces that storage access only happens inside an active contract execution frame (previously the tests called `env.storage()` directly, which now panics with "this function is not accessible outside of a contract").

## Verification

- `cargo check` across the whole workspace (all buildable contract/tooling members) now completes with no errors.
- `zk-verifier` went from **failing to compile at all** to **13/17 tests passing**.

## Remaining test failures (out of scope)

4 tests in `zk-verifier` still fail after these fixes:

- `tests::verify_proof_accepts_valid_proof`
- `tests::verify_proof_rejects_double_spend`
- `tests::nullifier_replay_prevented`
- `groth16::tests::verify_rejects_input_count_mismatch`

These are **pre-existing business-logic bugs**, unrelated to the Soroban SDK version:

- `ZkVerifier::verify_proof` in `lib.rs` calls `verify(&vk, &proof, &[])` with a **hardcoded empty slice** instead of the actual computed public inputs (`pi_flat`/`inputs`), so the public-input binding/count check never receives real data.
- In the `groth16` test, the constructed `VerifyingKey` has only 1 `gamma_abc` entry (implying 0 expected public inputs), and the test passes 0 inputs too — so no mismatch actually occurs, even though the test's intent was to exercise a mismatch.

Since this crate never previously compiled (added after the last SDK migration, and never exercised by CI), these logic bugs were never caught. They are functional/cryptographic-verification defects, not SDK-compatibility issues, so fixing them is out of scope for this dependency-update issue and is left for a follow-up.

Closes #38
