### PR TITLE
feat(engine): Fuzz-Harness Generator — export native AFL/honggfuzz test scaffolds

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -69,6 +69,14 @@
 - Cross-contract message wire format stability
 - Local reproduction recipes
 
+### Fuzz-Harness Generator
+
+**[docs/fuzz-harness-generator.md](docs/fuzz-harness-generator.md)** - `sanctifier harness` CLI command
+
+- Generates native `afl.rs` / `honggfuzz` fuzz-target scaffolds from a contract's ABI
+- Bridges static analysis (AST-level function/parameter extraction) to dynamic analysis
+- `SorobanArbitrary`-based input generation, crate auto-detection, usage examples
+
 ### Technical Architecture
 
 **[ARCHITECTURE.md](ARCHITECTURE.md)** - System design and components

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ sanctifier diff       [PATH] --baseline <report.json>   # new/resolved findings 
 sanctifier watch      [PATH]              # re-runs on file change
 sanctifier workspace  [PATH]              # cargo-workspace-aware scan
 sanctifier callgraph  [PATH] --output callgraph.dot
+sanctifier harness    [PATH] --output fuzz-harness --target afl|honggfuzz|both
 sanctifier badge      --report report.json --svg-output sanctifier.svg
 sanctifier fix        [PATH] --rule S003  # apply patcher fixes
 sanctifier verify     [PATH]              # Z3-only invariant pass

--- a/docs/fuzz-harness-generator.md
+++ b/docs/fuzz-harness-generator.md
@@ -1,0 +1,133 @@
+# Fuzz-Harness Generator (`sanctifier harness`)
+
+## Overview
+
+`sanctifier harness` bridges Sanctifier's *static* analysis (AST-level
+contract/ABI extraction) to *dynamic* analysis by generating ready-to-build
+native fuzz-target scaffolds for a Soroban contract source file — no manual
+harness-writing required.
+
+Given a contract source file, the command:
+
+1. Parses the file and discovers every `#[contractimpl]` block
+   ([`sanctifier_core::harness_spec`](../tooling/sanctifier-core/src/harness_spec.rs)).
+2. For each public, non-reserved function (i.e. excluding `__constructor` and
+   `__check_auth`), extracts its typed parameter list (skipping the
+   mandatory leading `Env` parameter).
+3. Emits one fuzz target per function for each requested backend
+   (`afl.rs`, `honggfuzz`, or both), plus a self-contained `Cargo.toml` per
+   backend.
+
+This targets the same invariant class as the hand-written harnesses
+described in [`docs/contracts-fuzz.md`](contracts-fuzz.md) — "does this
+contract entry point ever panic on attacker-controlled input?" — but removes
+the need to hand-write a harness for every function.
+
+## Usage
+
+```bash
+sanctifier harness path/to/contract.rs \
+  --output fuzz-harness \
+  --target both            # afl | honggfuzz | both (default)
+  --function transfer      # optional: restrict to one function
+```
+
+This produces:
+
+```
+fuzz-harness/
+├── afl/
+│   ├── Cargo.toml
+│   └── src/bin/
+│       ├── token_transfer.rs
+│       └── token_balance.rs
+└── honggfuzz/
+    ├── Cargo.toml
+    └── src/bin/
+        ├── token_transfer.rs
+        └── token_balance.rs
+```
+
+Each `afl/` or `honggfuzz/` directory is an independent, workspace-excluded
+Cargo package (`[workspace]` with no members — the same convention already
+used by `contracts/my-contract/fuzz/Cargo.toml`), so it can be built without
+disturbing the analyzed contract's own workspace:
+
+```bash
+cd fuzz-harness/afl
+cargo afl build
+cargo afl fuzz -i in -o out target/debug/token_transfer
+```
+
+```bash
+cd fuzz-harness/honggfuzz
+cargo hfuzz build
+cargo hfuzz run token_transfer
+```
+
+## How inputs are generated
+
+Every generated target follows the pattern documented by
+[`soroban_sdk::testutils::arbitrary`](https://docs.rs/soroban-sdk/latest/soroban_sdk/testutils/arbitrary/index.html)
+for fuzzing host-managed contract types: each parameter becomes a
+`<ParamType as SorobanArbitrary>::Prototype` field on a derived `Arbitrary`
+struct, and the harness body converts each prototype into its real Soroban
+value with `.into_val(&env)` before calling `client.try_<function>(..)`. For
+example, `transfer(env: Env, from: Address, to: Address, amount: i128)`
+generates:
+
+```rust
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    from: <Address as SorobanArbitrary>::Prototype,
+    to: <Address as SorobanArbitrary>::Prototype,
+    amount: <i128 as SorobanArbitrary>::Prototype,
+}
+
+fn main() {
+    fuzz!(|input: FuzzInput| {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, Token);
+        let client = TokenClient::new(&env, &contract_id);
+
+        let from: Address = input.from.into_val(&env);
+        let to: Address = input.to.into_val(&env);
+        let amount: i128 = input.amount.into_val(&env);
+
+        let _ = client.try_transfer(&from, &to, &amount);
+    });
+}
+```
+
+`try_<function>` (rather than `<function>`) is used so the fuzzer treats
+unexpected host-level panics as crashes while expected `Err` returns (e.g.
+validation rejections) do not themselves count as findings; switch to the
+non-`try_` call if you want to fuzz for panics *and* logic-level error paths.
+
+Custom `#[contracttype]` structs/enums used as parameters are fuzzable too:
+the Soroban SDK derives `SorobanArbitrary` for them automatically whenever
+the `testutils` feature is enabled, which is why every generated `Cargo.toml`
+enables `soroban-sdk`'s `testutils` feature.
+
+## Crate auto-detection
+
+`sanctifier harness` walks upward from the source file looking for the
+nearest `Cargo.toml` to discover the contract crate's package name, and adds
+it as a `path` dependency (with `features = ["testutils"]`) in the generated
+manifest, plus the matching `use <crate>::{Contract, ContractClient};` in
+each harness file. If no manifest is found, both are left as a `// TODO`
+placeholder for you to fill in.
+
+> **Note:** the target contract crate must itself define (or you must add) a
+> `testutils` feature that turns on `soroban-sdk/testutils` — this is what
+> makes `SorobanArbitrary` available for the crate's own `#[contracttype]`
+> types. See the `soroban_sdk::testutils::arbitrary` module docs for details.
+
+## Relationship to existing fuzz infrastructure
+
+This command is a *generator*: it produces new, disposable scaffold crates
+next to a contract you're analyzing. It does not replace or modify the
+hand-written, CI-integrated harnesses described in
+[`docs/contracts-fuzz.md`](contracts-fuzz.md), which continue to run in
+`.github/workflows/contracts-fuzz.yml` as before.

--- a/tooling/sanctifier-cli/src/commands/harness.rs
+++ b/tooling/sanctifier-cli/src/commands/harness.rs
@@ -1,0 +1,564 @@
+//! `sanctifier harness` — generate native `afl.rs` / `honggfuzz` fuzz-target
+//! scaffolds from static analysis of a Soroban contract's public ABI.
+//!
+//! This bridges *static* analysis (the AST-level function/parameter
+//! extraction performed by [`sanctifier_core::harness_spec`]) to *dynamic*
+//! analysis: each public, non-reserved `#[contractimpl]` function becomes a
+//! standalone fuzz target that
+//!
+//! 1. derives an `Arbitrary` input struct whose fields are
+//!    `<ParamType as SorobanArbitrary>::Prototype` — the pattern
+//!    documented by `soroban_sdk::testutils::arbitrary` for fuzzing
+//!    host-managed contract types, and
+//! 2. registers the contract, builds a client, converts each prototype into
+//!    its real Soroban type with `.into_val(&env)`, and invokes
+//!    `client.try_<fn>(..)`.
+//!
+//! Generated scaffolds are self-contained, workspace-excluded mini-crates
+//! (mirroring the `contracts/*/fuzz/Cargo.toml` convention already used in
+//! this repository for `cargo-fuzz`/libFuzzer harnesses) so they can be
+//! built independently with `cargo afl build` / `cargo hfuzz build` without
+//! disturbing the analyzed contract's own workspace.
+
+use anyhow::Context;
+use clap::{Args, ValueEnum};
+use sanctifier_core::harness_spec::{self, HarnessContract, HarnessFunction};
+use std::fmt::Write as FmtWrite;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::commands::color as c;
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FuzzTarget {
+    /// Generate an `afl.rs`-based scaffold only.
+    Afl,
+    /// Generate a `honggfuzz`-based scaffold only.
+    Honggfuzz,
+    /// Generate both scaffolds (default).
+    Both,
+}
+
+#[derive(Args, Debug)]
+pub struct HarnessArgs {
+    /// Path to the Rust source file containing one or more Soroban contracts
+    pub path: PathBuf,
+
+    /// Output directory for the generated fuzz-harness scaffold(s)
+    #[arg(short, long, default_value = "fuzz-harness")]
+    pub output: PathBuf,
+
+    /// Which fuzzing backend(s) to scaffold
+    #[arg(short, long, value_enum, default_value_t = FuzzTarget::Both)]
+    pub target: FuzzTarget,
+
+    /// Only generate a harness for this function name (default: all public functions)
+    #[arg(long)]
+    pub function: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Backend {
+    Afl,
+    Honggfuzz,
+}
+
+impl Backend {
+    fn dir_name(self) -> &'static str {
+        match self {
+            Backend::Afl => "afl",
+            Backend::Honggfuzz => "honggfuzz",
+        }
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Backend::Afl => "AFL (afl.rs)",
+            Backend::Honggfuzz => "honggfuzz",
+        }
+    }
+
+    fn dependency_line(self) -> &'static str {
+        match self {
+            Backend::Afl => "afl = \"0.15\"",
+            Backend::Honggfuzz => "honggfuzz = \"0.5\"",
+        }
+    }
+
+    fn use_line(self) -> &'static str {
+        match self {
+            Backend::Afl => "use afl::fuzz;",
+            Backend::Honggfuzz => "use honggfuzz::fuzz;",
+        }
+    }
+
+    fn run_instructions(self, bin_name: &str) -> String {
+        match self {
+            Backend::Afl => format!(
+                "//! Run with:\n//!   cargo afl build\n//!   cargo afl fuzz -i in -o out target/debug/{bin_name}"
+            ),
+            Backend::Honggfuzz => format!(
+                "//! Run with:\n//!   cargo hfuzz build\n//!   cargo hfuzz run {bin_name}"
+            ),
+        }
+    }
+}
+
+struct CrateInfo {
+    /// Cargo package name (as declared in `[package] name`), used verbatim
+    /// as the `path = ...` dependency key.
+    name: String,
+    /// Rust identifier form of `name` (hyphens replaced with underscores),
+    /// used in `use` statements.
+    ident: String,
+    /// Absolute path to the crate root directory (containing `Cargo.toml`).
+    dir: PathBuf,
+}
+
+/// Walk upward from `source_path`'s parent directory looking for the
+/// nearest `Cargo.toml`, returning its declared package name and location.
+///
+/// Returns `None` (rather than an error) when no manifest is found, since a
+/// harness can still be generated — just with a `// TODO` placeholder
+/// import — for a source file that is not part of a Cargo crate on disk.
+fn locate_crate_info(source_path: &Path) -> Option<CrateInfo> {
+    let mut dir = source_path.parent()?.to_path_buf();
+    if dir.as_os_str().is_empty() {
+        dir = PathBuf::from(".");
+    }
+    loop {
+        let candidate = dir.join("Cargo.toml");
+        if candidate.is_file() {
+            let content = fs::read_to_string(&candidate).ok()?;
+            let doc: toml::Value = content.parse().ok()?;
+            let name = doc.get("package")?.get("name")?.as_str()?.to_string();
+            let ident = name.replace('-', "_");
+            let abs_dir = fs::canonicalize(&dir).unwrap_or(dir.clone());
+            return Some(CrateInfo {
+                name,
+                ident,
+                dir: abs_dir,
+            });
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// `MyContract` -> `my_contract`.
+fn to_snake_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() {
+            if i > 0 {
+                out.push('_');
+            }
+            out.extend(ch.to_lowercase());
+        } else if ch == '-' {
+            out.push('_');
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn harness_bin_name(struct_name: &str, fn_name: &str) -> String {
+    format!("{}_{}", to_snake_case(struct_name), fn_name)
+}
+
+pub fn exec(args: HarnessArgs) -> anyhow::Result<()> {
+    let source = fs::read_to_string(&args.path)
+        .with_context(|| format!("failed to read {}", args.path.display()))?;
+
+    let parsed = sanctifier_core::parser::parse_source(&source)
+        .map_err(|e| anyhow::anyhow!("failed to parse {}: {}", args.path.display(), e))?;
+
+    let mut contracts = harness_spec::extract_harness_contracts(&parsed.file);
+
+    if let Some(filter) = &args.function {
+        for contract in &mut contracts {
+            contract.functions.retain(|f| &f.name == filter);
+        }
+        contracts.retain(|c| !c.functions.is_empty());
+    }
+
+    if contracts.is_empty() {
+        println!(
+            "{} No fuzzable public contract functions found in {}",
+            c::yellow_warning(),
+            args.path.display()
+        );
+        return Ok(());
+    }
+
+    let crate_info = locate_crate_info(&args.path);
+    if crate_info.is_none() {
+        println!(
+            "{} Could not locate a Cargo.toml above {} — generated scaffolds will contain a TODO placeholder import instead of a path dependency.",
+            c::yellow_warning(),
+            args.path.display()
+        );
+    }
+
+    let backends: &[Backend] = match args.target {
+        FuzzTarget::Afl => &[Backend::Afl],
+        FuzzTarget::Honggfuzz => &[Backend::Honggfuzz],
+        FuzzTarget::Both => &[Backend::Afl, Backend::Honggfuzz],
+    };
+
+    let mut total_generated = 0usize;
+    for &backend in backends {
+        total_generated +=
+            generate_backend_scaffold(backend, &contracts, crate_info.as_ref(), &args.output)?;
+    }
+
+    let fn_count: usize = contracts.iter().map(|c| c.functions.len()).sum();
+    println!(
+        "{} Generated {} fuzz target(s) ({} function(s) x {} backend(s)) in {}",
+        c::green_check(),
+        total_generated,
+        fn_count,
+        backends.len(),
+        args.output.display()
+    );
+    Ok(())
+}
+
+fn generate_backend_scaffold(
+    backend: Backend,
+    contracts: &[HarnessContract],
+    crate_info: Option<&CrateInfo>,
+    output_root: &Path,
+) -> anyhow::Result<usize> {
+    let backend_dir = output_root.join(backend.dir_name());
+    let bin_dir = backend_dir.join("src").join("bin");
+    fs::create_dir_all(&bin_dir)
+        .with_context(|| format!("failed to create {}", bin_dir.display()))?;
+
+    let mut bin_entries: Vec<(String, String)> = Vec::new();
+
+    for contract in contracts {
+        for function in &contract.functions {
+            let bin_name = harness_bin_name(&contract.struct_name, &function.name);
+            let file_name = format!("{bin_name}.rs");
+            let source = render_harness_source(backend, contract, function, crate_info);
+            let file_path = bin_dir.join(&file_name);
+            fs::write(&file_path, source)
+                .with_context(|| format!("failed to write {}", file_path.display()))?;
+            bin_entries.push((bin_name, format!("src/bin/{file_name}")));
+        }
+    }
+
+    let manifest = render_manifest(backend, crate_info, &bin_entries);
+    let manifest_path = backend_dir.join("Cargo.toml");
+    fs::write(&manifest_path, manifest)
+        .with_context(|| format!("failed to write {}", manifest_path.display()))?;
+
+    Ok(bin_entries.len())
+}
+
+fn render_manifest(
+    backend: Backend,
+    crate_info: Option<&CrateInfo>,
+    bins: &[(String, String)],
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "[package]");
+    let _ = writeln!(out, "name = \"fuzz-harness-{}\"", backend.dir_name());
+    let _ = writeln!(out, "version = \"0.0.1\"");
+    let _ = writeln!(out, "edition = \"2021\"");
+    let _ = writeln!(out, "publish = false");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "# Excludes this scaffold from any parent Cargo workspace, mirroring the"
+    );
+    let _ = writeln!(
+        out,
+        "# convention used by contracts/*/fuzz crates in this repository."
+    );
+    let _ = writeln!(out, "[workspace]");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "[dependencies]");
+    let _ = writeln!(out, "{}", backend.dependency_line());
+    let _ = writeln!(
+        out,
+        "arbitrary = {{ version = \"1\", features = [\"derive\"] }}"
+    );
+    let _ = writeln!(
+        out,
+        "soroban-sdk = {{ version = \"21.7.0\", features = [\"testutils\"] }}"
+    );
+    match crate_info {
+        Some(info) => {
+            let _ = writeln!(
+                out,
+                "{} = {{ path = {:?}, features = [\"testutils\"] }}",
+                info.name, info.dir
+            );
+        }
+        None => {
+            let _ = writeln!(
+                out,
+                "# TODO: point this at your contract crate, enabling a `testutils` feature"
+            );
+            let _ = writeln!(
+                out,
+                "# that turns on `soroban-sdk/testutils` (required for `SorobanArbitrary`"
+            );
+            let _ = writeln!(out, "# to be derived on your #[contracttype] types).");
+            let _ = writeln!(
+                out,
+                "# your-contract = {{ path = \"../..\", features = [\"testutils\"] }}"
+            );
+        }
+    }
+    let _ = writeln!(out);
+
+    for (bin_name, path) in bins {
+        let _ = writeln!(out, "[[bin]]");
+        let _ = writeln!(out, "name = {bin_name:?}");
+        let _ = writeln!(out, "path = {path:?}");
+        let _ = writeln!(out, "test = false");
+        let _ = writeln!(out, "doc = false");
+        let _ = writeln!(out);
+    }
+
+    out
+}
+
+fn render_harness_source(
+    backend: Backend,
+    contract: &HarnessContract,
+    function: &HarnessFunction,
+    crate_info: Option<&CrateInfo>,
+) -> String {
+    let contract_ty = &contract.struct_name;
+    let client_ty = format!("{contract_ty}Client");
+    let fn_name = &function.name;
+    let bin_name = harness_bin_name(contract_ty, fn_name);
+
+    let mut out = String::new();
+
+    // ── Doc header ─────────────────────────────────────────────────────────
+    let _ = writeln!(
+        out,
+        "//! Auto-generated {} fuzz harness for `{contract_ty}::{fn_name}`.",
+        backend.display_name()
+    );
+    let _ = writeln!(out, "//!");
+    let _ = writeln!(
+        out,
+        "//! Generated by `sanctifier harness` — bridges static analysis to dynamic"
+    );
+    let _ = writeln!(
+        out,
+        "//! analysis. Review the imports and call site below before fuzzing."
+    );
+    let _ = writeln!(out, "//!");
+    let _ = writeln!(out, "{}", backend.run_instructions(&bin_name));
+    let _ = writeln!(out);
+
+    // ── Imports ────────────────────────────────────────────────────────────
+    let _ = writeln!(
+        out,
+        "use soroban_sdk::testutils::arbitrary::{{Arbitrary, SorobanArbitrary}};"
+    );
+    let _ = writeln!(out, "use soroban_sdk::{{Env, IntoVal}};");
+    let _ = writeln!(out, "{}", backend.use_line());
+    let _ = writeln!(out);
+    match crate_info {
+        Some(info) => {
+            let _ = writeln!(out, "use {}::{{{contract_ty}, {client_ty}}};", info.ident);
+        }
+        None => {
+            let _ = writeln!(out, "// TODO: could not auto-detect the contract crate.");
+            let _ = writeln!(out, "// use your_contract_crate::{{{contract_ty}, {client_ty}}};");
+        }
+    }
+    let _ = writeln!(out);
+
+    // ── Fuzz input struct ──────────────────────────────────────────────────
+    let _ = writeln!(out, "#[derive(Debug, Arbitrary)]");
+    if function.params.is_empty() {
+        let _ = writeln!(out, "struct FuzzInput;");
+    } else {
+        let _ = writeln!(out, "struct FuzzInput {{");
+        for p in &function.params {
+            let _ = writeln!(
+                out,
+                "    {}: <{} as SorobanArbitrary>::Prototype,",
+                p.name, p.ty_tokens
+            );
+        }
+        let _ = writeln!(out, "}}");
+    }
+    let _ = writeln!(out);
+
+    // ── Entry point ────────────────────────────────────────────────────────
+    let _ = writeln!(out, "fn main() {{");
+    match backend {
+        Backend::Afl => {
+            let _ = writeln!(out, "    fuzz!(|input: FuzzInput| {{");
+        }
+        Backend::Honggfuzz => {
+            let _ = writeln!(out, "    loop {{");
+            let _ = writeln!(out, "        fuzz!(|input: FuzzInput| {{");
+        }
+    }
+    let indent = match backend {
+        Backend::Afl => "        ",
+        Backend::Honggfuzz => "            ",
+    };
+    let _ = writeln!(out, "{indent}let env = Env::default();");
+    let _ = writeln!(out, "{indent}env.mock_all_auths();");
+    let _ = writeln!(
+        out,
+        "{indent}let contract_id = env.register_contract(None, {contract_ty});"
+    );
+    let _ = writeln!(
+        out,
+        "{indent}let client = {client_ty}::new(&env, &contract_id);"
+    );
+    if !function.params.is_empty() {
+        let _ = writeln!(out);
+        for p in &function.params {
+            let _ = writeln!(
+                out,
+                "{indent}let {}: {} = input.{}.into_val(&env);",
+                p.name, p.ty_tokens, p.name
+            );
+        }
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "{indent}// `try_{fn_name}` reports contract errors as `Err` instead of panicking,"
+    );
+    let _ = writeln!(
+        out,
+        "{indent}// so the fuzzer only treats host-level panics as crashes. Switch to"
+    );
+    let _ = writeln!(
+        out,
+        "{indent}// `{fn_name}` directly if you want expected `Err` returns to count too."
+    );
+    let call_args = function
+        .params
+        .iter()
+        .map(|p| format!("&{}", p.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(out, "{indent}let _ = client.try_{fn_name}({call_args});");
+    match backend {
+        Backend::Afl => {
+            let _ = writeln!(out, "    }});");
+        }
+        Backend::Honggfuzz => {
+            let _ = writeln!(out, "        }});");
+            let _ = writeln!(out, "    }}");
+        }
+    }
+    let _ = writeln!(out, "}}");
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_snake_case_converts_pascal_case() {
+        assert_eq!(to_snake_case("MyContract"), "my_contract");
+        assert_eq!(to_snake_case("Token"), "token");
+        assert_eq!(to_snake_case("ZKVerifier"), "z_k_verifier");
+    }
+
+    #[test]
+    fn harness_bin_name_combines_contract_and_function() {
+        assert_eq!(harness_bin_name("Token", "transfer"), "token_transfer");
+    }
+
+    #[test]
+    fn render_manifest_without_crate_info_has_todo_placeholder() {
+        let manifest = render_manifest(Backend::Afl, None, &[]);
+        assert!(manifest.contains("afl = \"0.15\""));
+        assert!(manifest.contains("[workspace]"));
+        assert!(manifest.contains("TODO"));
+    }
+
+    #[test]
+    fn render_manifest_with_crate_info_has_path_dependency() {
+        let info = CrateInfo {
+            name: "my-contract".to_string(),
+            ident: "my_contract".to_string(),
+            dir: PathBuf::from("/tmp/my-contract"),
+        };
+        let manifest = render_manifest(
+            Backend::Honggfuzz,
+            Some(&info),
+            &[("my_contract_transfer".to_string(), "src/bin/my_contract_transfer.rs".to_string())],
+        );
+        assert!(manifest.contains("honggfuzz = \"0.5\""));
+        assert!(manifest.contains("my-contract = { path"));
+        assert!(manifest.contains("testutils"));
+        assert!(manifest.contains("[[bin]]"));
+        assert!(manifest.contains("name = \"my_contract_transfer\""));
+    }
+
+    #[test]
+    fn render_harness_source_afl_contains_expected_shape() {
+        let contract = HarnessContract {
+            struct_name: "Token".to_string(),
+            functions: vec![],
+        };
+        let function = HarnessFunction {
+            name: "transfer".to_string(),
+            params: vec![
+                harness_spec::HarnessParam {
+                    name: "from".to_string(),
+                    ty_tokens: "Address".to_string(),
+                },
+                harness_spec::HarnessParam {
+                    name: "amount".to_string(),
+                    ty_tokens: "i128".to_string(),
+                },
+            ],
+        };
+        let src = render_harness_source(Backend::Afl, &contract, &function, None);
+        assert!(src.contains("use afl::fuzz;"));
+        assert!(src.contains("struct FuzzInput {"));
+        assert!(src.contains("from: <Address as SorobanArbitrary>::Prototype,"));
+        assert!(src.contains("amount: <i128 as SorobanArbitrary>::Prototype,"));
+        assert!(src.contains("let contract_id = env.register_contract(None, Token);"));
+        assert!(src.contains("let client = TokenClient::new(&env, &contract_id);"));
+        assert!(src.contains("let from: Address = input.from.into_val(&env);"));
+        assert!(src.contains("let _ = client.try_transfer(&from, &amount);"));
+        assert!(src.contains("fuzz!(|input: FuzzInput| {"));
+    }
+
+    #[test]
+    fn render_harness_source_honggfuzz_wraps_in_loop() {
+        let contract = HarnessContract {
+            struct_name: "Counter".to_string(),
+            functions: vec![],
+        };
+        let function = HarnessFunction {
+            name: "increment".to_string(),
+            params: vec![],
+        };
+        let src = render_harness_source(Backend::Honggfuzz, &contract, &function, None);
+        assert!(src.contains("use honggfuzz::fuzz;"));
+        assert!(src.contains("loop {"));
+        assert!(src.contains("struct FuzzInput;"));
+        assert!(src.contains("let _ = client.try_increment();"));
+    }
+
+    #[test]
+    fn to_snake_case_handles_hyphens() {
+        assert_eq!(to_snake_case("my-contract"), "my_contract");
+    }
+}

--- a/tooling/sanctifier-cli/src/commands/init.rs
+++ b/tooling/sanctifier-cli/src/commands/init.rs
@@ -62,6 +62,7 @@ impl ConfigGenerator {
                 },
             ],
             approaching_threshold: 0.8,
+            smt_timeout_ms: None,
         }
     }
 }

--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod explain;
 pub mod export;
 pub mod fix;
 pub mod gas;
+pub mod harness;
 pub mod init;
 pub mod install_hooks;
 pub mod lsp;

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -89,6 +89,8 @@ pub enum Commands {
     Badge(commands::badge::BadgeArgs),
     /// Compare two scan results and show new/resolved findings
     Diff(commands::diff::DiffArgs),
+    /// Generate native AFL/honggfuzz fuzz-harness scaffolds from a contract's ABI
+    Harness(commands::harness::HarnessArgs),
 }
 
 fn main() {
@@ -146,5 +148,6 @@ fn run() -> anyhow::Result<()> {
         Commands::Export(args) => commands::export::exec(args),
         Commands::Badge(args) => commands::badge::exec(args),
         Commands::Diff(args) => commands::diff::exec(args),
+        Commands::Harness(args) => commands::harness::exec(args),
     }
 }

--- a/tooling/sanctifier-cli/tests/harness_tests.rs
+++ b/tooling/sanctifier-cli/tests/harness_tests.rs
@@ -1,0 +1,289 @@
+/// Integration / e2e tests for `sanctifier harness` (#415).
+///
+/// Covers: default (both backends), single-backend selection, function
+/// filtering, generated file/manifest shape, crate auto-detection, the
+/// "nothing to fuzz" case, and a nonexistent source path.
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn write_contract(dir: &tempfile::TempDir, name: &str, src: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, src).unwrap();
+    path
+}
+
+const TOKEN_SRC: &str = r#"
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct Token;
+
+#[contractimpl]
+impl Token {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {}
+    pub fn balance(env: Env, id: Address) -> i128 { 0 }
+}
+"#;
+
+// ── default (both backends) ────────────────────────────────────────────────
+
+#[test]
+fn harness_default_generates_both_backends() {
+    let dir = tempdir().unwrap();
+    let src = write_contract(&dir, "token.rs", TOKEN_SRC);
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generated"))
+        .stdout(predicate::str::contains("4 fuzz target(s)"));
+
+    assert!(output.join("afl").join("Cargo.toml").is_file());
+    assert!(output.join("honggfuzz").join("Cargo.toml").is_file());
+    assert!(output
+        .join("afl")
+        .join("src")
+        .join("bin")
+        .join("token_transfer.rs")
+        .is_file());
+    assert!(output
+        .join("afl")
+        .join("src")
+        .join("bin")
+        .join("token_balance.rs")
+        .is_file());
+    assert!(output
+        .join("honggfuzz")
+        .join("src")
+        .join("bin")
+        .join("token_transfer.rs")
+        .is_file());
+}
+
+// ── single-backend selection ────────────────────────────────────────────────
+
+#[test]
+fn harness_target_afl_only_generates_afl_directory() {
+    let dir = tempdir().unwrap();
+    let src = write_contract(&dir, "token.rs", TOKEN_SRC);
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .args(["--target", "afl"])
+        .assert()
+        .success();
+
+    assert!(output.join("afl").join("Cargo.toml").is_file());
+    assert!(
+        !output.join("honggfuzz").exists(),
+        "honggfuzz dir must not be generated when --target afl is given"
+    );
+}
+
+#[test]
+fn harness_target_honggfuzz_only_generates_honggfuzz_directory() {
+    let dir = tempdir().unwrap();
+    let src = write_contract(&dir, "token.rs", TOKEN_SRC);
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .args(["--target", "honggfuzz"])
+        .assert()
+        .success();
+
+    assert!(output.join("honggfuzz").join("Cargo.toml").is_file());
+    assert!(!output.join("afl").exists());
+}
+
+// ── function filtering ──────────────────────────────────────────────────────
+
+#[test]
+fn harness_function_filter_restricts_to_one_function() {
+    let dir = tempdir().unwrap();
+    let src = write_contract(&dir, "token.rs", TOKEN_SRC);
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .args(["--target", "afl", "--function", "transfer"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 fuzz target(s)"));
+
+    assert!(output
+        .join("afl")
+        .join("src")
+        .join("bin")
+        .join("token_transfer.rs")
+        .is_file());
+    assert!(!output
+        .join("afl")
+        .join("src")
+        .join("bin")
+        .join("token_balance.rs")
+        .exists());
+}
+
+// ── generated content shape ─────────────────────────────────────────────────
+
+#[test]
+fn harness_generated_afl_source_has_expected_shape() {
+    let dir = tempdir().unwrap();
+    let src = write_contract(&dir, "token.rs", TOKEN_SRC);
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .args(["--target", "afl", "--function", "transfer"])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(
+        output
+            .join("afl")
+            .join("src")
+            .join("bin")
+            .join("token_transfer.rs"),
+    )
+    .unwrap();
+
+    assert!(content.contains("use afl::fuzz;"));
+    assert!(content.contains("#[derive(Debug, Arbitrary)]"));
+    assert!(content.contains("struct FuzzInput {"));
+    assert!(content.contains("from: <Address as SorobanArbitrary>::Prototype,"));
+    assert!(content.contains("amount: <i128 as SorobanArbitrary>::Prototype,"));
+    assert!(content.contains("let contract_id = env.register_contract(None, Token);"));
+    assert!(content.contains("let client = TokenClient::new(&env, &contract_id);"));
+    assert!(content.contains("let _ = client.try_transfer(&from, &to, &amount);"));
+    // The mandatory leading `Env` parameter must never appear as a fuzzed field.
+    assert!(!content.contains("env: <Env"));
+}
+
+#[test]
+fn harness_generated_manifest_excludes_parent_workspace() {
+    let dir = tempdir().unwrap();
+    let src = write_contract(&dir, "token.rs", TOKEN_SRC);
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .args(["--target", "afl"])
+        .assert()
+        .success();
+
+    let manifest = fs::read_to_string(output.join("afl").join("Cargo.toml")).unwrap();
+    assert!(manifest.contains("[workspace]"));
+    assert!(manifest.contains("afl = \"0.15\""));
+    assert!(manifest.contains("[[bin]]"));
+    assert!(manifest.contains("soroban-sdk"));
+    assert!(manifest.contains("testutils"));
+}
+
+// ── crate auto-detection ────────────────────────────────────────────────────
+
+#[test]
+fn harness_detects_sibling_cargo_toml_and_adds_path_dependency() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"my-token\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let src = src_dir.join("lib.rs");
+    fs::write(&src, TOKEN_SRC).unwrap();
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .args(["--target", "afl"])
+        .assert()
+        .success();
+
+    let manifest = fs::read_to_string(output.join("afl").join("Cargo.toml")).unwrap();
+    assert!(
+        manifest.contains("my-token = { path"),
+        "manifest should reference the detected crate by name:\n{manifest}"
+    );
+
+    let source = fs::read_to_string(
+        output
+            .join("afl")
+            .join("src")
+            .join("bin")
+            .join("token_transfer.rs"),
+    )
+    .unwrap();
+    assert!(source.contains("use my_token::{Token, TokenClient};"));
+}
+
+// ── nothing to fuzz ──────────────────────────────────────────────────────────
+
+#[test]
+fn harness_contract_with_no_public_functions_warns_and_generates_nothing() {
+    let dir = tempdir().unwrap();
+    let src = write_contract(
+        &dir,
+        "empty.rs",
+        "pub struct MyContract;\nimpl MyContract {}",
+    );
+    let output = dir.path().join("fuzz-out");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness"])
+        .arg(&src)
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No fuzzable public contract functions"));
+
+    assert!(!output.exists(), "no output directory should be created");
+}
+
+// ── error cases ──────────────────────────────────────────────────────────────
+
+#[test]
+fn harness_nonexistent_path_exits_with_error() {
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["harness", "/no/such/file.rs"])
+        .assert()
+        .failure();
+}

--- a/tooling/sanctifier-core/src/contract_discovery.rs
+++ b/tooling/sanctifier-core/src/contract_discovery.rs
@@ -97,9 +97,9 @@ impl DiscoveredContract {
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 /// Soroban-defined reserved function names that are not user-callable.
-const RESERVED_ENTRYPOINTS: &[&str] = &["__constructor", "__check_auth"];
+pub(crate) const RESERVED_ENTRYPOINTS: &[&str] = &["__constructor", "__check_auth"];
 
-fn has_attr_named(attrs: &[syn::Attribute], name: &str) -> bool {
+pub(crate) fn has_attr_named(attrs: &[syn::Attribute], name: &str) -> bool {
     attrs.iter().any(|attr| {
         if let Meta::Path(path) = &attr.meta {
             path.is_ident(name) || path.segments.iter().any(|s| s.ident == name)
@@ -109,7 +109,7 @@ fn has_attr_named(attrs: &[syn::Attribute], name: &str) -> bool {
     })
 }
 
-fn type_to_name(ty: &Type) -> Option<String> {
+pub(crate) fn type_to_name(ty: &Type) -> Option<String> {
     if let Type::Path(tp) = ty {
         tp.path.segments.last().map(|s| s.ident.to_string())
     } else {

--- a/tooling/sanctifier-core/src/harness_spec.rs
+++ b/tooling/sanctifier-core/src/harness_spec.rs
@@ -1,0 +1,346 @@
+//! Fuzz-harness specification extraction — bridges static analysis to
+//! dynamic analysis.
+//!
+//! This module walks the same `#[contractimpl]` blocks that
+//! [`crate::contract_discovery`] discovers, but additionally extracts the
+//! full, typed parameter list of every public function. The result — a
+//! [`HarnessContract`] tree — is a source-agnostic description of a
+//! contract's callable ABI that a code generator (see the CLI's `harness`
+//! subcommand) can turn into native `afl.rs` / `honggfuzz` fuzz-target
+//! scaffolds.
+//!
+//! # Why not reuse [`crate::contract_discovery::DiscoveredFunction`]?
+//!
+//! `DiscoveredFunction` intentionally only carries a function's `name` and
+//! `line` — enough for call-graph and complexity analyses, but not enough to
+//! generate a fuzz harness, which must know each parameter's Rust type in
+//! order to derive an `Arbitrary`/`SorobanArbitrary` input value for it.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use sanctifier_core::{parser, harness_spec};
+//!
+//! let parsed = parser::parse_source(source)?;
+//! for contract in harness_spec::extract_harness_contracts(&parsed.file) {
+//!     for f in &contract.functions {
+//!         println!("{}::{}", contract.struct_name, f.name);
+//!         for p in &f.params {
+//!             println!("  {}: {}", p.name, p.ty_tokens);
+//!         }
+//!     }
+//! }
+//! ```
+
+use std::collections::BTreeMap;
+use syn::{FnArg, Item, ImplItem, Pat, Type};
+
+use crate::contract_discovery::{has_attr_named, type_to_name, RESERVED_ENTRYPOINTS};
+
+// ── Public data types ─────────────────────────────────────────────────────────
+
+/// A single typed parameter of a fuzzable contract function.
+///
+/// The mandatory leading `Env` parameter that every Soroban contract
+/// function takes is deliberately excluded — a fuzz harness constructs its
+/// own `Env` rather than deriving one from fuzzer input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessParam {
+    /// Parameter name as written (falls back to `argN` for irrefutable
+    /// patterns `syn` cannot name, e.g. destructuring).
+    pub name: String,
+    /// The parameter's type, rendered as valid Rust source (e.g. `"Address"`,
+    /// `"BytesN<32>"`, `"i128"`, `"Vec<Address>"`).
+    pub ty_tokens: String,
+}
+
+/// A public, non-reserved contract function together with its fuzzable
+/// parameter list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessFunction {
+    /// Function name (e.g. `"transfer"`).
+    pub name: String,
+    /// Typed parameters, in declaration order, excluding the leading `Env`.
+    pub params: Vec<HarnessParam>,
+}
+
+/// A Soroban contract's fuzzable surface: every public, non-reserved
+/// function reachable through a `#[contractimpl]` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessContract {
+    /// Name of the contract struct.
+    pub struct_name: String,
+    /// Fuzzable functions, in source order.
+    pub functions: Vec<HarnessFunction>,
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Extract the fuzzable ABI of every contract in a parsed source file.
+///
+/// Only functions inside `#[contractimpl]` blocks are considered, matching
+/// [`crate::contract_discovery::discover_contracts`]'s notion of a
+/// "contract". Reserved entry-points (`__constructor`, `__check_auth`) and
+/// non-`pub` functions are excluded, since neither is meaningfully callable
+/// through a generated client-based fuzz harness.
+///
+/// Returns one [`HarnessContract`] per unique struct name, in deterministic
+/// (lexicographic) order. Contracts with zero fuzzable functions (e.g. only
+/// reserved entry-points) are omitted entirely.
+pub fn extract_harness_contracts(file: &syn::File) -> Vec<HarnessContract> {
+    let mut by_name: BTreeMap<String, Vec<HarnessFunction>> = BTreeMap::new();
+
+    for item in &file.items {
+        let Item::Impl(impl_block) = item else {
+            continue;
+        };
+        if !has_attr_named(&impl_block.attrs, "contractimpl") {
+            continue;
+        }
+
+        let struct_name =
+            type_to_name(&impl_block.self_ty).unwrap_or_else(|| "<unknown>".to_string());
+        let entry = by_name.entry(struct_name).or_default();
+
+        for impl_item in &impl_block.items {
+            let ImplItem::Fn(f) = impl_item else {
+                continue;
+            };
+            if !matches!(f.vis, syn::Visibility::Public(_)) {
+                continue;
+            }
+            let name = f.sig.ident.to_string();
+            if RESERVED_ENTRYPOINTS.contains(&name.as_str()) {
+                continue;
+            }
+
+            let params = extract_params(f);
+            entry.push(HarnessFunction { name, params });
+        }
+    }
+
+    by_name
+        .into_iter()
+        .filter(|(_, functions)| !functions.is_empty())
+        .map(|(struct_name, functions)| HarnessContract {
+            struct_name,
+            functions,
+        })
+        .collect()
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Collects every non-`Env` parameter of a function signature as a
+/// [`HarnessParam`].
+///
+/// By Soroban convention `Env` is always the first parameter of a public
+/// contract function; any parameter whose rendered type is exactly `"Env"`
+/// is skipped regardless of position, so unconventional signatures degrade
+/// gracefully rather than producing a bogus fuzz field.
+fn extract_params(f: &syn::ImplItemFn) -> Vec<HarnessParam> {
+    let mut params = Vec::new();
+    let mut anon_index = 0usize;
+
+    for input in &f.sig.inputs {
+        let FnArg::Typed(typed) = input else {
+            continue; // `self` receivers do not occur in #[contractimpl] fns
+        };
+
+        let ty_tokens = render_type(&typed.ty);
+        if ty_tokens == "Env" {
+            continue;
+        }
+
+        let name = pattern_name(&typed.pat).unwrap_or_else(|| {
+            let name = format!("arg{anon_index}");
+            anon_index += 1;
+            name
+        });
+
+        params.push(HarnessParam { name, ty_tokens });
+    }
+
+    params
+}
+
+/// Renders a `syn::Type` as compact, valid Rust source (e.g. `BytesN<32>`
+/// rather than `syn`'s debug/token-stream spacing).
+fn render_type(ty: &Type) -> String {
+    match ty {
+        Type::Group(group) => render_type(&group.elem),
+        Type::Paren(paren) => render_type(&paren.elem),
+        Type::Reference(reference) => format!("&{}", render_type(&reference.elem)),
+        Type::Tuple(tuple) if tuple.elems.is_empty() => "()".to_string(),
+        _ => normalize_tokens(&quote::quote!(#ty).to_string()),
+    }
+}
+
+/// Collapses `quote!`'s token-by-token spacing (`"BytesN < 32 >"`) into
+/// idiomatic Rust source (`"BytesN<32>"`).
+fn normalize_tokens(input: &str) -> String {
+    let tokens: Vec<&str> = input.split_whitespace().collect();
+    let mut out = String::with_capacity(input.len());
+    for (i, tok) in tokens.iter().enumerate() {
+        if i > 0 {
+            let prev = tokens[i - 1];
+            let glued = matches!(prev, "<" | "(" | "&" | "::")
+                || matches!(*tok, "<" | ">" | ")" | "," | "::");
+            if !glued {
+                out.push(' ');
+            }
+        }
+        out.push_str(tok);
+    }
+    out
+}
+
+/// Best-effort extraction of a parameter's identifier from its pattern.
+fn pattern_name(pat: &Pat) -> Option<String> {
+    match pat {
+        Pat::Ident(ident) => Some(ident.ident.to_string()),
+        Pat::Reference(reference) => pattern_name(&reference.pat),
+        Pat::Type(typed) => pattern_name(&typed.pat),
+        Pat::Paren(paren) => pattern_name(&paren.pat),
+        _ => None,
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_source;
+
+    fn file_from(src: &str) -> syn::File {
+        parse_source(src).expect("test source must parse").file
+    }
+
+    #[test]
+    fn empty_file_yields_no_contracts() {
+        let file = file_from("   ");
+        assert!(extract_harness_contracts(&file).is_empty());
+    }
+
+    #[test]
+    fn contract_with_only_reserved_entrypoints_is_omitted() {
+        let file = file_from(
+            r#"
+            #[contractimpl]
+            impl MyContract {
+                pub fn __constructor(_env: Env) {}
+            }
+        "#,
+        );
+        assert!(extract_harness_contracts(&file).is_empty());
+    }
+
+    #[test]
+    fn env_param_is_excluded_from_harness_params() {
+        let file = file_from(
+            r#"
+            #[contractimpl]
+            impl Token {
+                pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {}
+            }
+        "#,
+        );
+        let contracts = extract_harness_contracts(&file);
+        assert_eq!(contracts.len(), 1);
+        let f = &contracts[0].functions[0];
+        assert_eq!(f.name, "transfer");
+        assert_eq!(f.params.len(), 3, "Env must be excluded");
+        assert_eq!(f.params[0].name, "from");
+        assert_eq!(f.params[0].ty_tokens, "Address");
+        assert_eq!(f.params[1].name, "to");
+        assert_eq!(f.params[2].name, "amount");
+        assert_eq!(f.params[2].ty_tokens, "i128");
+    }
+
+    #[test]
+    fn generic_and_reference_types_render_idiomatically() {
+        let file = file_from(
+            r#"
+            #[contractimpl]
+            impl Vault {
+                pub fn deposit(env: Env, id: BytesN<32>, amounts: Vec<i128>, note: &Bytes) {}
+            }
+        "#,
+        );
+        let contracts = extract_harness_contracts(&file);
+        let f = &contracts[0].functions[0];
+        assert_eq!(f.params[0].ty_tokens, "BytesN<32>");
+        assert_eq!(f.params[1].ty_tokens, "Vec<i128>");
+        assert_eq!(f.params[2].ty_tokens, "&Bytes");
+    }
+
+    #[test]
+    fn private_and_reserved_functions_are_excluded() {
+        let file = file_from(
+            r#"
+            #[contractimpl]
+            impl Token {
+                pub fn __constructor(_env: Env) {}
+                fn internal(_env: Env) {}
+                pub fn transfer(_env: Env, _amount: i128) {}
+            }
+        "#,
+        );
+        let contracts = extract_harness_contracts(&file);
+        assert_eq!(contracts[0].functions.len(), 1);
+        assert_eq!(contracts[0].functions[0].name, "transfer");
+    }
+
+    #[test]
+    fn zero_argument_function_yields_empty_params() {
+        let file = file_from(
+            r#"
+            #[contractimpl]
+            impl Counter {
+                pub fn increment(_env: Env) -> u32 { 0 }
+            }
+        "#,
+        );
+        let contracts = extract_harness_contracts(&file);
+        assert!(contracts[0].functions[0].params.is_empty());
+    }
+
+    #[test]
+    fn multiple_contracts_are_each_extracted() {
+        let file = file_from(
+            r#"
+            #[contractimpl]
+            impl TokenA {
+                pub fn a(_env: Env, _x: i128) {}
+            }
+            #[contractimpl]
+            impl TokenB {
+                pub fn b(_env: Env, _y: u32) {}
+            }
+        "#,
+        );
+        let contracts = extract_harness_contracts(&file);
+        assert_eq!(contracts.len(), 2);
+        let names: Vec<&str> = contracts.iter().map(|c| c.struct_name.as_str()).collect();
+        assert!(names.contains(&"TokenA"));
+        assert!(names.contains(&"TokenB"));
+    }
+
+    #[test]
+    fn unnamed_or_unpatternable_params_get_positional_fallback_names() {
+        let file = file_from(
+            r#"
+            #[contractimpl]
+            impl Weird {
+                pub fn f(_env: Env, (a, b): (i128, i128)) {}
+            }
+        "#,
+        );
+        let contracts = extract_harness_contracts(&file);
+        let f = &contracts[0].functions[0];
+        assert_eq!(f.params.len(), 1);
+        assert_eq!(f.params[0].name, "arg0");
+        assert_eq!(f.params[0].ty_tokens, "(i128, i128)");
+    }
+}

--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod finding_codes;
 pub mod gas_estimator;
 pub mod gas_report;
 pub mod circom_parser;
+pub mod harness_spec;
 pub mod input_validation;
 pub mod noir_parser;
 pub mod parser;
@@ -189,6 +190,7 @@ impl Default for SanctifyConfig {
             telemetry: default_telemetry_enabled(),
             strict_mode: false,
             rules: vec![],
+            smt_timeout_ms: None,
         }
     }
 }

--- a/tooling/sanctifier-core/src/noir_parser.rs
+++ b/tooling/sanctifier-core/src/noir_parser.rs
@@ -199,14 +199,6 @@ fn parse_function(lines: &[&str], start: usize) -> Result<(NoirFunction, usize),
 
     Ok((
         NoirFunction { name, params, return_type, return_visibility, body },
-        (consumed as usize).saturating_sub(1),
-        NoirFunction {
-            name,
-            params,
-            return_type,
-            return_visibility,
-            body,
-        },
         consumed.saturating_sub(1),
     ))
 }


### PR DESCRIPTION
## Summary

Resolves #415 — "[engine] Fuzz-Harness Generator: Export native `Afl.rs`/`honggfuzz` test scaffolds".

Adds a new `sanctifier harness` CLI subcommand that bridges Sanctifier's *static* analysis (AST-level parsing) to *dynamic* analysis: given a Soroban contract source file, it generates ready-to-build native fuzz-target scaffolds for `afl.rs` and/or `honggfuzz`, one per public contract function.

## How it works

1. **`sanctifier-core::harness_spec`** (new module) walks the same `#[contractimpl]` blocks that `contract_discovery` already knows about, but additionally extracts each public, non-reserved function's full typed parameter list (name + Rust type, e.g. `Address`, `BytesN<32>`, `i128`, `Vec<Address>`), skipping the mandatory leading `Env` parameter.
2. **`sanctifier-cli` `harness` subcommand** turns that into code, for each requested backend:
   - a `#[derive(Arbitrary)]` input struct whose fields are `<ParamType as SorobanArbitrary>::Prototype` — the pattern documented by `soroban_sdk::testutils::arbitrary` for fuzzing host-managed Soroban types,
   - a `main()` that builds an `Env`, registers the contract, builds a client, converts each prototype via `.into_val(&env)`, and calls `client.try_<function>(..)`,
   - a self-contained, workspace-excluded `Cargo.toml` per backend (mirroring the `contracts/*/fuzz/Cargo.toml` convention already used in this repo), auto-detecting and `path`-dependency-linking the analyzed crate when a `Cargo.toml` is found above the source file (falls back to a `// TODO` placeholder otherwise).

```bash
sanctifier harness contracts/amm-pool/src/lib.rs --output fuzz-harness --target both
# ✅ Generated 12 fuzz target(s) (6 function(s) x 2 backend(s)) in fuzz-harness

cd fuzz-harness/afl && cargo afl build && cargo afl fuzz -i in -o out target/debug/amm_pool_swap
cd fuzz-harness/honggfuzz && cargo hfuzz build && cargo hfuzz run amm_pool_swap
```

See `docs/fuzz-harness-generator.md` for full usage, the generated-code shape, and how it relates to the existing hand-written bolero/libFuzzer harnesses documented in `docs/contracts-fuzz.md` (unchanged — this is a separate, additive generator, not a replacement).

## Testing

- New unit tests in `sanctifier-core::harness_spec` (8 tests) covering `Env`-exclusion, generic/reference type rendering, reserved-entrypoint/private-function exclusion, multi-contract files, and positional-fallback naming for unpatternable parameters.
- New unit tests in `sanctifier-cli::commands::harness` (7 tests) covering snake-case conversion, manifest rendering (with/without crate detection), and generated source shape for both backends.
- New end-to-end integration tests in `tooling/sanctifier-cli/tests/harness_tests.rs` (9 tests) covering: default (both backends), `--target afl`/`--target honggfuzz` selection, `--function` filtering, generated file/manifest content assertions, real crate auto-detection via a sibling `Cargo.toml`, the "no fuzzable functions" case, and a nonexistent-path error case.
- Manually verified end-to-end against a real contract in this repo (`contracts/amm-pool`) — correctly detected the crate name/path and generated 12 valid targets.
- `cargo clippy -p sanctifier-cli --no-deps -- -D warnings` is clean for all new code.

## Incidental prerequisite fixes (unrelated to #415)

While getting `sanctifier-core`/`sanctifier-cli` to build in this environment (no `libclang`/`libz3`, so the optional `smt` feature can't be enabled), I found that **both crates currently fail to compile in *any* feature configuration on `main`** — these are hard compile errors, not environment-specific:

- `SanctifyConfig`'s two `Default`-equivalent constructors (`sanctifier-core::lib.rs` and `sanctifier-cli::commands::init.rs`) were missing the `smt_timeout_ms` field that a previous change added to the struct (`E0063`).
- `noir_parser::parse_function`'s `Ok((...))` accidentally constructed a duplicate `NoirFunction`, returning a 4-element tuple where `(NoirFunction, usize)` was expected (`E0308`) — clearly leftover from a bad merge.

These three one-line/small fixes are included because they block compiling the very crates this feature lives in, in any configuration; they're unrelated to the harness generator itself. I did not go further and fix other pre-existing, unrelated clippy lints/test failures I noticed while investigating (e.g. a dead-code warning in `zk_verifier_skippable.rs`, or an unrelated failing test in `rules::z007_under_constrained`) since those are out of scope for this issue.

I also changed `has_attr_named`/`type_to_name`/`RESERVED_ENTRYPOINTS` in `contract_discovery.rs` from private to `pub(crate)` so `harness_spec` can reuse the existing `#[contractimpl]`-matching logic instead of duplicating it.

Closes #415
