### PR TITLE
docs: add area: zk and mainnet labels to label taxonomy (#1255)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -629,6 +629,10 @@ If your PR has not received a response within the SLA, ping `@HyperSafeD` in the
 | `area: contracts` | Changes to `contracts/` |
 | `area: docs` | Changes to documentation files |
 | `area: testing` | Test infrastructure or coverage |
+| `area: zk` | Zero-knowledge proof related work |
+| `mainnet` | Mainnet deployment and configuration |
+| `component:zk` | ZK component work |
+| `zk` | Zero-knowledge proof related |
 | `difficulty: easy` | Good for first-time contributors; well-scoped |
 | `difficulty: medium` | Requires familiarity with the codebase |
 | `difficulty: hard` | Complex; discuss approach before starting |


### PR DESCRIPTION
Closes #1255

## Summary
Added `area: zk`, `mainnet`, `component:zk`, and `zk` labels to the repo label taxonomy in CONTRIBUTING.md.

## What changed
- Updated the Label Glossary in `CONTRIBUTING.md` to include the new labels added for the Stellar Wave contributor programme:
  - `area: zk` — Zero-knowledge proof related work
  - `mainnet` — Mainnet deployment and configuration
  - `component:zk` — ZK component work
  - `zk` — Zero-knowledge proof related

## Verification
- Labels documented in the central label reference (CONTRIBUTING.md)
- Consistent with the existing label taxonomy format