### PR TITLE
Parallelize per-file analysis with rayon (issue #1474)

### DIFF
--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -3,7 +3,6 @@ use crate::telemetry::{self, AnalysisTelemetry};
 use crate::vulndb::{VulnDatabase, VulnMatch};
 use clap::Args;
 use colored::*;
-#[allow(unused_imports)]
 use rayon::prelude::*;
 use sanctifier_core::finding_codes;
 use sanctifier_core::rules::RuleRegistry;
@@ -193,33 +192,44 @@ pub(crate) fn run_analysis(args: AnalyzeArgs) -> anyhow::Result<bool> {
         collect_rs_files(&path, &config.ignore_paths)
     };
 
-    let registry = RuleRegistry::with_default_rules();
-    let analyzer = Analyzer::new(config.clone());
+    let registry = std::sync::Arc::new(RuleRegistry::with_default_rules());
+    let analyzer = std::sync::Arc::new(Analyzer::new(config.clone()));
+
+    // Parallelized with rayon (issue: implement parallel processing here) --
+    // each file's registry/ledger-size/storage-collision passes are
+    // independent, so this mirrors the Arc<Analyzer> + par_iter pattern
+    // workspace.rs already uses for the same shape of per-file work.
+    let per_file_results: Vec<(String, Vec<sanctifier_core::RuleViolation>, usize, usize)> = rs_files
+        .par_iter()
+        .filter_map(|file_path| {
+            let content = fs::read_to_string(file_path).ok()?;
+            let file_str = file_path.display().to_string();
+            // In JSON/SARIF log modes stderr must stay structured, so route the
+            // progress line through the tracing subscriber. In text mode print it
+            // directly so it is always visible regardless of the log level.
+            if args.format == "json" || args.format == "sarif" {
+                tracing::info!(target: "sanctifier", "Analyzing {}", file_str);
+            } else {
+                eprintln!("Analyzing {}", file_str);
+            }
+            tracing::debug!(target: "sanctifier", "Scanning Rust source file: {}", file_str);
+            let violations = registry.run_all(&content);
+            let size_warnings = analyzer.analyze_ledger_size(&content).len();
+            let collisions = analyzer.scan_storage_collisions(&content).len();
+            Some((file_str, violations, size_warnings, collisions))
+        })
+        .collect();
 
     let mut all_violations: Vec<(String, sanctifier_core::RuleViolation)> = Vec::new();
     let mut size_warnings_total: usize = 0;
     let mut collision_total: usize = 0;
 
-    for file_path in &rs_files {
-        let content = match fs::read_to_string(file_path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        let file_str = file_path.display().to_string();
-        // In JSON/SARIF log modes stderr must stay structured, so route the
-        // progress line through the tracing subscriber. In text mode print it
-        // directly so it is always visible regardless of the log level.
-        if args.format == "json" || args.format == "sarif" {
-            tracing::info!(target: "sanctifier", "Analyzing {}", file_str);
-        } else {
-            eprintln!("Analyzing {}", file_str);
-        }
-        tracing::debug!(target: "sanctifier", "Scanning Rust source file: {}", file_str);
-        for v in registry.run_all(&content) {
+    for (file_str, violations, size_warnings, collisions) in per_file_results {
+        for v in violations {
             all_violations.push((file_str.clone(), v));
         }
-        size_warnings_total += analyzer.analyze_ledger_size(&content).len();
-        collision_total += analyzer.scan_storage_collisions(&content).len();
+        size_warnings_total += size_warnings;
+        collision_total += collisions;
     }
 
     let total = all_violations.len();


### PR DESCRIPTION
## Summary



**#1474 — parallel processing**
The issue's file pointer (`tooling/sanctifier-cli/src/config.rs`) doesn't exist anywhere in this
repo. The real "process multiple files concurrently" opportunity it describes is
`analyze.rs`'s `run_analysis()`: a sequential `for file_path in &rs_files` loop running
`RuleRegistry::run_all`, `analyze_ledger_size`, and `scan_storage_collisions` per file — each
independent of the others. The file already had
`#[allow(unused_imports)] use rayon::prelude::*;` — rayon was already a declared dependency and
imported here, just never actually used.

Switched to `rs_files.par_iter().filter_map(...)`, mirroring the `Arc<Analyzer>` + `par_iter`
pattern `workspace.rs` already uses for the identical shape of per-file work in this same crate.
`registry`/`analyzer` are now wrapped in `Arc` for read-only cross-thread sharing; each file's
`(violations, size_warnings, collisions)` are collected into a `Vec` first, then folded into the
existing totals sequentially afterward — avoids needing a `Mutex` around the shared counters,
and keeps the final output equivalent to the original sequential loop (aside from violation
ordering across files, which was never specified as significant).

## Test plan

- [x] `cargo check` (`tooling/sanctifier-cli`): passes cleanly. Full workspace build, ~2m49s.
      Only warning is a pre-existing, unrelated dead-code warning in `sanctifier-core`
      (`expr_contains_verifier`), not touched by this change.

Closes #1474

Closes #1476 

Closes #1475 

Closes #1478 