### PR TITLE
Add S001 integration tests; fix -n flag collisions breaking analyze/benchmark

### DIFF
--- a/tooling/sanctifier-cli/src/commands/analyze.rs
+++ b/tooling/sanctifier-cli/src/commands/analyze.rs
@@ -99,7 +99,14 @@ pub struct AnalyzeArgs {
     #[arg(long, value_enum, default_value_t = SeverityLevel::High)]
     pub min_severity: SeverityLevel,
     /// Disable incremental analysis cache
-    #[arg(short = 'n', long)]
+    //
+    // No short flag: `-n` collides with the global `--network` flag
+    // (main.rs's `Cli.network`, `global = true`), which clap only catches
+    // via a debug_assert! that panics the very first time `analyze` runs in
+    // a non-release build -- i.e. every invocation under `cargo test`/
+    // `cargo run`. This made the entire `analyze` subcommand, and every
+    // integration test that exercises it, fail unconditionally.
+    #[arg(long)]
     pub no_cache: bool,
     /// Analysis profile preset — overrides --exit-code and --min-severity when set
     #[arg(long, value_enum)]

--- a/tooling/sanctifier-cli/src/commands/benchmark.rs
+++ b/tooling/sanctifier-cli/src/commands/benchmark.rs
@@ -20,7 +20,12 @@ pub struct BenchmarkArgs {
     pub corpus: PathBuf,
 
     /// Number of analysis iterations per rule (must be ≥ 1)
-    #[arg(short = 'n', long, default_value_t = 3)]
+    //
+    // No short flag: `-n` collides with the global `--network` flag
+    // (main.rs's `Cli.network`, `global = true`) -- same bug as
+    // analyze.rs's `no_cache` field, see that file's comment for the full
+    // explanation of how this panics every non-release invocation.
+    #[arg(long, default_value_t = 3)]
     pub iterations: usize,
 
     /// Path to a baseline JSON file produced by a previous `--output` run.

--- a/tooling/sanctifier-cli/tests/cli_tests.rs
+++ b/tooling/sanctifier-cli/tests/cli_tests.rs
@@ -1473,3 +1473,112 @@ fn test_documented_exit_codes() {
         .assert()
         .code(2);
 }
+
+// ── S001 (auth_gap) integration tests (issue #1455) ─────────────────────────
+//
+// Runs the CLI end-to-end against a mock workspace (a temp contract missing
+// `require_auth`) and asserts on the SARIF/JSON output specifically for the
+// S001 finding, rather than "some finding fired" generically the way
+// test_analyze_sarif_findings_are_in_results_array already does.
+
+/// A minimal Soroban contract whose only issue is a missing `require_auth`
+/// call before a state-changing storage write — the exact shape `auth_gap.rs`
+/// (rule name `"auth_gap"`, finding code S001, see finding_codes.rs) detects.
+fn write_auth_gap_only_fixture(dir: &std::path::Path) -> std::path::PathBuf {
+    let contract = dir.join("lib.rs");
+    fs::write(
+        &contract,
+        r#"#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Address, String};
+
+#[contract]
+pub struct AuthGapContract;
+
+#[contractimpl]
+impl AuthGapContract {
+    pub fn set_admin(env: Env, admin: Address) {
+        env.storage().instance().set(&String::from_slice(&env, "admin"), &admin);
+    } // Missing require_auth — this is the only issue in this fixture.
+}
+"#,
+    )
+    .unwrap();
+    contract
+}
+
+#[test]
+fn test_s001_auth_gap_appears_in_json_output() {
+    let dir = tempdir().unwrap();
+    let contract = write_auth_gap_only_fixture(dir.path());
+
+    let output = Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(&contract)
+        .arg("--format")
+        .arg("json")
+        .env_remove("RUST_LOG")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "json output should exit 0");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout).expect("json output should be valid JSON");
+    let violations = json["rule_violations"]
+        .as_array()
+        .expect("rule_violations must be an array");
+
+    let auth_gap_violation = violations
+        .iter()
+        .find(|v| v["rule_name"] == "auth_gap")
+        .expect("expected an auth_gap (S001) violation in rule_violations");
+    assert!(
+        auth_gap_violation["location"].is_string(),
+        "auth_gap violation must carry a location"
+    );
+
+    // finding_codes.rs's S001 entry (AUTH_GAP) must also be present in the
+    // error_codes catalog the json output ships alongside violations.
+    let error_codes = json["error_codes"]
+        .as_array()
+        .expect("error_codes must be an array");
+    assert!(
+        error_codes.iter().any(|c| c["code"] == "S001"),
+        "error_codes catalog must include S001"
+    );
+}
+
+#[test]
+fn test_s001_auth_gap_appears_in_sarif_output() {
+    let dir = tempdir().unwrap();
+    let contract = write_auth_gap_only_fixture(dir.path());
+
+    let output = Command::cargo_bin("sanctifier")
+        .unwrap()
+        .arg("analyze")
+        .arg(&contract)
+        .arg("--format")
+        .arg("sarif")
+        .env_remove("RUST_LOG")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "sarif output should exit 0");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout).expect("sarif output should be valid JSON");
+    let results = json["runs"][0]["results"]
+        .as_array()
+        .expect("sarif results must be an array");
+
+    let auth_gap_result = results
+        .iter()
+        .find(|r| r["ruleId"] == "auth_gap")
+        .expect("expected a sarif result with ruleId 'auth_gap' (S001)");
+    assert!(
+        auth_gap_result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+            .is_string(),
+        "auth_gap sarif result must carry a physical location URI"
+    );
+}


### PR DESCRIPTION
## Summary


**#1455 — integration tests for S001/auth_gap**
The issue's file pointer (`tooling/sanctifier-core/src/rules/s001.rs`) doesn't exist — S001 is
the `AUTH_GAP` finding code (`finding_codes.rs`), implemented by `rules/auth_gap.rs` (rule name
`"auth_gap"`). Existing SARIF/JSON integration tests in `cli_tests.rs` already assert "some
finding fired" against the shared `vulnerable_contract.rs` fixture, but none specifically target
S001/auth_gap the way the issue asks ("write tests that run the CLI against a mock workspace and
assert on the SARIF/JSON output").

Added two tests, matching every existing test in the file's conventions
(`assert_cmd::Command::cargo_bin`, tempdir-based fixtures):

- `test_s001_auth_gap_appears_in_json_output` — runs the CLI against a new, minimal fixture (a
  contract missing `require_auth` before a storage write, with no other issues so the assertion
  is unambiguous), asserts the JSON output's `rule_violations` contains a `rule_name ==
  "auth_gap"` entry with a location, and that `error_codes` includes `S001`.
- `test_s001_auth_gap_appears_in_sarif_output` — same fixture, asserts the SARIF output's
  `results` array contains a `ruleId == "auth_gap"` entry with a physical location URI.

## A real, severe pre-existing bug found by actually running these tests

Compiling passed, but running the new tests failed — `sanctifier analyze` panics on **every**
non-release invocation: `main.rs`'s global `-n`/`--network` flag collides with `analyze.rs`'s own
`-n` for `--no-cache`. Clap only catches short-flag collisions via a `debug_assert!`, so this
never shows up in a release build, but panics immediately under `cargo test`/`cargo run` — and
for anyone building this crate locally without `--release`. Confirmed this broke **every existing
integration test in `cli_tests.rs` that invokes `analyze`**, not just mine (ran
`test_analyze_valid_contract` before my fix; same panic, nothing to do with this PR).

Found and fixed a second instance of the identical bug: `benchmark.rs`'s `iterations` field also
used `-n`, breaking `benchmark` and (via `completions`, which validates the whole command tree) 3
further tests. Fixed both by dropping the short flag (long form `--no-cache`/`--iterations`
unaffected) rather than reassigning `--network`'s `-n`, since network is the global flag used
across every subcommand.

## Test plan

- [x] `cargo test --test cli_tests`: **61 passed, 0 failed, 2 ignored** (the 2 ignored are
      pre-existing, unrelated — a documented flaky-HTTP-mock test). Includes both new S001 tests
      and every previously-broken `analyze`/`benchmark`/`completions` test, now passing.

Closes #1455
Closes #1459 
Closes #1457 
Closes #1454 