### PR TITLE
CallGraph skeleton loader + compact ErrorBoundary fallback

### DIFF
--- a/frontend/app/components/CallGraph.tsx
+++ b/frontend/app/components/CallGraph.tsx
@@ -36,6 +36,10 @@ interface LayoutNode extends CallGraphNode {
   y: number;
 }
 
+// The loading skeleton for this component lives in its own module,
+// `CallGraphSkeleton.tsx` — see that file's doc comment for why it isn't
+// exported from here.
+
 function layoutNodes(nodes: CallGraphNode[] = []): LayoutNode[] {
   if (!nodes || !Array.isArray(nodes)) {
     return [];

--- a/frontend/app/components/CallGraphSkeleton.tsx
+++ b/frontend/app/components/CallGraphSkeleton.tsx
@@ -1,0 +1,37 @@
+/**
+ * Skeleton placeholder for `CallGraph` (issue #1446).
+ *
+ * Deliberately kept in its own tiny module, separate from `CallGraph.tsx`:
+ * this component is meant to be imported *statically* as the `loading:`
+ * fallback for `next/dynamic(() => import("./CallGraph"))`, and a static
+ * import from `CallGraph.tsx` itself would drag the whole (SVG-heavy)
+ * call-graph renderer into the eagerly-loaded bundle, defeating the point of
+ * code-splitting it in the first place.
+ *
+ * Mirrors the real component's layout — title, stats line, legend row, graph
+ * area — instead of a bare "Loading…" string, so the page doesn't visibly
+ * reflow once the real content mounts.
+ */
+export function CallGraphSkeleton() {
+  return (
+    <div
+      data-testid="call-graph-skeleton"
+      className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-6 animate-pulse"
+      role="status"
+      aria-label="Loading contract interaction graph"
+    >
+      <div className="flex flex-wrap justify-between items-start gap-2 mb-4">
+        <div className="w-full max-w-xs">
+          <div className="h-4 w-48 rounded bg-zinc-200 dark:bg-zinc-700 mb-2" />
+          <div className="h-3 w-64 rounded bg-zinc-100 dark:bg-zinc-800" />
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-3 mb-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-3 w-16 rounded bg-zinc-100 dark:bg-zinc-800" />
+        ))}
+      </div>
+      <div className="h-[220px] rounded bg-zinc-100 dark:bg-zinc-800" />
+    </div>
+  );
+}

--- a/frontend/app/components/ErrorBoundary.tsx
+++ b/frontend/app/components/ErrorBoundary.tsx
@@ -6,6 +6,16 @@ import type { ReactNode, ErrorInfo } from "react";
 interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
+  /**
+   * Render a small inline fallback instead of the default full-screen
+   * overlay (issue #1448). The default `min-h-screen` fallback assumes this
+   * boundary wraps the entire page; several call sites (e.g.
+   * `app/scan/page.tsx`) instead wrap a single section of a larger page, so
+   * a render error there shouldn't cover the whole viewport with an
+   * unrelated error card. Also offers "Try Again" (re-render this subtree
+   * only) alongside "Reload Page", instead of only the latter.
+   */
+  compact?: boolean;
 }
 
 interface ErrorBoundaryState {
@@ -52,6 +62,36 @@ export class ErrorBoundary extends Component<
         return this.props.fallback;
       }
 
+      if (this.props.compact) {
+        return (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-300 dark:border-red-700 bg-white dark:bg-gray-800 p-6 text-center"
+          >
+            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
+              This section couldn&apos;t be displayed
+            </p>
+            <p className="text-xs text-gray-600 dark:text-gray-400 mb-4">
+              {this.state.error?.message ?? "An unexpected error occurred."}
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              <button
+                onClick={this.handleReset}
+                className="rounded-lg bg-red-600 text-white px-3 py-1.5 text-xs font-medium hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 transition-colors"
+              >
+                Try Again
+              </button>
+              <button
+                onClick={this.handleCopyDetails}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-3 py-1.5 text-xs font-medium hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2 transition-colors"
+              >
+                Copy Error Details
+              </button>
+            </div>
+          </div>
+        );
+      }
+
       return (
         <div
           role="alert"
@@ -81,6 +121,12 @@ export class ErrorBoundary extends Component<
               {this.state.error?.message ?? "An unexpected error occurred. Please try reloading the page."}
             </p>
             <div className="flex flex-col gap-3">
+              <button
+                onClick={this.handleReset}
+                className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-4 py-2.5 text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2 transition-colors"
+              >
+                Try Again
+              </button>
               <button
                 onClick={this.handleReload}
                 className="w-full rounded-lg bg-red-600 text-white px-4 py-2.5 text-sm font-medium hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 transition-colors"

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -24,6 +24,7 @@ import { SummaryChart } from "../components/SummaryChart";
 import { SanctityScore } from "../components/SanctityScore";
 import { ComparisonView } from "../components/ComparisonView";
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { CallGraphSkeleton } from "../components/CallGraphSkeleton";
 import { useWorkspace } from "../providers/WorkspaceProvider";
 import { WorkspaceSidebar } from "../components/WorkspaceSidebar";
 import { DashboardHeader } from "../components/DashboardHeader";
@@ -32,11 +33,7 @@ import { saveScanRecord, getScanHistory, clearScanHistory, type ScanRecord } fro
 
 const CallGraph = dynamic(() => import("../components/CallGraph").then((m) => m.CallGraph), {
   ssr: false,
-  loading: () => (
-    <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-6 text-center text-zinc-500">
-      Loading call graph…
-    </div>
-  ),
+  loading: () => <CallGraphSkeleton />,
 });
 
 type Tab = "findings" | "callgraph" | "diff";

--- a/frontend/app/scan/page.tsx
+++ b/frontend/app/scan/page.tsx
@@ -8,6 +8,7 @@ import { FindingsList } from "../components/FindingsList";
 import { ZkFindingsPanel } from "../components/ZkFindingsPanel";
 import { SeverityFilter } from "../components/SeverityFilter";
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { CallGraphSkeleton } from "../components/CallGraphSkeleton";
 import { nextScanProgressPhase } from "../lib/scan-progress";
 import { getSettingsHeaders } from "../lib/settings";
 import type { Finding, Severity } from "../types";
@@ -15,11 +16,7 @@ import Link from "next/link";
 
 const CallGraph = dynamic(() => import("../components/CallGraph").then((m) => m.CallGraph), {
   ssr: false,
-  loading: () => (
-    <div className="h-[400px] w-full flex items-center justify-center rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-500">
-      Loading call graph…
-    </div>
-  ),
+  loading: () => <CallGraphSkeleton />,
 });
 
 export default function ScanPage() {
@@ -190,7 +187,7 @@ export default function ScanPage() {
         {findings.length > 0 && !isAnalyzing && (
           <section className="space-y-12 animate-in fade-in duration-1000 pt-10 border-t border-zinc-200 dark:border-zinc-800">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-              <ErrorBoundary>
+              <ErrorBoundary compact>
                 <SanctityScore findings={findings} />
               </ErrorBoundary>
               <div className="space-y-6">
@@ -229,7 +226,7 @@ export default function ScanPage() {
                 <h2 className="text-2xl font-bold tracking-tight">Security Findings</h2>
                 <SeverityFilter selected={severityFilter} onChange={setSeverityFilter} />
               </div>
-              <ErrorBoundary>
+              <ErrorBoundary compact>
                 <ZkFindingsPanel findings={findings} />
                 <FindingsList findings={findings} severityFilter={severityFilter} />
               </ErrorBoundary>
@@ -237,7 +234,7 @@ export default function ScanPage() {
 
             <div className="space-y-6 pt-10 border-t border-zinc-200 dark:border-zinc-800">
               <h2 className="text-2xl font-bold tracking-tight">System Integrity Map</h2>
-              <ErrorBoundary>
+              <ErrorBoundary compact>
                 <CallGraph nodes={[]} edges={[]} /> {/* Call graph would need more data from API if desired */}
                 <p className="text-xs text-zinc-500 text-center italic mt-4">Note: Visualizing complex call structures requires multiple analysis passes.</p>
               </ErrorBoundary>


### PR DESCRIPTION
## Summary

Closes #1446
Closes #1448
Closes #1449
Closes #1447 

 loading states.** Both `next/dynamic(() => import(".../CallGraph"))` call sites
(`app/scan/page.tsx`, `app/dashboard/page.tsx`) showed a plain "Loading call graph…" text string
while the chunk loaded. Replaces it with a proper skeleton (`CallGraphSkeleton.tsx`) — pulsing
placeholder blocks mirroring the real component's layout (title, stats line, legend row, graph
area) — so the page doesn't visibly reflow once the real content mounts. The skeleton lives in its
own new file rather than being exported from `CallGraph.tsx`: both call sites need to import it
*statically* so it renders before the dynamic chunk even starts loading, and a static import from
`CallGraph.tsx` itself would pull the whole SVG-heavy renderer into the eagerly-loaded bundle,
defeating the point of code-splitting it.
 error boundaries.** `ErrorBoundary`'s default fallback (no `fallback` prop given) is
`min-h-screen flex items-center justify-center` — a full-viewport overlay. That's right for a
boundary wrapping an entire page, but `app/scan/page.tsx` wraps three separate *sections* of a
larger page in their own `ErrorBoundary` (the sanctity score card, the findings list, the call
graph) — a render error in any one of those previously covered the whole screen with an unrelated
full-page error card instead of just replacing that section. Adds a `compact` prop for a small
inline fallback sized to its container, wired into all three of `scan/page.tsx`'s boundaries. Also
wires up `handleReset` — defined on the class already but never called from either fallback before
this — as a "Try Again" button that re-renders just the failed subtree, added to both the new
compact fallback and the existing full-page one (which previously only offered "Reload Page").

**Note on file pointers:** both issues' "File Pointer" links were stale — `frontend/components/
CallGraph.tsx` is actually `frontend/app/components/CallGraph.tsx`, and `frontend/pages/scan.tsx`
(Pages Router) is actually `frontend/app/scan/page.tsx` (App Router). Verified against the actual
repo layout before making changes.



## Test plan

- [x] Manual review of both changed components against the existing Tailwind/dark-mode conventions
      already used in this codebase
- [ ] `npx vitest run` / `npx tsc --noEmit` — not run; `npm install` in `frontend/` fails in this
      environment on an `EBADPLATFORM` error for an optional dependency (`@commitlint/message` wants
      `linux`, this environment is `darwin`) unrelated to this change
- [ ] Manual review against each issue's acceptance criteria