### PR TITLE
Fix action.yml severity-value mismatch, add typed events to vulnerable-contract

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   min-severity:
-    description: Minimum severity to report (critical|high|medium|low|info)
+    description: Minimum severity to report (critical|high|medium|low)
     required: false
     default: high
   format:

--- a/contracts/vulnerable-contract/src/lib.rs
+++ b/contracts/vulnerable-contract/src/lib.rs
@@ -1,5 +1,16 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Symbol};
+
+/// Typed payload for the `admin_set` event (issue #1445), matching the
+/// `contracttype` + `events().publish((topic,), data)` convention already
+/// used elsewhere in this workspace (e.g. `contracts/flashloan-token`),
+/// rather than publishing loose tuples an indexer would have to guess the
+/// shape of.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminSetEvent {
+    pub new_admin: Symbol,
+}
 
 #[contract]
 pub struct VulnerableContract;
@@ -12,6 +23,12 @@ impl VulnerableContract {
         env.storage()
             .instance()
             .set(&symbol_short!("admin"), &new_admin);
+        env.events().publish(
+            (symbol_short!("admin_set"),),
+            AdminSetEvent {
+                new_admin: new_admin.clone(),
+            },
+        );
     }
 
     // ✅ Secure version
@@ -25,6 +42,12 @@ impl VulnerableContract {
         env.storage()
             .instance()
             .set(&symbol_short!("admin"), &new_admin);
+        env.events().publish(
+            (symbol_short!("admin_set"),),
+            AdminSetEvent {
+                new_admin: new_admin.clone(),
+            },
+        );
     }
 
     pub fn fail_explicitly(_env: Env) {


### PR DESCRIPTION
## Summary

Closes #1443
Closes #1445 
Closes #1442 
Closes #1444 

 action.yml typos/language.** Did a full read of `action.yml` looking for typos and
grammar issues and didn't find any literal ones — the one place text and actual behavior disagreed
was the `min-severity` input's description, which advertised `(critical|high|medium|low|info)` as
accepted values. The CLI's own `SeverityLevel` enum
(`tooling/sanctifier-cli/src/commands/analyze.rs`) only implements `FromStr` for
critical/high/medium/low — `info` isn't real there. `scripts/action_inputs.py`'s
`_ALLOWED_SEVERITIES` set does accept `"info"` at the action-input-validation layer, so
`min-severity: info` would pass that check and then fail one step later inside the actual
`sanctifier analyze` invocation with `"unknown severity: info"` — a confusing two-stage failure for
a value the action's own description told the user was valid. Fixed the description to match
reality. Left `scripts/action_inputs.py`'s validation set unchanged since it's outside this issue's
named file — happy to also tighten it as a follow-up if wanted.

 event emissions.** Neither `set_admin` nor `set_admin_secure` (the only two
state-changing entrypoints in `contracts/vulnerable-contract` — `fail_explicitly` panics without
touching storage) emitted any event, so an indexer had no way to observe an admin change other than
diffing instance storage directly. Adds an `AdminSetEvent` `#[contracttype]` struct and publishes it
from both functions, following the same `contracttype` + `events().publish((topic,), data)`
convention already used elsewhere in this workspace (e.g. `contracts/flashloan-token`) rather than a
loose, unlabeled tuple an indexer would have to guess the shape of.



## Test plan

- [x] `cargo check -p vulnerable-contract` passes clean
- [ ] Manual review against each issue's acceptance criteria