### PR TITLE
fix: wrap home page in ErrorBoundary

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,15 @@
 import Link from "next/link";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 export default function Home() {
+  return (
+    <ErrorBoundary>
+      <HomeContent />
+    </ErrorBoundary>
+  );
+}
+
+function HomeContent() {
   return (
     <div className="relative min-h-[calc(100vh-64px)] flex flex-col items-center overflow-hidden bg-white dark:bg-zinc-950 font-sans">
       {/* Decorative background Elements */}


### PR DESCRIPTION
## Summary

- **#1431**: `frontend/app/page.tsx` rendered its hero/CTA markup with no error boundary, so any render error there would crash the entire app to a white screen. Split into `Home` (wraps `HomeContent` in the existing `ErrorBoundary` component) and `HomeContent` (original markup unchanged), matching the pattern already used at other call sites like `app/scan/page.tsx`.

## Test plan

- [ ] Home page renders identically to before
- [ ] Throwing inside `HomeContent` (temporarily, for testing) shows the `ErrorBoundary` fallback instead of a blank/crashed app

Closes #1431
Closes #1433
Closes #1432
Closes #1426