### PR TITLE
docs: fix typos and grammatical errors in rule-authoring-guide.md

### DIFF
--- a/docs/rule-authoring-guide.md
+++ b/docs/rule-authoring-guide.md
@@ -105,7 +105,7 @@ panic!("unreachable"); // sanctifier: ignore[no_panic_in_contractimpl]
 | `method_call`       | `method`, `receiver?`                              | Method calls (`obj.method(...)`)     |
 | `storage_operation` | `operation` (`get`/`set`/`remove`), `key_pattern?` | DataStore read/write patterns        |
 
-See [`custom-rules.example.yaml`](../custom-rules.example.yaml) for one example of each type.
+See [`custom-rules.example.yaml`](../custom-rules.example.yaml) for an example of each type.
 
 ---
 
@@ -214,7 +214,7 @@ in taint passes — taint silently disappears at the destructure boundary.
 
 ## 8. ZK Rules (Z-series) Namespace
 
-Sanctifier introduces a dedicated `Z001-Z0NN` numbering convention for Zero-Knowledge (ZK) specific vulnerability rules, functioning alongside the existing `S0xx` static-rule namespace.
+Sanctifier introduces a dedicated `Z001-Z0NN` numbering convention for Zero-Knowledge (ZK)-specific vulnerability rules, operating alongside the existing `S0xx` static-rule namespace.
 
 When authoring ZK rules:
 - **Namespace:** All ZK rules MUST use the `Z` prefix (e.g., `Z001`, `Z002`).


### PR DESCRIPTION
## Summary

Fixed grammatical errors in `docs/rule-authoring-guide.md`:

- "for one example of each type" → "for an example of each type" (§3 matcher-types table intro)
- "Zero-Knowledge (ZK) specific vulnerability rules" → "Zero-Knowledge (ZK)-specific vulnerability rules" (missing hyphen), and "functioning alongside" → "operating alongside" (§8 ZK Rules namespace)

Closes #1414
Closes #1413
Closes #1410
Closes #1407