### PR TITLE
fix(sanctifier-core): resolve compilation errors from duplicate types and missing deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,7 @@ dependencies = [
  "serde_yaml",
  "soroban-sdk",
  "syn 2.0.119",
+ "tempfile",
  "thiserror 1.0.69",
  "z3",
 ]

--- a/tooling/sanctifier-core/Cargo.toml
+++ b/tooling/sanctifier-core/Cargo.toml
@@ -38,6 +38,7 @@ criterion = "0.5.1"
 insta = { version = "1.40", features = ["json", "redactions"] }
 serde_json = "1.0"
 proptest = "1.4"
+tempfile = "3"
 
 [[bench]]
 name = "benchmark"

--- a/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
+++ b/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
@@ -1,8 +1,6 @@
 use crate::rules::{Rule, RuleViolation, Severity};
 use crate::ArithmeticIssue;
-use rayon::prelude::*;
 use std::collections::HashSet;
-use std::sync::Mutex;
 use syn::spanned::Spanned;
 use syn::visit::Visit;
 use syn::{parse_str, File};
@@ -152,16 +150,16 @@ impl ArithmeticOverflowRule {
     /// let violations = rule.check_parallel(&sources);
     /// ```
     pub fn check_parallel(&self, sources: &[&str]) -> Vec<RuleViolation> {
-        let violations = Mutex::new(Vec::new());
+        let mut violations = Vec::new();
         
-        sources.par_iter().for_each(|source| {
+        for source in sources {
             let file_violations = self.check(source);
             if !file_violations.is_empty() {
-                violations.lock().unwrap().extend(file_violations);
+                violations.extend(file_violations);
             }
-        });
+        }
         
-        violations.into_inner().unwrap()
+        violations
     }
     
     /// Check multiple files from paths in parallel.
@@ -189,9 +187,9 @@ impl ArithmeticOverflowRule {
     /// let violations = rule.check_files_parallel(&paths);
     /// ```
     pub fn check_files_parallel(&self, paths: &[&std::path::Path]) -> Vec<RuleViolation> {
-        let violations = Mutex::new(Vec::new());
+        let mut violations = Vec::new();
         
-        paths.par_iter().for_each(|path| {
+        for path in paths {
             if let Ok(source) = std::fs::read_to_string(path) {
                 let mut file_violations = self.check(&source);
                 
@@ -205,12 +203,12 @@ impl ArithmeticOverflowRule {
                 }
                 
                 if !file_violations.is_empty() {
-                    violations.lock().unwrap().extend(file_violations);
+                    violations.extend(file_violations);
                 }
             }
-        });
+        }
         
-        violations.into_inner().unwrap()
+        violations
     }
 }
 
@@ -777,5 +775,27 @@ mod tests {
             1,
             "arithmetic with a non-constant operand must still be flagged"
         );
+    }
+
+    /// Regression test: `check_parallel` works without rayon (was previously
+    /// using `par_iter()` which required the rayon crate as a dependency).
+    #[test]
+    fn test_check_parallel_compiles_and_returns_correct_results() {
+        let rule = ArithmeticOverflowRule::new();
+        let source_a = r#"
+            fn add(a: u64, b: u64) -> u64 {
+                a + b
+            }
+        "#;
+        let source_b = r#"
+            fn safe(a: u64) -> u64 {
+                a.checked_add(1).unwrap_or(0)
+            }
+        "#;
+        let sources = vec![source_a, source_b];
+        let violations = rule.check_parallel(&sources);
+        // source_a has one `+` violation; source_b has none.
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].location.contains("add:"));
     }
 }

--- a/tooling/sanctifier-core/src/smt/circuit_range.rs
+++ b/tooling/sanctifier-core/src/smt/circuit_range.rs
@@ -32,31 +32,11 @@ use z3::ast::{Ast, Int};
 use z3::{Config, Context, SatResult, Solver};
 
 use crate::circom_parser::CircomFile;
-pub use crate::smt::types::{CircuitRangeCheckResult, FlaggedSignal};
+use crate::smt::types::{CircuitRangeCheckResult, FlaggedSignal};
 
 /// BN254 (BabyJubJub) field modulus used by Circom 2.x.
 const BN254_MODULUS: &str =
     "21888242871839275222246405745257275088548364400416034343698204186575808495617";
-
-/// Result of a circuit range-check verification.
-#[derive(Debug, Clone, PartialEq)]
-pub struct CircuitRangeCheckResult {
-    /// Template name.
-    pub template_name: String,
-    /// Signals flagged as potentially under-constrained.
-    pub flagged_signals: Vec<FlaggedSignal>,
-}
-
-/// A signal that may be under-constrained.
-#[derive(Debug, Clone, PartialEq)]
-pub struct FlaggedSignal {
-    /// Signal name.
-    pub signal_name: String,
-    /// The SMT model (counterexample) when available.
-    pub counterexample: Option<String>,
-    /// Whether the solver timed out.
-    pub is_timeout: bool,
-}
 
 /// Verify that all signals in a circuit are range-constrained.
 ///
@@ -485,5 +465,33 @@ template OverflowCheck() {
         // For now, check that the analysis runs and produces consistent
         // results.
         let _ = results;
+    }
+
+    /// Regression test: verify that `CircuitRangeCheckResult` returned by
+    /// `verify_circuit_range_checks` is the same type as `crate::smt::types::CircuitRangeCheckResult`
+    /// (previously, duplicate struct definitions caused a type mismatch).
+    #[test]
+    fn circuit_range_result_is_types_module_type() {
+        let circuit = parse(VULNERABLE_CIRCUIT).unwrap();
+        let results = verify_circuit_range_checks(&circuit, 5000);
+        assert!(!results.is_empty());
+
+        // Verify the returned type is exactly `crate::smt::types::CircuitRangeCheckResult`
+        // by assigning it to a variable with that explicit type.
+        let _typed_results: Vec<crate::smt::types::CircuitRangeCheckResult> = results;
+    }
+
+    /// Regression test: verify `CircuitRangeCheckResult` and `FlaggedSignal`
+    /// implement `Serialize` (they live in `types.rs` with `#[derive(Serialize)]`).
+    #[test]
+    fn circuit_range_types_are_serializable() {
+        let circuit = parse(VULNERABLE_CIRCUIT).unwrap();
+        let results = verify_circuit_range_checks(&circuit, 5000);
+        assert!(!results.is_empty());
+
+        // Should serialize without error.
+        let json = serde_json::to_string(&results).expect("results should serialize");
+        assert!(json.contains("flagged_signals"));
+        assert!(json.contains("template_name"));
     }
 }

--- a/tooling/sanctifier-core/src/smt/types.rs
+++ b/tooling/sanctifier-core/src/smt/types.rs
@@ -74,7 +74,7 @@ pub enum SmtBackend {
 // ── Circuit range-check types (Z007 deep-verify) ──────────────────────────────
 
 /// Result of a circuit range-check verification.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CircuitRangeCheckResult {
     /// Template name.
     pub template_name: String,
@@ -83,7 +83,7 @@ pub struct CircuitRangeCheckResult {
 }
 
 /// A signal that may be under-constrained.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FlaggedSignal {
     /// Signal name.
     pub signal_name: String,


### PR DESCRIPTION
## What it fixes

Resolves 3 compilation errors (`E0255`, `E0433`/`E0599`, `E0308`) and 2 additional issues in `sanctifier-core` that prevent the crate from compiling. These were introduced by prior PRs that added parallel processing (`rayon`) without adding the dependency, and SMT types that conflicted with duplicate definitions.

## Root cause

1. **Duplicate type definitions (E0255):** `smt/circuit_range.rs` re-exported `CircuitRangeCheckResult` and `FlaggedSignal` from `types.rs` via `pub use`, then defined its own identically-named structs in the same module scope — a Rust name collision.

2. **Missing `rayon` dependency (E0433/E0599):** `rules/arithmetic_overflow.rs` imported `rayon::prelude::*` and used `par_iter()`, but `rayon` was never added to `Cargo.toml`'s `[dependencies]`.

3. **Type mismatch (E0308):** `Analyzer::deep_verify_circuit_range` in `lib.rs` had return type `Vec<types::CircuitRangeCheckResult>`, but `circuit_range::verify_circuit_range_checks` returned `Vec<circuit_range::CircuitRangeCheckResult>` — nominally different types despite identical fields.

4. **Missing `Serialize`/`Deserialize` on circuit types:** `CircuitRangeCheckResult` and `FlaggedSignal` in `types.rs` lacked serde derives, so the types couldn't be serialized (needed for tests and downstream consumers).

5. **Missing `tempfile` dev-dependency:** `arithmetic_overflow_integration_test.rs` imports `tempfile::TempDir` but it wasn't in `[dev-dependencies]`.

## The fix and why

| File | Change | Rationale |
|------|--------|-----------|
| `smt/circuit_range.rs` | Removed duplicate struct defs, changed `pub use` to `use` | Single source of truth in `types.rs` eliminates type collision and mismatch |
| `smt/types.rs` | Added `Serialize, Deserialize` to `CircuitRangeCheckResult` and `FlaggedSignal` | Enables JSON serialization for tests and CLI output |
| `rules/arithmetic_overflow.rs` | Replaced `par_iter()` with `for` loop, removed `rayon` + `Mutex` imports | `rayon` is not in dependencies; these methods are unused in the codebase; parallelization can be re-added behind a feature flag |
| `Cargo.toml` | Added `tempfile = "3"` to `[dev-dependencies]` | Required by integration tests |

**Trade-off:** Replacing `par_iter()` with sequential iteration means `check_parallel` / `check_files_parallel` are no longer concurrent. This is acceptable because (a) neither method is called anywhere in the codebase, (b) `rayon` was never declared as a dependency, and (c) parallelization can be re-introduced behind a feature flag in a follow-up.

## How it was tested

- `cargo test -p sanctifier-core --lib` → **433 tests pass** (3 new regression tests added)
- `cargo check -p sanctifier-core` → **compiles cleanly**
- Pre-existing integration test failures (`arithmetic_overflow_integration_test.rs`) are **not caused by this PR** — the CLI binary itself has unrelated compilation errors.

## New tests added

| Test | File | What it catches |
|------|------|----------------|
| `circuit_range_result_is_types_module_type` | `smt/circuit_range.rs` | Verifies the return type of `verify_circuit_range_checks` is exactly `types::CircuitRangeCheckResult` (regression for E0255/E0308) |
| `circuit_range_types_are_serializable` | `smt/circuit_range.rs` | Verifies `CircuitRangeCheckResult`/`FlaggedSignal` can serialize to JSON (regression for missing derives) |
| `test_check_parallel_compiles_and_returns_correct_results` | `rules/arithmetic_overflow.rs` | Verifies `check_parallel` works correctly without `rayon` (regression for E0433/E0599) |

## Follow-up worth filing separately

- **Re-add `rayon` as an optional feature flag** for parallel analysis of large monorepos
- **Fix CLI compilation errors** — `sanctifier-cli` has separate build failures (`num_cpus`, etc.) that prevent integration tests from running
- **Modularize `lib.rs`** — the 2159-line `lib.rs` still mixes the `Analyzer` struct, visitors, and type definitions; extracting `analyzer.rs` would improve maintainability

Closes #1380

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>